### PR TITLE
Feat: Tailwind 클래스 축약 (센터정렬,타이틀/플레이스홀더) (#58)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -18,3 +18,41 @@
     'Segoe UI',
     sans-serif;
 }
+
+/* 중앙 정렬용 */
+.flex-center {
+  @apply flex items-center justify-center;
+}
+
+/* Title Font Styles */
+.title-xl {
+  @apply text-[32px] font-bold;
+}
+
+.title-l {
+  @apply text-[20px] font-semibold;
+}
+
+/* 로그인 페이지 용 */
+.title-m-a {
+  @apply text-[18px] font-bold;
+}
+
+/* 마이페이지 / 쪽지 / 비밀번호 변경 용 */
+.title-m-b {
+  @apply text-[18px] font-semibold;
+}
+
+/* Placeholder Font Styles */
+
+/* 로그인 페이지 용 */
+.placeholder-a {
+  @apply text-[14px] font-normal;
+}
+
+/* 마이페이지 / 쪽지 / 비밀번호 변경 용 */
+.placeholder-b {
+  @apply text-[16px] font-normal;
+}
+
+

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 
 export default function StyleTestPage() {
   return (

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -1,130 +1,41 @@
-import { useState } from 'react'
-import { CommonInput, Dropdown, Error404, Loading, NotFound, Password } from '@/components/common'
-import TestPageApiPanel from '@/components/TestPageApiPanel'
+import React from "react";
 
-const options = [
-  { label: '옵션 1', value: 'option-1' },
-  { label: '옵션 2', value: 'option-2' },
-  { label: '옵션 3', value: 'option-3' },
-  { label: '옵션 4', value: 'option-4' },
-  { label: '옵션 5', value: 'option-5' },
-  { label: '옵션 6', value: 'option-6' },
-]
-
-function TestPage() {
-  const [value, setValue] = useState<string | undefined>()
-  const [password, setPassword] = useState('')
-  const [passwordState, setPasswordState] = useState<'default' | 'error' | 'success'>('default')
-  const [inputValue, setInputValue] = useState('')
-  const [showNotFound, setShowNotFound] = useState(false)
-
-  // 가짜 로그인용 올바른 비밀번호
-  const correctPassword = 'Test123!'
-
-  const handlePasswordChange = (newPassword: string) => {
-    setPassword(newPassword)
-    // 입력값이 변경되면 상태를 default로 초기화
-    if (passwordState !== 'default') {
-      setPasswordState('default')
-    }
-  }
-
-  const handleLogin = () => {
-    if (password === correctPassword) {
-      setPasswordState('success')
-    } else {
-      setPasswordState('error')
-    }
-  }
-
-  if (showNotFound) {
-    return (
-      <div className="min-h-screen bg-[#FAFAFB] p-10">
-        <div className="mb-8 flex items-center justify-between">
-          <div className="flex flex-wrap items-center justify-between gap-4">
-            <h1 className="text-2xl font-semibold text-black">404/NotFound/Loading</h1>
-            <button
-              type="button"
-              onClick={() => setShowNotFound(false)}
-              className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
-            >
-              돌아가기
-            </button>
-          </div>
-        </div>
-        <div className="grid gap-8 md:grid-cols-3">
-          <div className="flex flex-col items-center gap-4 rounded-lg border border-gray-200 bg-white p-6">
-            <p className="text-sm font-medium text-gray-700">Error404</p>
-            <Error404 />
-          </div>
-          <div className="flex flex-col items-center gap-4 rounded-lg border border-gray-200 bg-white p-6">
-            <p className="text-sm font-medium text-gray-700">NotFound</p>
-            <NotFound />
-          </div>
-          <div className="flex flex-col items-center gap-4 rounded-lg border border-gray-200 bg-white p-6">
-            <p className="text-sm font-medium text-gray-700">Loading</p>
-            <Loading />
-          </div>
-        </div>
-      </div>
-    )
-  }
-
+export default function StyleTestPage() {
   return (
-    <div className="min-h-screen bg-[#FAFAFB] p-10">
-      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
-        <h1 className="text-2xl font-semibold text-black">컴포넌트 테스트</h1>
-        <button
-          type="button"
-          onClick={() => setShowNotFound(true)}
-          className="w-fit rounded-md bg-[#111111] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#2a2a2a]"
-        >
-          404/NotFound/Loading 테스트
-        </button>
-
-        <TestPageApiPanel />
-        {/* Dropdown 테스트 */}
-        <div className="flex flex-col gap-4 rounded-xl border border-gray-200 bg-white p-6">
-          <h2 className="text-xl font-semibold text-black">Dropdown 테스트</h2>
-          <Dropdown options={options} value={value} onChange={setValue} />
-          <Dropdown options={options} disabled />
+    <div className="p-10 space-y-12 bg-gray-50 min-h-screen">
+      {/* Title Section */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-bold">Title Styles</h2>
+        <div className="space-y-2">
+          <p className="title-xl">Title XL - 32px Bold</p>
+          <p className="title-l">Title L - 20px Semibold</p>
+          <p className="title-m-a">Title M A - 18px Bold (로그인 페이지용)</p>
+          <p className="title-m-b">Title M B - 18px Semibold (마이/쪽지/비번 페이지용)</p>
         </div>
+      </section>
 
-        {/* Password 테스트 */}
-        <div className="flex flex-col gap-4 rounded-xl border border-gray-200 bg-white p-6">
-          <h2 className="text-xl font-semibold text-black">Password 테스트</h2>
-          <Password
-            width={288}
-            value={password}
-            onChange={handlePasswordChange}
-            placeholder="비밀번호를 입력해주세요"
-            state={passwordState}
+      {/* Placeholder Section */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-bold">Placeholder Styles</h2>
+        <div className="space-y-4 max-w-sm">
+          <input
+            className="placeholder-a border p-2 w-full"
+            placeholder="로그인 페이지용 placeholder (14px)"
           />
-          <button
-            type="button"
-            onClick={handleLogin}
-            className="w-[288px] rounded-md bg-[#6201E0] px-4 py-2 text-white hover:bg-[#5210be] transition-colors"
-          >
-            로그인
-          </button>
-          <p className="text-xs text-gray-500">
-            테스트용 올바른 비밀번호: <span className="font-mono font-semibold">{correctPassword}</span>
-          </p>
-        </div>
-
-        {/* CommonInput 테스트 */}
-        <div className="flex flex-col gap-4 rounded-xl border border-gray-200 bg-white p-6">
-          <h2 className="text-xl font-semibold text-black">CommonInput 테스트</h2>
-          <CommonInput
-            value={inputValue}
-            onChange={setInputValue}
-            placeholder="입력해주세요"
-            width={288}
+          <input
+            className="placeholder-b border p-2 w-full"
+            placeholder="마이/쪽지/비번변경 페이지용 placeholder (16px)"
           />
         </div>
-      </div>
+      </section>
+
+      {/* Layout Section */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-bold">flex-center</h2>
+        <div className="h-32 bg-white border flex-center">
+          <span className="title-m-b"> h-32 bg-white border flex-center</span>
+        </div>
+      </section>
     </div>
-  )
+  );
 }
-
-export default TestPage


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #58 

## 📑 구현 사항
- 반복적으로 사용되던 Tailwind 유틸리티 클래스를 `@apply`를 사용해 공통 스타일로 분리
- 중앙 정렬, 타이틀 폰트, 플레이스홀더 폰트 스타일을 `app.css`에 정의
- JSX 코드의 가독성과 유지보수성을 개선

---

## 🌀 어려웠던 점 / 고민했던 부분
- Tailwind 유틸리티를 어디까지 `@apply`로 묶는 것이 적절한지 고민함
- px 단위 폰트 사이즈를 유지하면서도 Tailwind 방식에 어긋나지 않게 작성하는 방법을 고민함
- 네이밍을 `a / b` 방식으로 할지, 의미 기반으로 할지 결정하는 과정에서 고민이 있었음

---

## 📸 구현 이미지
<img width="1488" height="563" alt="스크린샷 2026-01-23 오후 4 35 14" src="https://github.com/user-attachments/assets/e31e5eba-1523-4572-833b-05cfd01e37ab" />


---

## ❇️ 코드 설명
- `@apply`를 사용해 자주 반복되는 Tailwind 클래스 조합을 하나의 클래스로 정의했습니다.
- 타이틀과 플레이스홀더는 사용 맥락에 따라 크기와 font-weight를 구분했습니다.

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.