### PR TITLE
feat: 쪽지시험 결과 확인 페이지 UI 생성 (#90)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import SignupPage from '@/pages/SignupPage'
 import MyPage from '@/pages/MyPage'
 import MyPageQuiz from '@/components/MyPageQuiz'
 import QuizPage from '@/pages/QuizPage'
+import QuizResultPage from '@/pages/QuizResultPage'
 import MainLayout from '@/components/layout/MainLayout'
 import { RequireAuth } from '@/components/auth/RequireAuth'
 import MyInfo from './components/MyInfo'
@@ -40,6 +41,7 @@ function App() {
         <Route element={<RequireAuth />}>
           <Route path="/quiz" element={<QuizPage />} />
           <Route path="/quiz/:deploymentId" element={<QuizPage />} />
+          <Route path="/quiz/result/:submissionId" element={<QuizResultPage />} />
         </Route>
       </Routes>
       <ReactQueryDevtools initialIsOpen={false} />

--- a/src/components/quiz/QuizCard.tsx
+++ b/src/components/quiz/QuizCard.tsx
@@ -23,7 +23,7 @@ export default function QuizCard({ quiz }: QuizCardProps) {
   const handleFallbackImageError = () => setFallbackImageError(true)
   const handleButtonClick = () => {
     if (isDone && quiz.submissionId) {
-      navigate(`/quiz/${quiz.id}/result`)
+      navigate(`/quiz/result/${quiz.submissionId}`)
     } else {
       navigate(`/quiz/${quiz.id}`)
     }

--- a/src/components/quiz/QuizHeader.tsx
+++ b/src/components/quiz/QuizHeader.tsx
@@ -28,7 +28,7 @@ function QuizHeader({
   const maxCheatingCount = 3
 
   return (
-    <header className="border-b border-gray-200 bg-[#FAFAFA] px-6 py-6">
+    <header className="border-b border-gray-200 bg-[#FAFAFA] px-6 py-6 border-b-4 border-[#BDBDBD] shadow-lg">
       <div className="mx-auto flex max-w-[1200px] items-center justify-between">
         {/* 좌측 영역 */}
         <div className="flex flex-col">

--- a/src/components/quiz/QuizResultTop.tsx
+++ b/src/components/quiz/QuizResultTop.tsx
@@ -1,0 +1,20 @@
+// 타이틀과 서브타이틀 내용 정의
+const title = "쪽지시험 응시 결과"
+const subtitle = "고생 많으셨어요😊 틀린 문제는 해설을 보며 꼭 복습해보세요. 앞으로의 성장을 기대하겠습니다!"
+
+// 스타일 정의
+const titleStyle = "text-[32px] font-bold text-[#121212]"
+const subtitleStyle = "text-[16px] font-normal text-[#4D4D4D]"
+
+const QuizResultTop = () => {
+  return (
+    <div className="flex-center bg-[#EFE6FC] w-full h-[118px]">
+        <div className="flex flex-col items-start justify-center gap-2 w-[1180px]">
+            <h1 className={titleStyle}>{title}</h1>
+            <p className={subtitleStyle}>{subtitle}</p>
+        </div>
+    </div>
+  )
+}
+
+export default QuizResultTop

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Button, Loading, Modal, NotFound } from '@/components/common'
-import QuizHeader from '@/components/QuizHeader'
+import QuizHeader from '@/components/quiz/QuizHeader'
 import QuizWarningBox from '@/components/QuizWarningBox'
 import { useExamDeploymentDetailQuery, useExamDeploymentStatusQuery } from '@/hooks/useQuiz'
 import {
@@ -182,7 +182,7 @@ function QuizPage() {
       </main>
 
       <footer>
-        <div className="flex justify-center">
+        <div className="flex justify-center mb-10">
           <Button variant="primary" size="md" rounded="default" onClick={handleSubmit}>
             제출하기
           </Button>

--- a/src/pages/QuizResultPage.tsx
+++ b/src/pages/QuizResultPage.tsx
@@ -1,0 +1,60 @@
+import { useNavigate, useParams } from 'react-router-dom'
+import { Button, Loading } from '@/components/common'
+import QuizHeader from "@/components/quiz/QuizHeader"
+import QuizResultTop from '@/components/quiz/QuizResultTop'
+import { useExamSubmissionResultQuery } from '@/hooks/useQuiz'
+
+function QuizResultPage() {
+  const navigate = useNavigate()
+  const { submissionId } = useParams<{ submissionId: string }>()
+  const submissionIdNumber = submissionId ? Number(submissionId) : 0
+
+  const { data, isLoading } = useExamSubmissionResultQuery(
+    submissionIdNumber,
+    !!submissionId
+  )
+
+  const handleSubmit = () => {
+    navigate('/mypage/quiz')
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen w-full">
+        <Loading />
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <QuizHeader
+        subjectName={data?.exam.title}
+        message="총 문항수: 7ㆍ부정행위: 1회ㆍ응시시간: 30분ㆍ응시 결과 점수: 80점/100점"
+      />
+
+      <main>
+        <QuizResultTop />
+          <div className="w-[1290px] h-[500px]">
+
+          </div>
+      </main>
+
+
+      <footer>
+        <div className="flex justify-center mb-10">
+          <Button 
+            variant="primary" 
+            size="xs" 
+            rounded="default" 
+            onClick={handleSubmit}
+          >
+            완료
+          </Button>
+        </div>
+      </footer>
+    </div>
+  )
+}
+
+export default QuizResultPage


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #90 

## 📑 구현 사항

- 쪽지시험 결과 확인 페이지 UI 생성 (`QuizResultPage`)
- 결과 페이지 상단 타이틀/서브타이틀 컴포넌트 생성 (`QuizResultTop`)
- 마이페이지 쪽지시험 목록에서 상세보기 버튼 클릭 시 결과 페이지로 이동
- 결과 페이지 라우트 설정 (`/quiz/result/:submissionId`)
- 로딩 화면 중앙 정렬 처리

## 🌀 어려웠던 점 / 고민했던 부분

- 결과 페이지용 문제별 컴포넌트는 추후 구현 예정

## 📸 구현 이미지

- <img width="1502" height="710" alt="스크린샷 2026-01-28 오후 1 17 25" src="https://github.com/user-attachments/assets/29087b79-4d2c-4f3c-bbb5-f77ba4a1afbe" />

https://github.com/user-attachments/assets/d7a0944a-deb3-4161-8aef-48b08141a1e2

## ❇️ 코드 설명

-

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.