### PR TITLE
feat: 쪽지시험 응시하기 페이지 기본 UI (#45)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,25 @@
-import { BrowserRouter, Routes, Route } from 'react-router'
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router'
 import '@/App.css'
 import LandingPage from '@/pages/LandingPage'
 import TestPage from '@/pages/TestPage'
 import { Header } from '@/components/common'
 import MyPage from '@/pages/MyPage'
 import MyPageQuiz from '@/components/MyPageQuiz'
+import QuizPage from './pages/QuizPage'
 
-function App() {
+function AppContent() {
+  const location = useLocation();
+  // 퀴즈 페이지일 때는 공통 Header를 숨깁니다.
+  const showHeader = location.pathname !== '/quiz';
+
   return (
-    <BrowserRouter>
-      <Header />
+    <>
+      {showHeader && <Header />}
       <Routes>
         <Route path="/" element={<LandingPage />} />
         <Route path="/qna" element={<div>질의응답 페이지 (구현 예정)</div>} />
         <Route path="/test" element={<TestPage />} />
+        <Route path="/quiz" element={<QuizPage />} />
 
         {/* 마이페이지 및 하위컴포넌트 연결 */}
         <Route path="/mypage" element={<MyPage />}>
@@ -22,8 +28,17 @@ function App() {
           <Route path="password" element={<div>비밀번호 변경</div>} />
         </Route>
       </Routes>
-    </BrowserRouter>
+    </>
   )
+}
+
+
+function App() {
+  return (
+    <BrowserRouter>
+      <AppContent />
+    </BrowserRouter>
+  );
 }
 
 export default App

--- a/src/components/QuizHeader.tsx
+++ b/src/components/QuizHeader.tsx
@@ -1,0 +1,71 @@
+import { Link } from 'react-router'
+import clsx from 'clsx'
+
+// 스타일 선언명 정의
+const titleStyle = clsx('text-black font-semibold text-2xl ')
+const contentStyle = clsx('text-#4D4D4D font-normal text-xl ml-12')
+const timerBoxStyle = clsx('rounded-[30px] bg-white px-4 py-5 border border-[#ECECEC]')
+const timerTextStyle = clsx('text-[#6201E0] font-medium text-base font-bold-600')
+const timerNumberStyle = clsx('text-[#6201E0] font-semibold text-base font-bold-600')
+const warningLabelStyle = clsx('text-gray-700 font-semibold text-base px-1')
+const warningIconBoxStyle = clsx('h-6 w-4 rounded border border-gray-300 bg-white flex items-center justify-center')
+const warningIconTextStyle = clsx('text-gray-400 text-sm')
+
+interface QuizHeaderProps {
+  subjectName?: string
+  message?: string
+  timeRemaining?: string
+  timeRemainingSuffix?: string
+  cheatingCount?: number
+}
+
+function QuizHeader({
+  subjectName = 'TypeScript 쪽지시험',
+  message = '집중해서 천천히, 끝까지 응시해 주세요. 응원할게요 💪',
+  timeRemaining = '29 : 17',
+  timeRemainingSuffix = '뒤에 끝나요',
+  cheatingCount: _cheatingCount = 0,
+}: QuizHeaderProps) {
+  const maxCheatingCount = 3
+
+  return (
+    <header className="flex items-start justify-between border-b border-gray-200 bg-[#FAFAFA] px-70 py-6">
+      {/* 좌측 영역 */}
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-3">
+          <Link
+            to="/mypage/quiz"
+            className="flex items-center justify-center rounded-md p-1 text-black transition-colors hover:bg-gray-100 text-3xl"
+            aria-label="뒤로가기"
+          >
+            ←
+          </Link>
+          <h1 className={titleStyle}>{subjectName}</h1>
+        </div>
+        <p className={contentStyle}>{message}</p>
+      </div>
+
+      {/* 우측 영역 */}
+      <div className="flex items-center gap-4 mt-2">
+        {/* 타이머 박스 */}
+        <div className={timerBoxStyle}>
+          <span className={timerNumberStyle}>{timeRemaining}</span>
+          <span className={timerTextStyle}> {timeRemainingSuffix}</span>
+        </div>
+        {/* 부정행위 카운트 */}
+        <div className="flex items-center gap-2 bg-white border border-[#ECECEC] rounded-[30px] p-5">
+          <span className={warningLabelStyle}>부정행위</span>
+          <div className="flex gap-1">
+            {Array.from({ length: maxCheatingCount }).map((_, index) => (
+              <div key={index} className={warningIconBoxStyle}>
+                <span className={warningIconTextStyle}>!</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </header>
+  )
+}
+
+export default QuizHeader

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react'
+import { X, AlertCircle } from 'lucide-react'
+import { Button } from '@/components/common/Button'
+import clsx from 'clsx'
+import QuizHeader from '@/components/QuizHeader'
+
+// 스타일 선언
+const warningTitleStyle = clsx('text-black font-semibold text-2xl mb-3')
+const warningContentStyle = clsx('text-black font-normal text-xl')
+
+function QuizPage() {
+  const [showWarning, setShowWarning] = useState(true)
+
+  const handleCloseWarning = () => {
+    setShowWarning(false)
+  }
+
+  const handleSubmit = () => {
+    // 제출 로직은 추후 구현 예정
+    alert('시험이 제출되었습니다.')
+  }
+
+  return (
+    <div>
+      <QuizHeader />
+
+      {/* 메인 영역 */}
+      <main className="flex flex-col items-center px-10 py-6">
+
+        {/* 경고 박스 */}
+        {showWarning && (
+          <div className="mb- w-[73%] flex items-start gap-3 rounded-lg border border-pink-200 bg-[#EFE6FC] p-8">
+            <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-[#EC0037]">
+              <AlertCircle className="h-10 w-10 text-white" strokeWidth={2.5} />
+            </div>
+            <div className="flex-1">
+              <h2 className={warningTitleStyle}>시험에만 집중해 주세요</h2>
+              <p className={warningContentStyle}>
+                탭이나 창을 이동하면 부정행위로 처리돼 시험이 중단될 수 있어요. 안정적인 환경에서 시험을 이어가 주세요.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleCloseWarning}
+              className="flex-shrink-0 rounded-md p-1 transition-colors hover:bg-pink-200"
+              aria-label="닫기"
+            >
+              <X className="h-5 w-5 text-[#0F172A]]" />
+            </button>
+          </div>
+        )}
+
+        <div className="min-h-[500px]">
+          {/* 쪽지시험 유형별 컴포넌트가 들어갈 자리 */}
+        </div>
+      </main>
+
+      <footer>
+        <div className="flex justify-center">
+          <Button variant="primary" size="md" rounded="default" onClick={handleSubmit}>
+            제출하기
+          </Button>
+        </div>
+      </footer>
+    </div>
+  )
+}
+
+export default QuizPage


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#45 )
-->

## #️⃣ 연관된 이슈

- Resolves #45

## 📑 구현 사항

- **QuizPage 신규 생성** : 퀴즈 응시를 위한 메인 페이지 레이아웃 구현
- **QuizHeader 컴포넌트 구현** : 시험 제목, 응원 메시지, 타이머, 부정행위 카운트가 포함된 퀴즈 전용 헤더 제작
- **공통 헤더 조건부 렌더링** : `useLocation`을 활용하여 `/quiz` 경로에서는 기본 `Header` 대신 `QuizHeader`가 보이도록 `App.jsx` 구조 변경
- **주의사항 경고 배너** : 시험 시작 전 주의사항을 알리고 닫을 수 있는 Warning Box 구현
- **스타일 변수화 (clsx 활용)**: 코드 가독성과 유지보수성을 높이기 위해 사이즈, 컬러, 굵기, 배경색 등 스타일 속성을 선언명으로 정의하여 적용했습니다.

## 🌀 어려웠던 점 / 고민했던 부분

- **헤더 교체 로직** : 전체 서비스에서 공통으로 사용되는 Header를 특정 페이지에서만 숨겨야 했습니다. App.jsx 내부에 AppContent 컴포넌트를 분리하고 useLocation 훅을 사용하여 현재 경로가 /quiz인지 체크하는 로직을 통해 효율적으로 제어했습니다.
- **디자인 시스템의 코드화** : Tailwind CSS의 유틸리티 클래스가 길어지는 것을 방지하기 위해 warningTitleStyle, timerBoxStyle 등과 같이 스타일 선언명을 명확하게 정의했습니다. 이를 통해 JSX 구조 내에서는 의미 파악에 집중하고, 스타일 수정 시에는 선언부만 확인하면 되도록 고민하여 작성했습니다.
- **헤더 전환 로직** : 전역적으로 사용되는 헤더를 특정 페이지에서만 제외하기 위해 AppContent 컴포넌트를 분리하여 location.pathname에 따른 조건부 렌더링을 처리했습니다.

## 📸 구현 이미지

<img width="1498" height="768" alt="스크린샷 2026-01-23 오전 2 12 28" src="https://github.com/user-attachments/assets/d37a12d1-a142-459d-af06-44354e68f0e9" />

## ❇️ 코드 설명

-

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.