### PR TITLE
[feat] 응시코드 입력 모달을 통한 응시하기 페이지 연결 (#95)

### DIFF
--- a/src/components/common/Modal/variants/StartQuizModal.tsx
+++ b/src/components/common/Modal/variants/StartQuizModal.tsx
@@ -1,41 +1,41 @@
+import { useState, useEffect } from 'react'
 import { useForm, FormProvider } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useNavigate } from 'react-router'
 import { Modal } from '../Modal'
 import { Button } from '../../Button'
 import { CommonInputField } from '../../CommonInputField'
+import { useCheckExamCodeMutation } from '@/hooks/useQuiz'
 import { startQuizSchema, type StartQuizFormData } from '@/schemas/modalSchemas'
 
-// 시험 시작 모달 props 타입
 interface StartQuizModalProps {
   isOpen: boolean
   onClose: () => void
-  subjectName?: string
-  questionCount?: number
-  timeLimit?: number // 분 단위
+  deploymentId: number
+  imageUrl: string
+  subjectName: string
+  quizName: string
+  questionCount: number
+  timeLimit: number
   onSuccess?: (data: StartQuizFormData) => void
 }
 
-// 목업 데이터 - 나중에 API로 받을 데이터 구조
-// 참가 코드는 과목별로 Base62 인코딩된 값으로 받아올 예정
-const mockQuizData = {
-  subjectName: 'React',              // 과목명
-  quizName: 'React 심화',            // 쪽지시험 이름
-  questionCount: 20,                 // 문항수
-  timeLimit: 30,                     // 제한시간 (분)
-  verificationCode: 'Base62',        // 참가 코드 (Base62 인코딩된 값, 나중에 API로 받아올 예정)
-}
-
-// 시험 시작 모달 컴포넌트
 export function StartQuizModal({
   isOpen,
   onClose,
-  subjectName = mockQuizData.subjectName,
-  questionCount = mockQuizData.questionCount,
-  timeLimit = mockQuizData.timeLimit,
+  deploymentId,
+  imageUrl,
+  subjectName,
+  quizName,
+  questionCount,
+  timeLimit,
   onSuccess,
 }: StartQuizModalProps) {
   const navigate = useNavigate()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [imageError, setImageError] = useState(false)
+  const checkCodeMutation = useCheckExamCodeMutation()
+
   const methods = useForm<StartQuizFormData>({
     resolver: zodResolver(startQuizSchema),
     defaultValues: {
@@ -43,110 +43,58 @@ export function StartQuizModal({
     },
   })
 
-  // 목업: 쪽지시험 이름 생성 (과목명 + 기초/심화/응용)
-  // subjectName에 이미 레벨이 포함되어 있는지 확인
-  const quizLevels = ['기초', '심화', '응용']
-  const hasLevel = quizLevels.some((level) => subjectName.includes(level))
-  
-  // 레벨이 이미 포함되어 있으면 그대로 사용, 없으면 목업 데이터 사용
-  const displayQuizName = hasLevel
-    ? subjectName
-    : mockQuizData.quizName
-
-  // 과목명을 기반으로 이미지 경로 생성 (대소문자 구분 없이)
-  // 실제 파일명 목록 (대소문자 포함)
-  const courseImageFiles = [
-    'check.svg',
-    'css.svg',
-    'DB.svg',
-    'django.svg',
-    'fastapi.svg',
-    'flask.svg',
-    'github.svg',
-    'html.svg',
-    'JavaScript.svg',
-    'nodejs.svg',
-    'python.svg',
-    'React.svg',
-    'ReactNative.svg',
-    'typescript.svg',
-  ]
-
-  // 과목명과 대소문자 구분 없이 매칭되는 파일 찾기
-  const findCourseImage = (subjectName: string): string => {
-    const normalizedSubject = subjectName.toLowerCase().replace(/\s+/g, '')
-    const matchedFile = courseImageFiles.find((file) => {
-      const fileName = file.replace('.svg', '').toLowerCase()
-      return fileName === normalizedSubject || 
-             fileName.includes(normalizedSubject) || 
-             normalizedSubject.includes(fileName)
-    })
-    
-    if (matchedFile) {
-      return `/icons/Course/${matchedFile}`
+  useEffect(() => {
+    if (!isOpen) {
+      methods.reset()
+      setIsSubmitting(false)
+      setImageError(false)
     }
-    
-    // 매칭되지 않으면 과목명 그대로 시도
-    return `/icons/Course/${subjectName}.svg`
-  }
+  }, [isOpen, methods])
 
-  const courseImagePath = findCourseImage(subjectName)
+  const onSubmit = async (data: StartQuizFormData) => {
+    setIsSubmitting(true)
 
-  // 참가 코드 검증 함수
-  const validateVerificationCode = (code: string): boolean => {
-    // 목업: Base62 참가 코드와 비교
-    // 나중에 API로 받아올 때는 과목별로 다른 Base62 값을 받아올 예정
-    return code === mockQuizData.verificationCode
-  }
+    try {
+      await checkCodeMutation.mutateAsync({
+        deploymentId,
+        code: data.code,
+      })
 
-  const onSubmit = (data: StartQuizFormData) => {
-    // 참가 코드 검증
-    if (!validateVerificationCode(data.code)) {
-      // 에러 메시지 설정
+      onSuccess?.(data)
+      onClose()
+      navigate(`/quiz/${deploymentId}`)
+    } catch (error) {
       methods.setError('code', {
         type: 'manual',
         message: '*코드번호가 일치하지 않습니다.',
       })
-      return
+    } finally {
+      setIsSubmitting(false)
     }
-
-    // 참가 코드가 유효한 경우
-    onSuccess?.(data)
-    onClose()
-    // 쪽지시험 페이지로 이동
-    navigate('/quiz')
   }
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <Modal.Header>
         <div className="flex flex-col items-center gap-4">
-          <img 
-            src={courseImagePath} 
-            alt={subjectName}
-            className="w-16 h-16"
-            onError={(e) => {
-              // 이미지가 없을 경우 기본 이미지 또는 숨김 처리
-              e.currentTarget.style.display = 'none'
-            }}
-          />
+          {!imageError && (
+            <img
+              src={imageUrl}
+              alt={subjectName}
+              className="w-16 h-16"
+              onError={() => setImageError(true)}
+            />
+          )}
           <div className="flex flex-col items-center gap-2">
-            <h2 
-              className="text-center"
-              style={{
-                fontSize: '18px',
-                fontWeight: '600', // SemiBold
-                color: '#121212',
-              }}
-            >
-              {displayQuizName}
+            <h2 className="text-center text-[18px] font-semibold text-[#121212]">
+              {quizName}
             </h2>
             <p className="text-center">
-              <span style={{ fontSize: '14px', fontWeight: 'normal', color: '#303030' }}>
+              <span className="text-[14px] font-normal text-[#303030]">
                 총 {questionCount}문항
               </span>
               {' '}ㆍ{' '}
-              <span style={{ fontSize: '14px', fontWeight: 'normal', color: '#6201E0' }}>
+              <span className="text-[14px] font-normal text-[#6201E0]">
                 제한시간 {timeLimit}분
               </span>
             </p>
@@ -158,7 +106,7 @@ export function StartQuizModal({
         <FormProvider {...methods}>
           <form onSubmit={methods.handleSubmit(onSubmit)} className="space-y-4">
             <Modal.InputRow label="참가 코드입력">
-              <div style={{ minWidth: '348px' }}>
+              <div className="min-w-[348px]">
                 <CommonInputField<StartQuizFormData>
                   name="code"
                   placeholder="참가 코드를 입력해주세요"
@@ -166,7 +114,7 @@ export function StartQuizModal({
                   state={methods.formState.errors.code ? "error" : "default"}
                   helperTextByState={{
                     error: (
-                      <span style={{ color: '#EC0037', fontSize: '12px', fontWeight: 'normal' }}>
+                      <span className="text-[12px] font-normal text-[#EC0037]">
                         {methods.formState.errors.code?.message}
                       </span>
                     ),
@@ -182,8 +130,9 @@ export function StartQuizModal({
                 size="xl" 
                 className="w-full"
                 style={{ minWidth: '348px' }}
+                disabled={isSubmitting}
               >
-                시험시작
+                {isSubmitting ? '검증 중...' : '시험시작'}
               </Button>
             </div>
           </form>

--- a/src/components/quiz/QuizCard.tsx
+++ b/src/components/quiz/QuizCard.tsx
@@ -24,6 +24,7 @@ export default function QuizCard({ quiz }: QuizCardProps) {
 
   const handleImageError = () => setImageError(true)
   const handleFallbackImageError = () => setFallbackImageError(true)
+
   const requestFullscreen = async () => {
     if (document.fullscreenElement) return
     const element = document.documentElement
@@ -35,10 +36,10 @@ export default function QuizCard({ quiz }: QuizCardProps) {
       }
     }
   }
+
   const handleButtonClick = async () => {
     await requestFullscreen()
-  
-  const handleButtonClick = () => {
+
     if (isDone && quiz.submissionId) {
       navigate(`/quiz/result/${quiz.submissionId}`)
     } else {

--- a/src/components/quiz/QuizCard.tsx
+++ b/src/components/quiz/QuizCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/common/Button'
+import { StartQuizModal } from '@/components/common/Modal'
 import type { ExamDeploymentsResult } from '@/mappers/examDeployments'
 
 interface QuizCardProps {
@@ -11,6 +12,7 @@ export default function QuizCard({ quiz }: QuizCardProps) {
   const navigate = useNavigate()
   const [imageError, setImageError] = useState(false)
   const [fallbackImageError, setFallbackImageError] = useState(false)
+  const [isModalOpen, setIsModalOpen] = useState(false)
   const isDone = quiz.isDone
   const imageUrl = quiz.exam.subject.thumbnailImgUrl || quiz.exam.thumbnailImgUrl
   const subjectName = quiz.exam.subject.title
@@ -19,6 +21,7 @@ export default function QuizCard({ quiz }: QuizCardProps) {
     ? `${quiz.examInfo.score}점/${quiz.totalScore}점 ㆍ ${quiz.examInfo.correctAnswerCount}/${quiz.questionCount}개 정답`
     : '응시하고 점수를 확인해보세요!'
   const buttonText = isDone ? '상세보기' : '응시하기'
+
   const handleImageError = () => setImageError(true)
   const handleFallbackImageError = () => setFallbackImageError(true)
   const requestFullscreen = async () => {
@@ -34,11 +37,21 @@ export default function QuizCard({ quiz }: QuizCardProps) {
   }
   const handleButtonClick = async () => {
     await requestFullscreen()
+  
+  const handleButtonClick = () => {
     if (isDone && quiz.submissionId) {
       navigate(`/quiz/result/${quiz.submissionId}`)
     } else {
-      navigate(`/quiz/${quiz.id}`)
+      setIsModalOpen(true)
     }
+  }
+
+  const handleModalClose = () => {
+    setIsModalOpen(false)
+  }
+
+  const handleModalSuccess = () => {
+    navigate(`/quiz/${quiz.id}`)
   }
 
   // 스타일 클래스
@@ -92,6 +105,21 @@ export default function QuizCard({ quiz }: QuizCardProps) {
           {buttonText}
         </Button>
       </div>
+
+      {/* 응시코드 입력 모달 */}
+      {!isDone && (
+        <StartQuizModal
+          isOpen={isModalOpen}
+          onClose={handleModalClose}
+          onSuccess={handleModalSuccess}
+          deploymentId={quiz.id}
+          imageUrl={imageUrl || fallbackImageUrl}
+          subjectName={quiz.exam.subject.title}
+          quizName={quiz.exam.title}
+          questionCount={quiz.questionCount}
+          timeLimit={quiz.durationTime}
+        />
+      )}
     </div>
   )
 }

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -224,6 +224,13 @@ function TestPage() {
           console.log('쪽지시험 시작:', data)
           setStartQuizOpen(false)
         }}
+        // 테스트 페이지용 더미 데이터 (실제 화면에서는 QuizCard에서 전달)
+        deploymentId={101}
+        imageUrl="/icons/Course/React.svg"
+        subjectName="React"
+        quizName="React 기초 쪽지시험"
+        questionCount={10}
+        timeLimit={30}
       />
 
       <CheatingWarningModal


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #95 

## 📑 구현 사항

- 마이페이지 쪽지시험 카드의 응시하기 버튼 → `StartQuizModal`(응시코드 입력 모달) 오픈으로 변경
- `QuizCard`에서 이미지/과목명/쪽지시험명/총 문항 수/제한시간/deploymentId 를 `StartQuizModal`에 props로 전달하도록 연동
- `StartQuizModal`을 실제 사용 시나리오에 맞게 리팩터링
- `startQuizSchema` + `useCheckExamCodeMutation`를 이용한 응시 코드 검증 로직 구현
- 검증 성공 시 해당 쪽지시험 페이지(`/quiz/:deploymentId`)로 이동
- 기존 `TestPage`의 `StartQuizModal` 사용부를 새로운 props 형태에 맞게 수정 (더미 데이터 전달)

## 🌀 어려웠던 점 / 고민했던 부분

- `StartQuizModal`이 기존에는 독립적인 테스트용 모달이었기 때문에, 실제 응시 플로우(카드 → 모달 → 시험 페이지) 에 어떻게 자연스럽게 녹일지 구조를 고민했습니다.
- 응시 코드 검증 API와 연동을 고려하면서, Mock 환경(고정 코드 `123456`)과 실제 API 연동 시나리오를 동시에 만족하도록 타입/에러 처리 구조를 설계하는 부분을 신경 썼습니다.

## 📸 구현 이미지

-

https://github.com/user-attachments/assets/b300f028-563e-4599-8a37-04728078460e



## ❇️ 코드 설명

**- `QuizCard.tsx`**
 - `StartQuizModal` 연동: 응시하기 버튼 클릭 시 모달 오픈, 응시 완료된 경우에는 기존처럼 결과 페이지로 이동
 - 카드 정보(이미지, 과목명, 시험명, 문항 수, 제한시간, deploymentId)를 모달로 전달
 - 
**- `StartQuizModal.tsx`**
 - `deploymentId`, `imageUrl`, `subjectName`, `quizName`, `questionCount`, `timeLimit` 등 실제 쪽지시험 정보를 받도록 인터페이스 정리
 - `react-hook-form` + `zod` 기반으로 참가 코드 유효성 검사 및 에러 메시지 표시
 - `useCheckExamCodeMutation`으로 응시 코드 검증 후 성공 시 시험 페이지로 라우팅
 - 
**- `TestPage.tsx`**
 - 데모용 `StartQuizModal` 호출부를 새로운 props 구조에 맞게 수정하여 빌드 에러 제거.

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.