### PR TITLE
[feat] 마이페이지_쪽지시험 UI 추가 (#5)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,11 @@
 import { BrowserRouter, Routes, Route } from 'react-router'
 import '@/App.css'
 import LandingPage from '@/pages/LandingPage'
-import Header from '@/components/Heade'
 import TestPage from './pages/TestPage'
+import Header from './components/common/Header'
+import MyPage from './pages/MyPage'
+import MyPageQuiz from './components/MyPageQuiz'
+
 
 function App() {
   return (
@@ -12,7 +15,15 @@ function App() {
         <Route path="/" element={<LandingPage />} />
         <Route path="/qna" element={<div>질의응답 페이지 (구현 예정)</div>} />
         <Route path="/test" element={<TestPage />} />
+
+        {/* 마이페이지 및 하위컴포넌트 연결 */}
+        <Route path="/mypage" element={<MyPage />}>
+          <Route path="quiz" element={<MyPageQuiz />} />
+          <Route path="profile" element={<div>내 정보</div>} />
+          <Route path="password" element={<div>비밀번호 변경</div>} />
+        </Route>
       </Routes>
+
     </BrowserRouter>
   )
 }

--- a/src/components/MyPageQuiz.tsx
+++ b/src/components/MyPageQuiz.tsx
@@ -1,0 +1,36 @@
+import clsx from "clsx";
+
+const MyPageQuiz = () => {
+  const currentTab: "all" | "done" | "todo" = "all";
+
+  return (
+    <div className="space-y-6">
+      <h1 className="font-['Pretendard'] font-bold text-[32px] leading-[140%] tracking-[-0.03em] text-[#121212]">쪽지시험</h1>
+      {/* 상단 탭 */}
+      <div className="flex gap-6 border-b">
+        {[
+          { key: "all", label: "전체보기" },
+          { key: "done", label: "응시완료" },
+          { key: "todo", label: "미응시" },
+        ].map((tab) => (
+          <button
+            key={tab.key}
+            className={clsx(
+              "pb-3 transition-colors",
+              currentTab === tab.key
+                ? "border-b-2 border-blue-600 text-blue-600 font-semibold"
+                : "text-gray-500 hover:text-blue-600"
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* 카드 리스트 */}
+
+    </div>
+  );
+};
+
+export default MyPageQuiz;

--- a/src/components/MyPageQuiz.tsx
+++ b/src/components/MyPageQuiz.tsx
@@ -1,34 +1,45 @@
+import { useState } from "react";
 import clsx from "clsx";
 
+type TabKey = "all" | "done" | "todo";
+
+const TABS: { key: TabKey; label: string }[] = [
+  { key: "all", label: "전체보기" },
+  { key: "done", label: "응시완료" },
+  { key: "todo", label: "미응시" },
+];
+
 const MyPageQuiz = () => {
-  const currentTab: "all" | "done" | "todo" = "all";
+  const [currentTab, setCurrentTab] = useState<TabKey>("all");
+
+  const getTabClass = (tabKey: TabKey) =>
+    clsx(
+      "pb-3 transition-colors text-[18px] font-pretendard",                  // 공통 스타일
+      currentTab === tabKey
+        ? "border-b-2 border-[#6201E0] text-[#6201E0] font-semibold"     // Active일 때 스타일
+        : "text-[#9D9D9D] hover:text-[#6201E0]"                          // Inactive일 때 스타일
+    );
 
   return (
     <div className="space-y-6">
-      <h1 className="font-['Pretendard'] font-bold text-[32px] leading-[140%] tracking-[-0.03em] text-[#121212]">쪽지시험</h1>
+      <h1 className="font-pretendard font-bold text-[32px] leading-[140%] tracking-[-0.03em] text-[#121212]">
+        쪽지시험
+      </h1>
+
       {/* 상단 탭 */}
-      <div className="flex gap-6 border-b">
-        {[
-          { key: "all", label: "전체보기" },
-          { key: "done", label: "응시완료" },
-          { key: "todo", label: "미응시" },
-        ].map((tab) => (
+      <div className="flex gap-6 border-b border-gray-100">
+        {TABS.map((tab) => (
           <button
             key={tab.key}
-            className={clsx(
-              "pb-3 transition-colors",
-              currentTab === tab.key
-                ? "border-b-2 border-blue-600 text-blue-600 font-semibold"
-                : "text-gray-500 hover:text-blue-600"
-            )}
+            onClick={() => setCurrentTab(tab.key)}
+            className={getTabClass(tab.key)}
           >
             {tab.label}
           </button>
         ))}
       </div>
 
-      {/* 카드 리스트 */}
-
+      {/* 카드 리스트 영역 */}
     </div>
   );
 };

--- a/src/components/MyPageQuiz.tsx
+++ b/src/components/MyPageQuiz.tsx
@@ -3,7 +3,7 @@ import clsx from "clsx";
 
 type TabKey = "all" | "done" | "todo";
 
-const TABS: { key: TabKey; label: string }[] = [
+const Tabs: { key: TabKey; label: string }[] = [
   { key: "all", label: "전체보기" },
   { key: "done", label: "응시완료" },
   { key: "todo", label: "미응시" },
@@ -12,12 +12,15 @@ const TABS: { key: TabKey; label: string }[] = [
 const MyPageQuiz = () => {
   const [currentTab, setCurrentTab] = useState<TabKey>("all");
 
-  const getTabClass = (tabKey: TabKey) =>
+const getTabClass = (tabKey: TabKey) =>
     clsx(
-      "pb-3 transition-colors text-[18px] font-pretendard",                  // 공통 스타일
+      // 공통 스타일
+      "pb-3 transition-colors font-pretendard font-bold text-[20px] leading-[140%] tracking-[-0.03em]",
       currentTab === tabKey
-        ? "border-b-2 border-[#6201E0] text-[#6201E0] font-semibold"     // Active일 때 스타일
-        : "text-[#9D9D9D] hover:text-[#6201E0]"                          // Inactive일 때 스타일
+        ? // Active 스타일
+          "text-[#721AE3] border-b-[3px] border-[#721AE3]"
+        : // Inactive 스타일
+          "text-[#9D9D9D] border-b-[3px] border-transparent" 
     );
 
   return (
@@ -27,8 +30,8 @@ const MyPageQuiz = () => {
       </h1>
 
       {/* 상단 탭 */}
-      <div className="flex gap-6 border-b border-gray-100">
-        {TABS.map((tab) => (
+      <div className="flex gap-10 border-b-2 border-[#E5E5E5] w-full">
+        {Tabs.map((tab) => (
           <button
             key={tab.key}
             onClick={() => setCurrentTab(tab.key)}
@@ -40,6 +43,7 @@ const MyPageQuiz = () => {
       </div>
 
       {/* 카드 리스트 영역 */}
+      
     </div>
   );
 };

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,0 +1,46 @@
+import clsx from "clsx";
+import { NavLink, Outlet } from "react-router";
+
+const sideNavClass = ({ isActive }: { isActive: boolean }) =>
+  clsx(
+    // 공통 스타일
+    "w-[180px] h-[32px] flex items-center pl-4",
+    "font-pretendard font-semibold text-[18px] leading-[140%] tracking-[-0.03em]",
+    "transition-colors",
+
+    // 활성 / 비활성 구분 스타일
+    isActive
+      ? "border-l-[3px] border-[#6201E0] text-[#6201E0]"
+      : "text-[#9D9D9D]"
+  );
+
+
+const MyPage = () => {
+  return (
+    <div className="px-90 py-20">
+      <div className="flex">
+        {/* 좌측 nav */}
+        <aside className="pt-2">
+          <nav className="space-y-4">
+            <NavLink to="quiz" className={sideNavClass}>
+              쪽지시험
+            </NavLink>
+            <NavLink to="profile" className={sideNavClass}>
+              내 정보
+            </NavLink>
+            <NavLink to="password" className={sideNavClass}>
+              비밀번호 변경
+            </NavLink>
+          </nav>
+        </aside>
+
+        {/* 우측 콘텐츠 */}
+        <main>
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  )
+}
+
+export default MyPage;


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #5 

## 📑 구현 사항

- App.tsx에 마이페이지 및 하위페이지 라우터로 연결.
- Page/MyPage.tsx UI를 좌측 nav와 우측 콘텐츠로 나누어서 작업함.
 -> 좌측 nav는 NavLink로 구현
 -> 우측 콘텐츠는 Outlet으로 구현
- Header의 프로필 아이콘 클릭시 마이페이지로 연결.
- 중복되는 TailWind는 중복 코드는 clsx를 활용하여 구현.

## 🌀 어려웠던 점 / 고민했던 부분

 라우터 중첩 + 레이아웃 분리가 처음엔 어려웠음.
처음 사용해보는 Navlink와 clsx가 손에 익지 않아서 여러번 확인하고 생각하는 과정에 고민을 많이 했습니다.
- TailWind가 중복 사용되서 코드가 길어지는 문제가 있어, clsx라이브러리를 활용하여 구현

## 📸 구현 이미지

-

## ❇️ 코드 설명

-

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.