### PR TITLE
refactor: Outlet 기반의 중첩 라우팅 구조로 변경 (#48)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,42 +1,33 @@
-import { BrowserRouter, Routes, Route, useLocation } from 'react-router'
+import { BrowserRouter, Routes, Route } from 'react-router'
 import '@/App.css'
 import LandingPage from '@/pages/LandingPage'
 import TestPage from '@/pages/TestPage'
-import { Header } from '@/components/common'
 import MyPage from '@/pages/MyPage'
 import MyPageQuiz from '@/components/MyPageQuiz'
 import QuizPage from './pages/QuizPage'
-
-function AppContent() {
-  const location = useLocation();
-  // 퀴즈 페이지일 때는 공통 Header를 숨깁니다.
-  const showHeader = location.pathname !== '/quiz';
-
-  return (
-    <>
-      {showHeader && <Header />}
-      <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="/qna" element={<div>질의응답 페이지 (구현 예정)</div>} />
-        <Route path="/test" element={<TestPage />} />
-        <Route path="/quiz" element={<QuizPage />} />
-
-        {/* 마이페이지 및 하위컴포넌트 연결 */}
-        <Route path="/mypage" element={<MyPage />}>
-          <Route path="quiz" element={<MyPageQuiz />} />
-          <Route path="profile" element={<div>내 정보</div>} />
-          <Route path="password" element={<div>비밀번호 변경</div>} />
-        </Route>
-      </Routes>
-    </>
-  )
-}
-
+import MainLayout from './components/layout/MainLayout'
 
 function App() {
   return (
     <BrowserRouter>
-      <AppContent />
+      <Routes>
+        {/* 1. 헤더가 포함된 레이아웃을 적용할 페이지들 */}
+        <Route element={<MainLayout />}>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/qna" element={<div>질의응답 페이지</div>} />
+          <Route path="/test" element={<TestPage />} />
+          
+          {/* 마이페이지와 그 하위 페이지 */}
+          <Route path="/mypage" element={<MyPage />}>
+            <Route path="quiz" element={<MyPageQuiz />} />
+            <Route path="profile" element={<div>내 정보</div>} />
+            <Route path="password" element={<div>비밀번호 변경</div>} />
+          </Route>
+        </Route>
+
+        {/* 2. 헤더가 필요 없는 페이지 (레이아웃 밖으로 배치) */}
+        <Route path="/quiz" element={<QuizPage />} />
+      </Routes>
     </BrowserRouter>
   );
 }

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,0 +1,15 @@
+import { Outlet } from 'react-router'
+import { Header } from '../common'
+
+export default function MainLayout() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      {/* 헤더가 fixed이므로, 헤더의 높이만큼 padding-top을 주었습니다. */}
+      {/* h-16(64px) + 알림바(약 36px) = 약 100px */}
+      <main className="flex-1 pt-[100px]">
+        <Outlet />
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #48

## 📑 구현 사항


- **공통 레이아웃 컴포넌트(MainLayout) 도입**: Header와 콘텐츠 영역(Outlet)을 분리하여 레이아웃 관리 구조 개선
- **라우팅 구조 최적화**: App.tsx에서 조건부로 헤더를 렌더링하던 로직을 제거하고, React Router의 중첩 라우팅(Nested Routes) 기능을 활용해 헤더 노출 여부를 선언적으로 관리
- **헤더 가림 현상 해결**: 헤더가 fixed로 설정되어 콘텐츠 상단이 가려지던 문제를 레이아웃 레벨의 padding-top 설정을 통해 해결



## 🌀 어려웠던 점 / 고민했던 부분


- **조건부 헤더 처리**: 기존에는 location.pathname을 일일이 체크하여 특정 페이지(퀴즈 등)에서 헤더를 숨겼으나, 페이지가 늘어날 경우 유지보수가 어려울 것으로 판단했습니다. 이를 해결하기 위해 레이아웃 그룹을 나누어 관리하는 방식을 고민했습니다.
- **여백 수치 계산**: 상단 알림 바와 메인 헤더의 높이가 합쳐진 상태에서 하위 페이지들이 일관된 시작점을 가질 수 있도록 적절한 padding-top 값을 설정하는 데 신경을 썼습니다.



## 📸 구현 이미지


- **수정 전**

<img width="1495" height="523" alt="스크린샷 2026-01-23 오전 11 29 50" src="https://github.com/user-attachments/assets/caa709a7-8093-4807-8487-1b960432a8f8" />
<img width="1505" height="380" alt="스크린샷 2026-01-23 오전 11 30 01" src="https://github.com/user-attachments/assets/c3622ef4-ecb6-421d-9b29-9806d46ff7f8" />



- **수정 후**

<img width="1491" height="573" alt="스크린샷 2026-01-23 오전 11 30 16" src="https://github.com/user-attachments/assets/bdd17a0e-cc81-41ac-999b-96f056fb3225" />
<img width="1510" height="574" alt="스크린샷 2026-01-23 오전 11 30 27" src="https://github.com/user-attachments/assets/736148c1-0dfb-45ef-aeeb-1e76a0d95324" />




## ❇️ 코드 설명


-`src/components/layout/MainLayout.tsx`: 헤더와 하위 페이지 렌더링을 위한 `Outlet`을 포함하는 래퍼 컴포넌트입니다.

- `App.tsx` : 기존의 복잡한 조건부 렌더링 로직을 제거하고, MainLayout을 감싸는 라우트 그룹을 설정하여 가독성을 높였습니다.



## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.


1. 현재 `MainLayout`에 고정값으로 `pt-[100px]`을 주어 여백을 확보했습니다. 혹시 헤더 높이가 유동적으로 변할 가능성을 고려하여 더 나은 대응 방식이 있을지 의견 부탁드립니다.
2. 마이페이지(`MyPage`) 내의 중첩 라우트 구조가 현재의 `MainLayout`과 충돌 없이 매끄럽게 느껴지는지 확인 부탁드립니다.
