### PR TITLE
[feat] 쪽지시험 문제 유형별 카드 생성 및  응시페이지 연결/랜더링 추가 (#76)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "oz_externship_fe_template",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.2.2",
         "@tailwindcss/vite": "^4.1.10",
         "@tanstack/react-query": "^5.80.7",
@@ -93,6 +96,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -758,6 +762,60 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2146,6 +2204,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.19.tgz",
       "integrity": "sha512-qTZRZ4QyTzQc+M0IzrbKHxSeISUmRB3RPGmao5bT+sI6ayxSRhn0FXEnT5Hg3as8SBFcRosrXXRFB+yAcxVxJQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.19"
       },
@@ -2251,6 +2310,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
       "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -2260,6 +2320,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2323,6 +2384,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.34.0.tgz",
       "integrity": "sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.34.0",
         "@typescript-eslint/types": "8.34.0",
@@ -2561,6 +2623,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2848,6 +2911,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -3135,6 +3199,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -3191,7 +3256,8 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "peer": true
     },
     "node_modules/dargs": {
       "version": "8.1.0",
@@ -3643,6 +3709,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.29.0.tgz",
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5933,6 +6000,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6079,6 +6147,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6087,6 +6156,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -6099,6 +6169,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -6884,6 +6955,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7060,6 +7132,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7180,6 +7253,7 @@
       "version": "6.3.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7266,6 +7340,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
     "@tailwindcss/vite": "^4.1.10",
     "@tanstack/react-query": "^5.80.7",

--- a/src/components/MyPageQuiz.tsx
+++ b/src/components/MyPageQuiz.tsx
@@ -19,16 +19,16 @@ const MyPageQuiz = () => {
     [currentTab]
   )
 
-  // 쪽지시험 목록 조회
+  // 쪽지시험 목록 조회 : 탭(전체/응시완료/미응시)에 따라 status 바꿔서 조회
   const { data, isLoading, isError } = useExamDeploymentsQuery(
     {
       page: INITIAL_PAGE,
-      status: currentStatus,
+      status: currentStatus, // 'all' | 'done' | 'pending'
     },
     true
   )
 
-  // 쪽지시험 데이터 추출
+  // QuizContent에 전달해서 카드 목록 렌더링 하기 위해 데이터 추출
   const quizzes = useMemo(() => data?.results || [], [data?.results])
 
   return (

--- a/src/components/QuizHeader.tsx
+++ b/src/components/QuizHeader.tsx
@@ -40,7 +40,7 @@ function QuizHeader({
             >
               ←
             </Link>
-            <h1 className={titleStyle}>{subjectName}</h1>
+            <h1 className={titleStyle}>{subjectName} 쪽지시험</h1>
           </div>
           <p className={contentStyle}>{message}</p>
         </div>

--- a/src/components/QuizWarningBox.tsx
+++ b/src/components/QuizWarningBox.tsx
@@ -12,7 +12,7 @@ function QuizWarningBox() {
   }
 
   return (
-    <div className="min-w-[1200px] flex items-start gap-3 rounded-lg bg-[#EFE6FC] px-6 py-5">
+    <div className="min-w-[1200px] flex items-start gap-3 rounded-lg bg-[#EFE6FC] px-6 py-5 mb-10">
       <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full">
         <img
           src="/alertCircle.svg"

--- a/src/components/quiz/FillBlank.tsx
+++ b/src/components/quiz/FillBlank.tsx
@@ -1,0 +1,99 @@
+import { useState, useEffect } from 'react'
+import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
+
+interface FillBlankProps {
+  question: ExamDeploymentDetailResult['questions'][0]
+  answer: string[] | null
+  onAnswerChange: (questionId: number, answer: string[]) => void
+}
+
+const BLANK_LABELS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'] as const
+
+export default function FillBlank({ question, answer, onAnswerChange }: FillBlankProps) {
+  const blankCount = question.blankCount || 0
+  const blankLabels = BLANK_LABELS.slice(0, blankCount)
+
+  const [answers, setAnswers] = useState<string[]>(() =>
+    answer || Array(blankCount).fill('')
+  )
+
+  useEffect(() => {
+    if (answer) {
+      setAnswers(answer)
+    } else {
+      setAnswers(Array(blankCount).fill(''))
+    }
+  }, [answer, blankCount])
+
+  const handleInputChange = (index: number, value: string) => {
+    const newAnswers = [...answers]
+    newAnswers[index] = value
+    setAnswers(newAnswers)
+    onAnswerChange(question.questionId, newAnswers)
+  }
+
+  const renderPromptWithBlanks = () => {
+    if (!question.prompt) return null
+
+    const parts = question.prompt.split('__')
+    const result: React.ReactNode[] = []
+
+    parts.forEach((part, index) => {
+      result.push(<span key={`text-${index}`}>{part}</span>)
+      if (index < blankCount) {
+        result.push(
+          <span key={`blank-${index}`} className="font-bold">
+            ({blankLabels[index]})_______
+          </span>
+        )
+      }
+    })
+
+    return <div className="text-[16px] font-normal text-[#222222]">{result}</div>
+  }
+
+  return (
+    <div className="mb-20">
+      {/* 문제 헤더 */}
+      <div className="mb-4 flex items-center gap-2">
+        <span className="text-[20px] font-bold text-[#121212]">
+          {question.number}. {question.question}
+        </span>
+        <span className="bg-[#ECECEC] rounded-[2px] text-[12px] font-normal text-[#121212] px-2 py-[2px]">
+          {question.point}점
+        </span>
+        <span className="bg-[#ECECEC] rounded-[2px] text-[12px] font-normal text-[#121212] px-2 py-[2px]">
+          빈칸식
+        </span>
+      </div>
+
+      {/* 지문 박스 */}
+      {question.prompt && (
+        <div className="w-[648px] min-h-[96px] bg-[#F2F3F5]/50 p-[20px] rounded-lg mb-[26px] ml-6">
+          {renderPromptWithBlanks()}
+        </div>
+      )}
+
+      {/* 답변 입력 영역 */}
+      <div className="ml-6 space-y-3">
+        {blankLabels.map((label, index) => (
+          <div
+            key={label}
+            className="relative w-[308px] h-[48px] bg-[#F2F3F5] rounded-[4px] flex items-center px-4 py-2"
+          >
+            <span className="text-[16px] font-bold text-[#121212] mr-2">
+              {label}.
+            </span>
+            <input
+              type="text"
+              value={answers[index] || ''}
+              onChange={(e) => handleInputChange(index, e.target.value)}
+              placeholder="정답을 입력해 주세요."
+              className="flex-1 h-full bg-transparent border-none outline-none text-[16px] font-bold text-[#222222] placeholder:text-[16px] placeholder:text-[#BDBDBD] placeholder:font-normal"
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/quiz/OX.tsx
+++ b/src/components/quiz/OX.tsx
@@ -1,0 +1,126 @@
+import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
+
+interface OXProps {
+  question: ExamDeploymentDetailResult['questions'][0]
+  answer: string | null
+  onAnswerChange: (questionId: number, answer: string) => void
+}
+
+const OPTION_LABELS = {
+  O: '맞아요',
+  X: '아니에요',
+} as const
+
+const COLORS = {
+  selected: {
+    card: 'bg-[#EFE6FC]',
+    checkmark: 'text-[#6201E0]',
+  },
+  unselected: {
+    card: 'bg-[#F2F3F5]',
+    checkmark: 'text-[#BDBDBD]',
+  },
+  icon: {
+    oSelected: 'border-[#00c05c] bg-[#EFE6FC]',
+    oUnselected: 'border-[#B4B4B4] bg-white',
+    xSelected: 'text-[#ee1444]',
+    xUnselected: 'text-[#B4B4B4]',
+  },
+} as const
+
+interface OXOptionProps {
+  option: string
+  isSelected: boolean
+  questionId: number
+  onSelect: (option: string) => void
+}
+
+function OXOption({ option, isSelected, questionId, onSelect }: OXOptionProps) {
+  const isO = option === 'O' || option === '맞아요'
+  const displayText = option === 'O' ? OPTION_LABELS.O : option === 'X' ? OPTION_LABELS.X : option
+
+  const cardClass = `w-[308px] h-[48px] rounded-[4px] flex items-center justify-between px-4 cursor-pointer transition-colors ${
+    isSelected ? COLORS.selected.card : COLORS.unselected.card
+  }`
+
+  const iconClass = isO
+    ? `w-6 h-6 rounded-full border-2 flex-shrink-0 ${
+        isSelected ? COLORS.icon.oSelected : COLORS.icon.oUnselected
+      }`
+    : 'w-6 h-6 flex items-center justify-center flex-shrink-0'
+
+  const xIconClass = `text-xl font-bold ${
+    isSelected ? COLORS.icon.xSelected : COLORS.icon.xUnselected
+  }`
+
+  const checkmarkClass = `text-2xl font-normal ${
+    isSelected ? COLORS.selected.checkmark : COLORS.unselected.checkmark
+  }`
+
+  return (
+    <label className={cardClass}>
+      <div className="flex items-center gap-3">
+        {isO ? (
+          <div className={iconClass} />
+        ) : (
+          <div className={iconClass}>
+            <span className={xIconClass}>✕</span>
+          </div>
+        )}
+        <span className="text-base font-medium text-[#121212]">{displayText}</span>
+      </div>
+      <span className={checkmarkClass}>✓</span>
+      <input
+        type="radio"
+        name={`question-${questionId}`}
+        value={option}
+        checked={isSelected}
+        onChange={() => onSelect(option)}
+        className="hidden"
+      />
+    </label>
+  )
+}
+
+export default function OX({ question, answer, onAnswerChange }: OXProps) {
+  const handleOptionChange = (option: string) => {
+    onAnswerChange(question.questionId, option)
+  }
+
+  return (
+    <div className="mb-20">
+      {/* 문제 헤더 */}
+      <div className="mb-4 flex items-center gap-2">
+        <span className="text-[20px] font-bold text-[#121212]">
+          {question.number}. {question.question}
+        </span>
+        <span className="bg-[#ECECEC] rounded-[2px] text-[12px] font-normal text-[#121212] px-2 py-[2px]">
+          {question.point}점
+        </span>
+        <span className="bg-[#ECECEC] rounded-[2px] text-[12px] font-normal text-[#121212] px-2 py-[2px]">
+          OX선택
+        </span>
+      </div>
+
+      {/* 지문 */}
+      {question.prompt && (
+        <div className="mb-[26px] flex flex-col ml-6">
+          <p className="text-[16px] font-normal text-[#222222]">{question.prompt}</p>
+        </div>
+      )}
+
+      {/* 옵션 */}
+      <div className="flex flex-col gap-[18px] ml-6">
+        {question.options?.map((option, index) => (
+          <OXOption
+            key={index}
+            option={option}
+            isSelected={answer === option}
+            questionId={question.questionId}
+            onSelect={handleOptionChange}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/quiz/Ordering.tsx
+++ b/src/components/quiz/Ordering.tsx
@@ -1,0 +1,248 @@
+import { useState, useEffect, useMemo } from 'react'
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  useDraggable,
+  useDroppable,
+} from '@dnd-kit/core'
+import { CSS } from '@dnd-kit/utilities'
+import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
+
+interface OrderingProps {
+  question: ExamDeploymentDetailResult['questions'][0]
+  answer: string[] | null
+  onAnswerChange: (questionId: number, answer: string[]) => void
+}
+
+const OPTION_LABELS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'] as const
+
+interface DraggableLabelProps {
+  id: string
+  label: string
+  item: string
+  isUsed: boolean
+}
+
+function DraggableLabel({ id, label, item, isUsed }: DraggableLabelProps) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id,
+    disabled: isUsed,
+    data: { item, label },
+  })
+
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    opacity: isDragging ? 0.5 : isUsed ? 0.4 : 1,
+    padding: '3px',
+  }
+
+  return (
+    <span
+      ref={setNodeRef}
+      style={style}
+      {...listeners}
+      {...attributes}
+      className={`inline-flex items-center justify-center w-8 h-8 rounded-[4px] bg-[#EFE6FC] text-[18px] font-normal text-[#6201E0] ${
+        isUsed ? 'cursor-not-allowed' : 'cursor-grab active:cursor-grabbing'
+      }`}
+    >
+      {label}
+    </span>
+  )
+}
+
+interface DroppableSlotProps {
+  id: string
+  index: number
+  label: string | null
+  onRemove: () => void
+}
+
+function DroppableSlot({ id, index, label, onRemove }: DroppableSlotProps) {
+  const { setNodeRef, isOver } = useDroppable({ id })
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`w-[62px] h-[62px] p-[3px] rounded-[4px] bg-[#F2F3F5] flex items-center justify-center transition-colors ${
+        isOver ? 'ring-2 ring-primary ring-offset-2' : ''
+      }`}
+    >
+      {label ? (
+        <div className="relative w-full h-full flex items-center justify-center">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              onRemove()
+            }}
+            className="absolute -top-1 -right-1 w-4 h-4 flex items-center justify-center text-gray-400 hover:text-gray-600 text-xs bg-white rounded-full border border-gray-300"
+          >
+            ×
+          </button>
+          <span className="text-[18px] font-normal text-[#6201E0] bg-[#EFE6FC] w-8 h-8 flex items-center justify-center rounded-[4px]">
+            {label}
+          </span>
+        </div>
+      ) : (
+        <span className="text-[#F2F3F5] text-sm font-medium">{index + 1}</span>
+      )}
+    </div>
+  )
+}
+
+export default function Ordering({ question, answer, onAnswerChange }: OrderingProps) {
+  const options = question.options || []
+  const optionLabels = useMemo(
+    () => OPTION_LABELS.slice(0, options.length),
+    [options.length]
+  )
+
+  const initializeSlots = (): (string | null)[] => {
+    const initialSlots = Array(options.length).fill(null)
+    if (answer && answer.length > 0) {
+      answer.forEach((item, idx) => {
+        if (idx < initialSlots.length) {
+          const index = options.findIndex((opt) => opt === item)
+          if (index !== -1) {
+            initialSlots[idx] = optionLabels[index]
+          }
+        }
+      })
+    }
+    return initialSlots
+  }
+
+  const [slots, setSlots] = useState<(string | null)[]>(initializeSlots)
+
+  useEffect(() => {
+    const newSlots = Array(options.length).fill(null)
+    if (answer && answer.length > 0) {
+      answer.forEach((item, idx) => {
+        if (idx < newSlots.length) {
+          const index = options.findIndex((opt) => opt === item)
+          if (index !== -1) {
+            newSlots[idx] = optionLabels[index]
+          }
+        }
+      })
+    }
+    setSlots(newSlots)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [answer, options.length])
+
+  const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor))
+
+  const convertLabelsToAnswers = (labels: (string | null)[]): string[] => {
+    return labels
+      .filter((label): label is string => label !== null)
+      .map((label) => {
+        const labelIndex = optionLabels.findIndex((l) => l === label)
+        return labelIndex !== -1 ? options[labelIndex] : ''
+      })
+      .filter((val) => val !== '')
+  }
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over) return
+
+    const draggedLabel = (active.id as string).replace('label-', '')
+    const slotIndex = parseInt((over.id as string).replace('slot-', ''), 10)
+
+    const newSlots = [...slots]
+    const existingSlotIndex = newSlots.findIndex((label) => label === draggedLabel)
+
+    if (existingSlotIndex !== -1) {
+      newSlots[existingSlotIndex] = null
+    }
+
+    newSlots[slotIndex] = draggedLabel
+    setSlots(newSlots)
+    onAnswerChange(question.questionId, convertLabelsToAnswers(newSlots))
+  }
+
+  const handleRemoveFromSlot = (index: number) => {
+    const newSlots = [...slots]
+    newSlots[index] = null
+    setSlots(newSlots)
+    onAnswerChange(question.questionId, convertLabelsToAnswers(newSlots))
+  }
+
+  const isLabelUsed = (label: string) => slots.includes(label)
+
+  const renderOptions = () => (
+    <div className="space-y-[18px]">
+      {options.map((item, index) => (
+        <div key={`option-${index}`} className="flex items-center gap-3">
+          <DraggableLabel
+            id={`label-${optionLabels[index]}`}
+            label={optionLabels[index]}
+            item={item}
+            isUsed={isLabelUsed(optionLabels[index])}
+          />
+          <span className="text-[16px] font-normal text-[#222222]">{item}</span>
+        </div>
+      ))}
+    </div>
+  )
+
+  return (
+    <div className="mb-20">
+      {/* 문제 헤더 */}
+      <div className="mb-4 flex items-center gap-2">
+        <span className="text-[20px] font-bold text-[#121212]">
+          {question.number}. {question.question}
+        </span>
+        <span className="bg-[#ECECEC] rounded-[2px] text-[12px] font-normal text-[#121212] px-2 py-[2px]">
+          {question.point}점
+        </span>
+        <span className="bg-[#ECECEC] rounded-[2px] text-[12px] font-normal text-[#121212] px-2 py-[2px]">
+          순서배열
+        </span>
+      </div>
+
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        {/* 지문 및 옵션 박스 */}
+        {question.prompt ? (
+          <div className="w-[648px] min-h-[228px] bg-[#F2F3F5]/50 p-[20px] rounded-lg mb-4 ml-6">
+            <p className="text-[16px] font-normal text-[#222222] mb-[18px]">
+              {question.prompt}
+            </p>
+            {renderOptions()}
+          </div>
+        ) : (
+          options.length > 0 && (
+            <div className="w-[648px] min-h-[228px] bg-[#F2F3F5]/50 p-[20px] rounded-lg mb-4 ml-6">
+              {renderOptions()}
+            </div>
+          )
+        )}
+
+        {/* 빈칸 영역 */}
+        <div className="ml-6 mt-4">
+          <div className="flex gap-[10px]">
+            {slots.map((label, index) => (
+              <DroppableSlot
+                key={`slot-${index}`}
+                id={`slot-${index}`}
+                index={index}
+                label={label}
+                onRemove={() => handleRemoveFromSlot(index)}
+              />
+            ))}
+          </div>
+        </div>
+      </DndContext>
+    </div>
+  )
+}

--- a/src/components/quiz/QuizContent.tsx
+++ b/src/components/quiz/QuizContent.tsx
@@ -29,7 +29,7 @@ export default function QuizContent({ quizzes, isLoading, isError, currentTab }:
   if (isError) {
     return (
       <div className="flex justify-center items-center py-20">
-        <p className="text-red-500">데이터를 불러오는 중 오류가 발생했습니다.</p>
+        <p className="text-gray-200">데이터를 불러오는 중 오류가 발생했습니다.</p>
       </div>
     )
   }

--- a/src/components/quiz/SingleChoice.tsx
+++ b/src/components/quiz/SingleChoice.tsx
@@ -1,0 +1,93 @@
+import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
+
+interface SingleChoiceProps {
+  question: ExamDeploymentDetailResult['questions'][0]
+  answer: string | null
+  onAnswerChange: (questionId: number, answer: string) => void
+}
+
+const RADIO_STYLES = {
+  selected: {
+    className: 'bg-[#6201E0] border-[#6201E0]',
+    backgroundImage: 'radial-gradient(circle, white 40%, transparent 40%)',
+  },
+  unselected: {
+    className: 'bg-white border-gray-300',
+    backgroundImage: 'radial-gradient(circle, #ECECEC 40%, transparent 40%)',
+  },
+} as const
+
+interface RadioOptionProps {
+  option: string
+  isSelected: boolean
+  questionId: number
+  onSelect: (option: string) => void
+}
+
+function RadioOption({ option, isSelected, questionId, onSelect }: RadioOptionProps) {
+  const style = isSelected ? RADIO_STYLES.selected : RADIO_STYLES.unselected
+
+  return (
+    <label className="flex items-center gap-3 cursor-pointer">
+      <input
+        type="radio"
+        name={`question-${questionId}`}
+        value={option}
+        checked={isSelected}
+        onChange={() => onSelect(option)}
+        className={`w-5 h-5 rounded-full border-2 appearance-none cursor-pointer transition-colors ${style.className}`}
+        style={{ backgroundImage: style.backgroundImage }}
+      />
+      <span className="text-[16px] font-normal text-[#222222]">{option}</span>
+    </label>
+  )
+}
+
+export default function SingleChoice({ question, answer, onAnswerChange }: SingleChoiceProps) {
+  const handleOptionChange = (option: string) => {
+    onAnswerChange(question.questionId, option)
+  }
+
+  const renderOptions = () => (
+    <div className="space-y-[22px]">
+      {question.options?.map((option, index) => (
+        <RadioOption
+          key={index}
+          option={option}
+          isSelected={answer === option}
+          questionId={question.questionId}
+          onSelect={handleOptionChange}
+        />
+      ))}
+    </div>
+  )
+
+  return (
+    <div className="mb-20">
+      {/* 문제 헤더 */}
+      <div className="mb-4 flex items-center gap-2">
+        <span className="text-[20px] font-bold text-[#121212]">
+          {question.number}. {question.question}
+        </span>
+        <span className="bg-[#ECECEC] rounded-[2px] text-[12px] font-normal text-[#121212] px-2 py-[2px]">
+          {question.point}점
+        </span>
+        <span className="bg-[#ECECEC] rounded-[2px] text-[12px] font-normal text-[#121212] px-2 py-[2px]">
+          단일선택
+        </span>
+      </div>
+
+      {/* 지문 및 옵션 */}
+      {question.prompt ? (
+        <div className="w-[648px] min-h-[96px] bg-[#F2F3F5]/50 p-4 rounded-lg ml-6">
+          <p className="text-[16px] font-normal text-[#222222] mb-[26px]">
+            {question.prompt}
+          </p>
+          {renderOptions()}
+        </div>
+      ) : (
+        <div className="ml-6">{renderOptions()}</div>
+      )}
+    </div>
+  )
+}

--- a/src/components/quiz/index.ts
+++ b/src/components/quiz/index.ts
@@ -1,1 +1,7 @@
 export { default as QuizCard } from './QuizCard'
+export { default as SingleChoice } from './SingleChoice'
+export { default as OX } from './OX'
+export { default as Ordering } from './Ordering'
+export { default as FillBlank } from './FillBlank'
+export { default as QuizContent } from './QuizContent'
+export { default as QuizTabs } from './QuizTabs'

--- a/src/mappers/examDeploymentDetail.ts
+++ b/src/mappers/examDeploymentDetail.ts
@@ -52,21 +52,21 @@ export const mapExamDeploymentDetail = (
   response: ExamDeploymentDetailResponse
 ): ExamDeploymentDetailResult => {
   return {
-    examId: response.exam_id,
-    examName: response.exam_name,
-    durationTime: response.duration_time,
-    elapsedTime: response.elapsed_time,
-    cheatingCount: response.cheating_count,
-    questions: response.questions.map((question) => ({
-      questionId: question.question_id,
-      number: question.number,
-      type: question.type,
-      question: question.question,
-      point: question.point,
-      prompt: question.prompt,
-      blankCount: question.blank_count,
-      options: question.options,
-      answerInput: question.answer_input,
+    examId: response.exam_id,                             // 시험 배포 ID
+    examName: response.exam_name,                         // 시험 이름
+    durationTime: response.duration_time,                 // 시험 시간(분)
+    elapsedTime: response.elapsed_time,                   // 경과 시간(분)
+    cheatingCount: response.cheating_count,               // 부정행위 카운트
+    questions: response.questions.map((question) => ({    // 문제 목록
+      questionId: question.question_id,                     // 문제 ID
+      number: question.number,                              // 문제 번호
+      type: question.type,                                  // 문제 유형(문제 타입)
+      question: question.question,                          // 문제 내용
+      point: question.point,                                // 문제 점수
+      prompt: question.prompt,                              // 문제 프롬프트(빈칸 채우기 문제 시 사용)
+      blankCount: question.blank_count,                     // 빈칸 개수(빈칸 채우기 문제 시 사용)
+      options: question.options,                            // 문제 선택지(단답형 문제 시 사용)
+      answerInput: question.answer_input,                   // 문제 답변(단답형 문제 시 사용)
     })),
   }
 }


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #76 


## 📑 구현 사항


- **문제 유형별 카드 컴포넌트 추가**
  - `SingleChoice`: 단일선택(라디오)
  - `OX`: O/X 선택
  - `FillBlank`: 빈칸식 (지문에 `(A)_______` 표기, 하단 입력)
  - `Ordering`: 순서배열 (A/B/C/D 드래그 → 빈칸 슬롯에 배치)
- **QuizPage 문제 목록 렌더링**
  - `useExamDeploymentDetailQuery(deploymentId)`로 상세/문항 조회
  - 문항 `type`별로 위 카드 컴포넌트 매핑 후 렌더링
  - 답변 상태 `useState`로 관리, `handleAnswerChange`로 개별 문항 답변 반영
- **응시 페이지 ↔ API 연동**
  - URL `deploymentId` 기준 상세 API 호출 후 헤더 과목명(`examName`), 문항 목록 표시
  - MSW 핸들러(`examDeploymentDetail`) 연동
- **기타**
  - `@dnd-kit` 설치 및 Ordering 드래그 앤 드롭 적용
  - `MultipleChoice` 제거 후 `quiz/index` export 정리

---

## 🌀 어려웠던 점 / 고민했던 부분

- **Ordering**  
  - “지문 안 A/B/C/D만 드래그, 텍스트는 고정” + “하단 빈칸에 순서대로 배치” 요구를 만족하려고 `useDraggable` / `useDroppable` 구분과 `slots` 상태 설계를 고민함.  
  - `slots` 길이를 항상 `options.length`로 유지해, 드롭 시 나머지 빈칸이 사라지지 않도록 초기화·갱신 로직을 정리함.
- **FillBlank**  
  - 지문에는 `(A)_______` 형태만 두고, 실제 입력은 지문 아래 A/B별 인풋으로 분리하는 구조로 맞추는 과정에서 `prompt` 파싱과 입력 영역 배치를 조정함.
- **공통 스타일**  
  - 문제 카드별로 디자인 스펙(배지, 지문 박스, 간격 등)이 달라, 재사용 가능한 스타일 상수·공용 클래스로 어디까지 묶을지 경계를 나누는 데 시간을 씀.

---

## 📸 구현 이미지

-

https://github.com/user-attachments/assets/534895df-bf90-471a-91d1-b0595c4fccd4



## ❇️ 코드 설명

-

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.