### PR TITLE
[feat] 프로필아이콘 드롭다운 : UI수정 및 수강생등록 모달페이지 연결 (#79)

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -5,6 +5,16 @@ import { useAuthStore } from '@/store/authStore'
 import { Button } from '@/components/common/Button'
 import { RegisterStudentModal } from '@/components/common/Modal/variants'
 
+// 드롭다운 스타일
+const dropdownContainerClass =
+  'absolute top-17 right-0 z-50 w-[204px] rounded-[12px] bg-white px-[16px] py-[16px] shadow-[0_0_16px_0_#A0A0A040]'
+const userInfoContainerClass = 'h-[53px] w-[172px] items-start gap-[20px]'
+const userNameClass = 'text-[16px] font-semibold text-black py-2'
+const userEmailClass = 'text-[14px] font-normal text-gray-400 mb-2'
+const dividerClass = 'my-4 border-t border-mono-200'
+const dropdownButtonClass =
+  'hover:no-underline hover:bg-primary-100 hover:text-primary block w-full justify-start p-2 text-left text-sm'
+
 export default function Header() {
   const [open, setOpen] = useState(false)
   const [registerStudentModalOpen, setRegisterStudentModalOpen] = useState(false)
@@ -147,23 +157,19 @@ export default function Header() {
                 </Button>
 
                 {open && (
-                  <div className="absolute top-17 right-0 z-50 w-[204px] rounded-[12px] bg-white px-[16px] py-[16px] shadow-[0_0_16px_0_#A0A0A040]">
-                    <div className="h-[53px] w-[172px] items-start gap-[20px]">
-                      <p className="font-[Pretendard] text-[16px] leading-[140%] font-semibold tracking-[-0.03em] text-gray-900">
-                        {user?.name ?? '유저'}
-                      </p>
-                      <p className="text-mono-600 font-[Pretendard] text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
-                        {user?.email ?? ''}
-                      </p>
+                  <div className={dropdownContainerClass}>
+                    <div className={userInfoContainerClass}>
+                      <p className={userNameClass}>{user?.name ?? '유저'}</p>
+                      <p className={userEmailClass}>{user?.email ?? ''}</p>
                     </div>
 
-                    <div className="my-4 border-t border-mono-200" />
+                    <div className={dividerClass} />
 
                     <Button
                       type="button"
                       variant="link"
                       size="auto"
-                      className="hover:no-underline hover:bg-primary-100 hover:text-primary block w-full justify-start py-3 text-left text-sm"
+                      className={dropdownButtonClass}
                       onClick={() => {
                         setOpen(false)
                         setRegisterStudentModalOpen(true)
@@ -176,7 +182,7 @@ export default function Header() {
                       type="button"
                       variant="link"
                       size="auto"
-                      className="hover:no-underline hover:bg-primary-100 hover:text-primary block w-full justify-start py-3 text-left text-sm"
+                      className={dropdownButtonClass}
                       onClick={() => {
                         setOpen(false)
                         navigate('/mypage')
@@ -189,7 +195,7 @@ export default function Header() {
                       type="button"
                       variant="link"
                       size="auto"
-                      className="hover:no-underline hover:bg-primary-100 hover:text-primary block w-full justify-start py-3 text-left text-sm"
+                      className={dropdownButtonClass}
                       onClick={handleLogout}
                     >
                       로그아웃

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -3,9 +3,11 @@ import { useNavigate } from 'react-router-dom'
 import { useAuthStore } from '@/store/authStore'
 
 import { Button } from '@/components/common/Button'
+import { RegisterStudentModal } from '@/components/common/Modal/variants'
 
 export default function Header() {
   const [open, setOpen] = useState(false)
+  const [registerStudentModalOpen, setRegisterStudentModalOpen] = useState(false)
   const dropdownRef = useRef<HTMLDivElement | null>(null)
 
   const navigate = useNavigate()
@@ -164,7 +166,7 @@ export default function Header() {
                       className="hover:no-underline hover:bg-primary-100 hover:text-primary block w-full justify-start py-3 text-left text-sm"
                       onClick={() => {
                         setOpen(false)
-                        navigate('/register')
+                        setRegisterStudentModalOpen(true)
                       }}
                     >
                       수강생 등록
@@ -199,6 +201,15 @@ export default function Header() {
           </div>
         </div>
       </div>
+
+      <RegisterStudentModal
+        isOpen={registerStudentModalOpen}
+        onClose={() => setRegisterStudentModalOpen(false)}
+        onSuccess={(data) => {
+          console.log('수강생 등록 성공:', data)
+          setRegisterStudentModalOpen(false)
+        }}
+      />
     </header>
   )
 }


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #79

## 📑 구현 사항

- **프로필 드롭다운 UI 수정**
  - 유저 이름/이메일 텍스트 스타일 개선 (Pretendard 폰트 제거, 간격 조정)
  - 드롭다운 버튼 패딩 조정 (`py-3` → `p-2`)
  - 이메일 텍스트에 `mb-2` 추가로 간격 개선
- **수강생 등록 모달 연결**
  - 프로필 드롭다운의 "수강생 등록" 버튼 클릭 시 `RegisterStudentModal` 열기
  - 기존 라우팅(`navigate('/register')`) 대신 모달 방식으로 변경
  - 모달 상태 관리 추가 (`registerStudentModalOpen`)
- **코드 리팩토링**
  - 드롭다운 관련 스타일 클래스를 리턴문 밖에서 상수로 선언
  - 가독성 및 유지보수성 향상

## 🌀 어려웠던 점 / 고민했던 부분

- ** 라우팅 선택**
  - 기존에 구현된 `RegisterStudentModal` 컴포넌트를 재사용하여 일관성 유지
- **스타일 상수 분리**
  - 드롭다운 스타일을 상수로 분리하면서, 재사용성과 가독성 사이의 균형을 고려


## 📸 구현 이미지

https://github.com/user-attachments/assets/bba1f166-15b7-4169-8e9b-57e360459f70

## ❇️ 코드 설명

-

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.