### PR TITLE
feat: 타이머 및 종료 상태 관리 기능 추가

### DIFF
--- a/src/hooks/useQuiz.ts
+++ b/src/hooks/useQuiz.ts
@@ -46,6 +46,7 @@ export const useExamDeploymentStatusQuery = (deploymentId: number, enabled = tru
     queryKey: ['examDeploymentStatus', deploymentId],
     queryFn: () => fetchExamDeploymentStatus(deploymentId),
     enabled,
+    refetchInterval: 1000,
   })
 }
 

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react'
-import { useParams } from 'react-router-dom'
-import { Button, Loading } from '@/components/common'
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { Button, Loading, Modal } from '@/components/common'
 import QuizHeader from '@/components/QuizHeader'
 import QuizWarningBox from '@/components/QuizWarningBox'
-import { useExamDeploymentDetailQuery } from '@/hooks/useQuiz'
+import { useExamDeploymentDetailQuery, useExamDeploymentStatusQuery } from '@/hooks/useQuiz'
 import {
   SingleChoice,
   OX,
@@ -15,12 +15,20 @@ import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
 type Question = ExamDeploymentDetailResult['questions'][0]
 
 function QuizPage() {
+  const navigate = useNavigate()
   const { deploymentId } = useParams<{ deploymentId: string }>()
   const deploymentIdNumber = deploymentId ? Number(deploymentId) : 0
+  const [isEnded, setIsEnded] = useState(false)
+  const [endReason, setEndReason] = useState<'time' | 'status' | null>(null)
+  const [remainingSeconds, setRemainingSeconds] = useState(30 * 60)
 
   const { data, isLoading } = useExamDeploymentDetailQuery(
     deploymentIdNumber,
     !!deploymentId
+  )
+  const { data: statusData } = useExamDeploymentStatusQuery(
+    deploymentIdNumber,
+    !!deploymentId && !isEnded
   )
 
   // 답변 상태 관리
@@ -88,16 +96,73 @@ function QuizPage() {
     alert('시험이 제출되었습니다.')
   }
 
+
+  useEffect(() => {
+    if (isEnded) return
+    const timer = setInterval(() => {
+      setRemainingSeconds((prev) => {
+        if (prev <= 1) {
+          setIsEnded(true)
+          setEndReason('time')
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, [isEnded])
+
+  useEffect(() => {
+    if (isEnded) return
+    if (statusData?.examStatus === 'closed' || statusData?.forceSubmit) {
+      setIsEnded(true)
+      setEndReason('status')
+    }
+  }, [statusData, isEnded])
+
+  const minutes = Math.floor(remainingSeconds / 60)
+  const seconds = remainingSeconds % 60
+  const paddedSeconds = seconds.toString().padStart(2, '0')
+  const formattedRemaining = `${minutes} : ${paddedSeconds}`
+
+  const handleEndConfirm = () => {
+    navigate('/mypage/quiz')
+  }
+
+  const handleTimeEndTest = () => {
+    setRemainingSeconds(0)
+    setIsEnded(true)
+    setEndReason('time')
+  }
+
+  const handleStatusEndTest = () => {
+    setIsEnded(true)
+    setEndReason('status')
+  }
+
   if (isLoading) {
     return <Loading />
   }
 
   return (
     <div>
-      <QuizHeader subjectName={data?.examName || '쪽지시험'} />
+      <QuizHeader
+        subjectName={data?.examName || '쪽지시험'}
+        timeRemaining={formattedRemaining}
+        timeRemainingSuffix="남음"
+      />
 
       <main className="flex flex-col items-center px-10 py-6">
         <QuizWarningBox />
+        <div className="mb-6 flex items-center gap-3">
+          <Button variant="secondary" size="sm" rounded="default" onClick={handleTimeEndTest}>
+            타이머 종료 테스트
+          </Button>
+          <Button variant="secondary" size="sm" rounded="default" onClick={handleStatusEndTest}>
+            상태 종료 테스트
+          </Button>
+        </div>
 
         <div className="min-h-[500px] min-w-[1200px]">
           {data?.questions && data.questions.length > 0 ? (
@@ -125,6 +190,25 @@ function QuizPage() {
           </Button>
         </div>
       </footer>
+
+      <Modal isOpen={isEnded} onClose={handleEndConfirm}>
+        <Modal.Body>
+          <div className="flex flex-col items-center gap-6 py-4 min-w-[250px]">
+            <img src='/icons/cloud_404.svg' alt="not-found" className="h-[58px] w-[74px]" />
+            <p className="text-center text-[16px] text-[#222222]">
+              {endReason === 'time'
+                ? '시험 시간이 종료되었습니다.'
+                : '쪽지시험 상태가 변경되어 종료되었습니다.'}
+            </p>
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="primary" size="md" rounded="default" className='w-full' onClick={handleEndConfirm}>
+            확인
+          </Button>
+        </Modal.Footer>
+      </Modal>
+
     </div>
   )
 }


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #82

## 📑 구현 사항

- 타이머 및 종료 상태 관리 기능 추가

## 🌀 어려웠던 점 / 고민했던 부분

-

## 📸 구현 이미지

- 

https://github.com/user-attachments/assets/0480e0e1-e899-4ce1-9e56-18236c42ba46


## ❇️ 코드 설명

- 쪽지시험 타이머(30분) 추가: 1초마다 감소, 0이 되면 종료 모달 노출
- 시험 상태 폴링(1초 고정): closed/forceSubmit면 종료 모달 노출
- 종료 모달에서 확인 시 마이페이지 쪽지시험 목록으로 이동
- 종료 모달에 404 아이콘 적용 및 헤더 제거
- 상태 체크 훅은 1초 고정 폴링으로 통일

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.