### PR TITLE
refactor: QuizHeader 스타일 정리 및 경고 아이콘 이미지 교체 (#53)

### DIFF
--- a/public/alertCircle.svg
+++ b/public/alertCircle.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#EC0037" stroke="#EC0037" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 8V12" stroke="#FCD6DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 16H12.01" stroke="#FCD6DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/QuizHeader.tsx
+++ b/src/components/QuizHeader.tsx
@@ -1,15 +1,14 @@
 import { Link } from 'react-router'
-import clsx from 'clsx'
 
 // 스타일 선언명 정의
-const titleStyle = clsx('text-black font-semibold text-2xl ')
-const contentStyle = clsx('text-#4D4D4D font-normal text-xl ml-12')
-const timerBoxStyle = clsx('rounded-[30px] bg-white px-4 py-5 border border-[#ECECEC]')
-const timerTextStyle = clsx('text-[#6201E0] font-medium text-base font-bold-600')
-const timerNumberStyle = clsx('text-[#6201E0] font-semibold text-base font-bold-600')
-const warningLabelStyle = clsx('text-gray-700 font-semibold text-base px-1')
-const warningIconBoxStyle = clsx('h-6 w-4 rounded border border-gray-300 bg-white flex items-center justify-center')
-const warningIconTextStyle = clsx('text-gray-400 text-sm')
+const titleStyle = 'text-black font-semibold text-[20px]'
+const contentStyle = 'text-[#4D4D4D] font-normal text-[16px] ml-12'
+const infoBoxStyle = 'flex items-center gap-2 rounded-[30px] bg-white border border-[#ECECEC] px-6 py-3'
+const timerTextStyle = 'text-[#6201E0] text-[18px]'
+const timerNumberStyle = 'text-[#6201E0] font-semibold text-[18px]'
+const warningLabelStyle = 'text-gray-700 font-semibold text-[18px] px-1'
+const warningIconBoxStyle = 'h-6 w-4 rounded border border-gray-300 bg-white flex items-center justify-center'
+const warningIconTextStyle = 'text-gray-400 text-sm'
 
 interface QuizHeaderProps {
   subjectName?: string
@@ -29,38 +28,40 @@ function QuizHeader({
   const maxCheatingCount = 3
 
   return (
-    <header className="flex items-start justify-between border-b border-gray-200 bg-[#FAFAFA] px-70 py-6">
-      {/* 좌측 영역 */}
-      <div className="flex flex-col gap-2">
-        <div className="flex items-center gap-3">
-          <Link
-            to="/mypage/quiz"
-            className="flex items-center justify-center rounded-md p-1 text-black transition-colors hover:bg-gray-100 text-3xl"
-            aria-label="뒤로가기"
-          >
-            ←
-          </Link>
-          <h1 className={titleStyle}>{subjectName}</h1>
+    <header className="border-b border-gray-200 bg-[#FAFAFA] px-6 py-6">
+      <div className="mx-auto flex max-w-[1200px] items-center justify-between">
+        {/* 좌측 영역 */}
+        <div className="flex flex-col">
+          <div className="flex items-center gap-3">
+            <Link
+              to="/mypage/quiz"
+              className="flex items-center justify-center rounded-md p-1 text-black transition-colors hover:bg-gray-100 text-3xl"
+              aria-label="뒤로가기"
+            >
+              ←
+            </Link>
+            <h1 className={titleStyle}>{subjectName}</h1>
+          </div>
+          <p className={contentStyle}>{message}</p>
         </div>
-        <p className={contentStyle}>{message}</p>
-      </div>
 
-      {/* 우측 영역 */}
-      <div className="flex items-center gap-4 mt-2">
-        {/* 타이머 박스 */}
-        <div className={timerBoxStyle}>
-          <span className={timerNumberStyle}>{timeRemaining}</span>
-          <span className={timerTextStyle}> {timeRemainingSuffix}</span>
-        </div>
-        {/* 부정행위 카운트 */}
-        <div className="flex items-center gap-2 bg-white border border-[#ECECEC] rounded-[30px] p-5">
-          <span className={warningLabelStyle}>부정행위</span>
-          <div className="flex gap-1">
-            {Array.from({ length: maxCheatingCount }).map((_, index) => (
-              <div key={index} className={warningIconBoxStyle}>
-                <span className={warningIconTextStyle}>!</span>
-              </div>
-            ))}
+        {/* 우측 영역 */}
+        <div className="flex items-center gap-4">
+          {/* 타이머 박스 */}
+          <div className={infoBoxStyle}>
+            <span className={timerNumberStyle}>{timeRemaining}</span>
+            <span className={timerTextStyle}> {timeRemainingSuffix}</span>
+          </div>
+          {/* 부정행위 카운트 */}
+          <div className={infoBoxStyle}>
+            <span className={warningLabelStyle}>부정행위</span>
+            <div className="flex gap-1">
+              {Array.from({ length: maxCheatingCount }).map((_, index) => (
+                <div key={index} className={warningIconBoxStyle}>
+                  <span className={warningIconTextStyle}>!</span>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       </div>

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react'
-import { X, AlertCircle } from 'lucide-react'
+import { X } from 'lucide-react'
 import { Button } from '@/components/common/Button'
 import clsx from 'clsx'
 import QuizHeader from '@/components/QuizHeader'
 
 // 스타일 선언
-const warningTitleStyle = clsx('text-black font-semibold text-2xl mb-3')
-const warningContentStyle = clsx('text-black font-normal text-xl')
+const warningTitleStyle = clsx('text-black font-semibold text-[18px] mb-3')
+const warningContentStyle = clsx('text-black font-normal text-[14px]')
 
 function QuizPage() {
   const [showWarning, setShowWarning] = useState(true)
@@ -29,9 +29,13 @@ function QuizPage() {
 
         {/* 경고 박스 */}
         {showWarning && (
-          <div className="mb- w-[73%] flex items-start gap-3 rounded-lg border border-pink-200 bg-[#EFE6FC] p-8">
-            <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-[#EC0037]">
-              <AlertCircle className="h-10 w-10 text-white" strokeWidth={2.5} />
+          <div className="min-w-[1200px] flex items-start gap-3 rounded-lg bg-[#EFE6FC] px-6 py-5">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#EC0037]">
+              <img
+                src="/alertCircle.svg"
+                alt="경고"
+                className="h-5 w-5"
+              />
             </div>
             <div className="flex-1">
               <h2 className={warningTitleStyle}>시험에만 집중해 주세요</h2>
@@ -42,7 +46,6 @@ function QuizPage() {
             <button
               type="button"
               onClick={handleCloseWarning}
-              className="flex-shrink-0 rounded-md p-1 transition-colors hover:bg-pink-200"
               aria-label="닫기"
             >
               <X className="h-5 w-5 text-[#0F172A]]" />


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #53 

## 📑 구현 사항

- **QuizHeader 컴포넌트 스타일 리팩토링**
  - **불필요한 `clsx` 제거 및 문자열 클래스 선언으로 정리**
  - **Tailwind 클래스 오타 수정**  : `text-#4D4D4D` → `text-[#4D4D4D]`
  - **존재하지 않는 클래스 제거** : `font-bold-600`
  - **중복된 폰트 관련 클래스 정리**
- **QuizPage 경고 영역 UI 개선**
  - Lucide 아이콘 `<AlertCircle />` → 이미지(`alertCircle.svg`)로 교체

---

## 🌀 어려웠던 점 / 고민했던 부분

- 기존 스타일 선언부에서 `clsx`가 조건부 로직 없이 사용되고 있어,  
  유지보수 관점에서 단순 문자열 클래스로 변경하는 것이 적절한지 고민했습니다.
- 폰트 관련 Tailwind 클래스 중 중복되거나 비표준 클래스가 섞여 있어,  
  디자인 의도는 유지하면서 최소한의 클래스로 정리하는 데 신경 썼습니다.

## 📸 구현 이미지

-

## ❇️ 코드 설명

-

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.