### PR TITLE
feat: 이메일 회원가입 구현 (#84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # Externship Project Template
+
+## 로그인 / 회원가입 구현 요약 (담당자: 최진명)
+
+### 로그인 (Login)
+
+- `schemas/auth.ts`의 `loginSchema`(Zod) + `react-hook-form`을 사용해 입력값(이메일/비밀번호)을 즉시 검증합니다.
+- 로그인 제출 시 `authApi.login({ email, password })` 호출 → 성공하면 `access_token`을 저장합니다.
+- 이후 `authApi.me()`로 내 정보를 조회해 `user` 상태를 채우고, `isAuthenticated=true`로 로그인 상태를 확정합니다.
+- 전역 인증 상태는 `useAuthStore`(Zustand persist)에 저장되어 새로고침 후에도 유지됩니다.
+
+### 회원가입 (Signup)
+
+- `schemas/auth.ts`의 `signupSchema`(Zod)로 이름/닉네임/생년월일/성별/이메일/휴대폰/비밀번호 유효성을 검증합니다.
+- 페이지 로직은 `useSignupEmailForm` 훅에서 관리하며 `values / ui / messages / actions`로 화면에 필요한 값만 내려줍니다.
+- 가입 전 필수 단계:
+  1. 닉네임 중복 확인: `authApi.checkNickname`
+  2. 이메일 인증: `useVerificationFlow`로 코드 전송(`sendEmailVerification`) → 코드 확인(`verifyEmail`) → `email_token` 저장
+  3. 휴대폰 인증: `useVerificationFlow`로 코드 전송(`sendSmsVerification`) → 코드 확인(`verifySms`) → `sms_token` 저장
+- 최종 가입 시 `authApi.signup` 호출(payload에 `email_token`, `sms_token` 포함).
+- 가입 성공 후 `useAuthStore().login`을 호출해 자동 로그인 처리 후 메인 페이지로 이동합니다.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import LandingPage from '@/pages/LandingPage'
 import TestPage from '@/pages/TestPage'
 import LoginPage from '@/pages/LoginPage'
 import SignupPage from '@/pages/SignupPage'
+import SignupEmailPage from '@/pages/SignupEmailPage'
 import MyPage from '@/pages/MyPage'
 import MyPageQuiz from '@/components/MyPageQuiz'
 import QuizPage from '@/pages/QuizPage'
@@ -26,6 +27,7 @@ function App() {
           <Route path="/test" element={<TestPage />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignupPage />} />
+          <Route path="/signup/email" element={<SignupEmailPage />} />
 
           {/* 로그인이 필요한 페이지 */}
           <Route element={<RequireAuth />}>

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,7 +1,0 @@
-import axios from 'axios'
-
-const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL ?? '',
-})
-
-export default api

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,5 +1,9 @@
-import type { LoginPayload, LoginResult } from '@/types/auth'
 import { apiClient } from '@/api/client'
+import type { LoginPayload, User } from '@/types/auth'
+
+export type LoginResult = { access_token: string }
+export type VerifyEmailResult = { detail?: string; email_token: string }
+export type VerifySmsResult = { detail?: string; sms_token: string }
 
 export async function login(payload: LoginPayload): Promise<LoginResult> {
   const { data } = await apiClient.post<LoginResult>(
@@ -10,9 +14,63 @@ export async function login(payload: LoginPayload): Promise<LoginResult> {
 }
 
 export async function logout(): Promise<void> {
-  return
+  await apiClient.post('/api/v1/accounts/logout/')
 }
 
-export async function restoreSession(): Promise<LoginResult | null> {
-  return null
+export async function me(): Promise<User> {
+  const { data } = await apiClient.get<User>('/api/v1/accounts/me/')
+  return data
+}
+
+export async function checkNickname(payload: {
+  nickname: string
+}): Promise<void> {
+  await apiClient.post('/api/v1/accounts/check-nickname/', payload)
+}
+
+export async function sendEmailVerification(payload: {
+  email: string
+}): Promise<void> {
+  await apiClient.post('/api/v1/accounts/verification/send-email/', payload)
+}
+
+export async function verifyEmail(payload: {
+  email: string
+  code: string
+}): Promise<VerifyEmailResult> {
+  const { data } = await apiClient.post<VerifyEmailResult>(
+    '/api/v1/accounts/verification/verify-email/',
+    payload
+  )
+  return data
+}
+
+export async function sendSmsVerification(payload: {
+  phone_number: string
+}): Promise<void> {
+  await apiClient.post('/api/v1/accounts/verification/send-sms/', payload)
+}
+
+export async function verifySms(payload: {
+  phone_number: string
+  code: string
+}): Promise<VerifySmsResult> {
+  const { data } = await apiClient.post<VerifySmsResult>(
+    '/api/v1/accounts/verification/verify-sms/',
+    payload
+  )
+  return data
+}
+
+export async function signup(payload: {
+  password: string
+  password_confirm?: string
+  nickname: string
+  name: string
+  birthday: string
+  gender: 'M' | 'F'
+  email_token: string
+  sms_token: string
+}): Promise<void> {
+  await apiClient.post('/api/v1/accounts/signup/', payload)
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,16 +1,6 @@
 import axios from 'axios'
-import { useAuthStore } from '@/store/authStore'
 
 export const apiClient = axios.create({
-  baseURL: '',
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? '',
   withCredentials: true,
-})
-
-apiClient.interceptors.request.use((config) => {
-  const token = useAuthStore.getState().accessToken
-  if (token) {
-    config.headers = config.headers ?? {}
-    config.headers.Authorization = `Bearer ${token}`
-  }
-  return config
 })

--- a/src/api/quiz.ts
+++ b/src/api/quiz.ts
@@ -1,4 +1,4 @@
-import api from '@/api/api'
+import { apiClient } from '@/api/client'
 import {
   mapExamDeploymentsResult,
   type ExamDeploymentsResponse,
@@ -32,7 +32,7 @@ export interface FetchExamDeploymentsParams {
  * const data = await fetchExamDeployments({ page: 1, status: 'all' })
  */
 export const fetchExamDeployments = async (params: FetchExamDeploymentsParams = {}) => {
-  const response = await api.get<ExamDeploymentsResponse>('/api/v1/exams/deployments', {
+  const response = await apiClient.get<ExamDeploymentsResponse>('/api/v1/exams/deployments', {
     params: {
       page: params.page ?? 1,
       status: params.status ?? 'all',
@@ -47,7 +47,7 @@ export const fetchExamDeployments = async (params: FetchExamDeploymentsParams = 
  * const data = await fetchExamDeploymentDetail(101)
  */
 export const fetchExamDeploymentDetail = async (deploymentId: number) => {
-  const response = await api.get<ExamDeploymentDetailResponse>(
+  const response = await apiClient.get<ExamDeploymentDetailResponse>(
     `/api/v1/exams/deplayments/${deploymentId}`
   )
   return mapExamDeploymentDetail(response.data)
@@ -59,7 +59,7 @@ export const fetchExamDeploymentDetail = async (deploymentId: number) => {
  * const data = await fetchExamDeploymentStatus(101)
  */
 export const fetchExamDeploymentStatus = async (deploymentId: number) => {
-  const response = await api.get<ExamDeploymentStatusResponse>(
+  const response = await apiClient.get<ExamDeploymentStatusResponse>(
     `/api/v1/exams/deplayments/${deploymentId}/status`
   )
   return mapExamDeploymentStatus(response.data)
@@ -71,9 +71,12 @@ export const fetchExamDeploymentStatus = async (deploymentId: number) => {
  * const data = await checkExamCode(101, '123456')
  */
 export const checkExamCode = async (deploymentId: number, code: string) => {
-  const response = await api.post(`/api/v1/exams/deployments/${deploymentId}/check-code`, {
-    code,
-  })
+  const response = await apiClient.post(
+    `/api/v1/exams/deployments/${deploymentId}/check-code`,
+    {
+      code,
+    }
+  )
   return mapCheckCodeResult(response.data)
 }
 
@@ -96,7 +99,10 @@ export interface ExamSubmissionPayload {
  * const data = await submitExam(payload)
  */
 export const submitExam = async (payload: ExamSubmissionPayload) => {
-  const response = await api.post<ExamSubmissionResponse>('/api/v1/exams/submissions', payload)
+  const response = await apiClient.post<ExamSubmissionResponse>(
+    '/api/v1/exams/submissions',
+    payload
+  )
   return mapExamSubmissionResult(response.data)
 }
 
@@ -106,7 +112,7 @@ export const submitExam = async (payload: ExamSubmissionPayload) => {
  * const data = await fetchExamSubmissionResult(350)
  */
 export const fetchExamSubmissionResult = async (submissionId: number) => {
-  const response = await api.get<ExamSubmissionResultResponse>(
+  const response = await apiClient.get<ExamSubmissionResultResponse>(
     `/api/v1/exams/submissions/${submissionId}`
   )
   return mapExamSubmissionResultDetail(response.data)

--- a/src/api/setupInterceptors.ts
+++ b/src/api/setupInterceptors.ts
@@ -1,0 +1,19 @@
+import type { AxiosInstance, InternalAxiosRequestConfig } from 'axios'
+
+export function setupAuthInterceptor(
+  client: AxiosInstance,
+  getAccessToken: () => string | null
+) {
+  const id = client.interceptors.request.use(
+    (config: InternalAxiosRequestConfig) => {
+      const token = getAccessToken()
+      if (token) {
+        config.headers = config.headers ?? {}
+        config.headers.Authorization = `Bearer ${token}`
+      }
+      return config
+    }
+  )
+
+  return () => client.interceptors.request.eject(id)
+}

--- a/src/components/TestPageApiPanel.tsx
+++ b/src/components/TestPageApiPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useMutation, useQuery } from '@tanstack/react-query'
-import api from '@/api/api'
+import { apiClient } from '@/api/client'
 import { Button, CommonInput, Dropdown } from '@/components/common'
 
 const getErrorPayload = (error: unknown) => {
@@ -32,7 +32,7 @@ const TestPageApiPanel = () => {
   const deploymentsQuery = useQuery({
     queryKey: ['examDeployments', page, status],
     queryFn: async () => {
-      const response = await api.get('/api/v1/exams/deployments', {
+      const response = await apiClient.get('/api/v1/exams/deployments', {
         params: { page: Number(page) || 1, status },
       })
       return response.data
@@ -44,7 +44,7 @@ const TestPageApiPanel = () => {
   const detailQuery = useQuery({
     queryKey: ['examDeploymentDetail', deploymentId],
     queryFn: async () => {
-      const response = await api.get(`/api/v1/exams/deplayments/${deploymentId}`)
+      const response = await apiClient.get(`/api/v1/exams/deplayments/${deploymentId}`)
       return response.data
     },
     enabled: false,
@@ -53,7 +53,7 @@ const TestPageApiPanel = () => {
 
   const checkCodeMutation = useMutation({
     mutationFn: async () => {
-      const response = await api.post(
+      const response = await apiClient.post(
         `/api/v1/exams/deployments/${deploymentId}/check-code`,
         code ? { code } : {}
       )
@@ -77,7 +77,7 @@ const TestPageApiPanel = () => {
           { question_id: 5006, type: 'fill_blank', submitted_answer: ['A', 'B'] },
         ],
       }
-      const response = await api.post('/api/v1/exams/submissions', payload)
+      const response = await apiClient.post('/api/v1/exams/submissions', payload)
       return response.data
     },
     retry: false,
@@ -86,7 +86,7 @@ const TestPageApiPanel = () => {
   const submissionResultQuery = useQuery({
     queryKey: ['examSubmissionResult', submissionId],
     queryFn: async () => {
-      const response = await api.get(`/api/v1/exams/submissions/${submissionId}`)
+      const response = await apiClient.get(`/api/v1/exams/submissions/${submissionId}`)
       return response.data
     },
     enabled: false,

--- a/src/components/common/CommonInput.tsx
+++ b/src/components/common/CommonInput.tsx
@@ -89,15 +89,25 @@ export const CommonInput = forwardRef<HTMLInputElement, CommonInputProps>(
       hasValue,
     ])
 
+    const widthStyle =
+      typeof width === 'number'
+        ? `${width}px`
+        : typeof width === 'string'
+          ? width
+          : undefined
+
     return (
       <div
-        className="flex flex-col gap-1.5"
-        style={{ width: typeof width === 'number' ? `${width}px` : width }}
+        className="flex w-full min-w-0 flex-col gap-1.5"
+        style={{
+          width: widthStyle,
+          minWidth: 0,
+        }}
       >
         <div
           className={clsx(
-            'flex h-12 items-center gap-2.5 rounded-lg border px-4 transition-colors duration-200',
-            'focus-within:ring-1',
+            'flex h-12 min-w-0 items-center gap-2.5 rounded-lg border px-4 transition-colors duration-200',
+            'focus-within:ring-1 focus-within:ring-inset',
             state === 'default' &&
               'border-gray-300 bg-white focus-within:border-violet-600 focus-within:ring-violet-600',
             state === 'error' &&
@@ -130,7 +140,8 @@ export const CommonInput = forwardRef<HTMLInputElement, CommonInputProps>(
             aria-invalid={state === 'error' ? true : undefined}
             aria-describedby={shouldShowHelper ? helperId : undefined}
             className={clsx(
-              'flex-1 bg-transparent text-sm outline-none sm:text-base',
+              'w-full min-w-0 flex-1 bg-transparent text-sm outline-none sm:text-base',
+              'overflow-hidden text-ellipsis whitespace-nowrap',
               locked ? 'text-gray-400' : 'text-black',
               placeholderVariant === 'a' ? 'placeholder-a' : 'placeholder-b'
             )}

--- a/src/components/common/CommonInputField.tsx
+++ b/src/components/common/CommonInputField.tsx
@@ -4,35 +4,44 @@ import {
   type FieldValues,
   type Path,
   type RegisterOptions,
-} from "react-hook-form";
-import { CommonInput, type CommonInputProps, type FieldState } from "./CommonInput";
+} from 'react-hook-form'
+import {
+  CommonInput,
+  type CommonInputProps,
+  type FieldState,
+} from './CommonInput'
 
 type CommonInputFieldProps<T extends FieldValues> = Omit<
   CommonInputProps,
-  "value" | "onChange" | "name"
+  'value' | 'onChange' | 'name'
 > & {
-  name: Path<T>;
-  rules?: RegisterOptions<T>;
-  state?: FieldState;
-};
+  name: Path<T>
+  rules?: RegisterOptions<T>
+  state?: FieldState
+}
 
 export function CommonInputField<T extends FieldValues>({
   name,
   rules,
-  state = "default",
+  state = 'default',
   helperTextByState,
   ...props
 }: CommonInputFieldProps<T>) {
-  const { control } = useFormContext<T>();
+  const { control } = useFormContext<T>()
 
   const {
     field,
     fieldState: { error },
-  } = useController<T>({ name, control, rules });
+  } = useController<T>({ name, control, rules })
 
-  const fieldValue = String(field.value ?? "");
-  const isEmpty = fieldValue.trim().length === 0;
-  const resolvedState: FieldState = isEmpty ? "default" : state;
+  const fieldValue = String(field.value ?? '')
+  const isEmpty = fieldValue.trim().length === 0
+
+  const resolvedState: FieldState = error
+    ? 'error'
+    : isEmpty
+      ? 'default'
+      : state
 
   return (
     <CommonInput
@@ -48,5 +57,5 @@ export function CommonInputField<T extends FieldValues>({
         error: error?.message || helperTextByState?.error,
       }}
     />
-  );
+  )
 }

--- a/src/components/common/PasswordField.tsx
+++ b/src/components/common/PasswordField.tsx
@@ -4,36 +4,45 @@ import {
   type FieldValues,
   type Path,
   type RegisterOptions,
-} from "react-hook-form";
-import { PasswordInput } from "./PasswordInput";
-import type { FieldState } from "./CommonInput";
+} from 'react-hook-form'
+import { PasswordInput } from './PasswordInput'
+import type { FieldState } from './CommonInput'
 
 type PasswordFieldProps<T extends FieldValues> = Omit<
   React.ComponentProps<typeof PasswordInput>,
-  "value" | "onChange" | "name"
+  'value' | 'onChange' | 'name'
 > & {
-  name: Path<T>;
-  rules?: RegisterOptions<T>;
-  state?: FieldState;
-};
+  name: Path<T>
+  rules?: RegisterOptions<T>
+  state?: FieldState
+  autoState?: boolean
+}
 
 export function PasswordField<T extends FieldValues>({
   name,
   rules,
-  state = "default",
+  state = 'default',
+  autoState = false,
   helperTextByState,
   ...props
 }: PasswordFieldProps<T>) {
-  const { control } = useFormContext<T>();
+  const { control } = useFormContext<T>()
 
   const {
     field,
     fieldState: { error },
-  } = useController<T>({ name, control, rules });
+  } = useController<T>({ name, control, rules })
 
-  const fieldValue = String(field.value ?? "");
-  const isEmpty = fieldValue.trim().length === 0;
-  const resolvedState: FieldState = isEmpty ? "default" : state;
+  const fieldValue = String(field.value ?? '')
+  const isEmpty = fieldValue.trim().length === 0
+
+  const resolvedState: FieldState = error
+    ? 'error'
+    : isEmpty
+      ? 'default'
+      : autoState
+        ? 'success'
+        : state
 
   return (
     <PasswordInput
@@ -49,5 +58,5 @@ export function PasswordField<T extends FieldValues>({
         error: error?.message || helperTextByState?.error,
       }}
     />
-  );
+  )
 }

--- a/src/components/common/PasswordInput.tsx
+++ b/src/components/common/PasswordInput.tsx
@@ -1,39 +1,45 @@
-import { forwardRef, useMemo, useState } from "react";
+import { forwardRef, useMemo, useState } from 'react'
 import {
   CommonInput,
   type CommonInputProps,
   type FieldState,
   type HelperVisibility,
-} from "./CommonInput";
+} from './CommonInput'
 
-const DEFAULT_HELPER = "* 6~15자의 영문 대/소문자, 숫자 및 특수문자 조합";
-const ERROR_HELPER = "* 비밀번호가 올바르지 않습니다.";
-const SUCCESS_HELPER = "* 비밀번호가 확인되었습니다.";
+const DEFAULT_HELPER = '* 6~15자의 영문 대/소문자, 숫자 및 특수문자 조합'
+const ERROR_HELPER = '* 비밀번호가 올바르지 않습니다.'
+const SUCCESS_HELPER = '* 비밀번호가 확인되었습니다.'
 
 type PasswordInputProps = Omit<
   CommonInputProps,
-  "type" | "rightSlot" | "helperText" | "helperTextByState" | "helperVisibility"
+  'type' | 'rightSlot' | 'helperText' | 'helperTextByState' | 'helperVisibility'
 > & {
-  state?: FieldState;
-  showDefaultHelper?: boolean;
-  helperTextByState?: Partial<Record<FieldState, React.ReactNode>>;
-  helperVisibility?: HelperVisibility;
-};
+  state?: FieldState
+  showDefaultHelper?: boolean
+  helperTextByState?: Partial<Record<FieldState, React.ReactNode>>
+  helperVisibility?: HelperVisibility
+
+  showVisibilityToggle?: boolean
+  showStatusIcon?: boolean
+}
 
 export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
   (
     {
-      state = "default",
+      state = 'default',
       locked = false,
       disabled,
       showDefaultHelper = false,
       helperTextByState,
       helperVisibility,
+      showVisibilityToggle = true,
+      showStatusIcon = false,
+      autoComplete,
       ...props
     },
     ref
   ) => {
-    const [show, setShow] = useState(false);
+    const [show, setShow] = useState(false)
 
     const mergedHelpers = useMemo(() => {
       return {
@@ -41,18 +47,20 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
         error: ERROR_HELPER,
         success: SUCCESS_HELPER,
         ...helperTextByState,
-      };
-    }, [helperTextByState, showDefaultHelper]);
+      }
+    }, [helperTextByState, showDefaultHelper])
 
     const resolvedVisibility: HelperVisibility =
-      helperVisibility ?? (showDefaultHelper ? "focus" : "never");
+      helperVisibility ?? (showDefaultHelper ? 'focus' : 'never')
+
+    const canToggle = !disabled && !locked
 
     return (
       <CommonInput
         {...props}
         ref={ref}
-        type={show ? "text" : "password"}
-        autoComplete="current-password"
+        type={show ? 'text' : 'password'}
+        autoComplete={autoComplete ?? 'current-password'}
         state={state}
         locked={locked}
         disabled={disabled}
@@ -60,24 +68,35 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
         helperVisibility={resolvedVisibility}
         rightSlot={
           <div className="flex items-center gap-2">
-            {state === "success" && (
-              <img src="/icons/correct.svg" alt="검증 완료" className="w-4 h-4" />
+            {showStatusIcon && state === 'success' && (
+              <img
+                src="/icons/correct.svg"
+                alt="검증 완료"
+                className="h-4 w-4"
+              />
             )}
-            <button
-              type="button"
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={() => setShow((p) => !p)}
-              disabled={!!disabled || locked}
-              aria-label={show ? "비밀번호 숨기기" : "비밀번호 보기"}
-              className="p-1 -mr-1 text-gray-400 hover:text-gray-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus:outline-none focus:text-violet-600"
-            >
-              <img src={show ? "/icons/eyeOpen.svg" : "/icons/eyeClose.svg"} alt="" className="w-5 h-5" />
-            </button>
+
+            {showVisibilityToggle && (
+              <button
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => setShow((p) => !p)}
+                disabled={!canToggle}
+                aria-label={show ? '비밀번호 숨기기' : '비밀번호 보기'}
+                className="-mr-1 p-1 text-gray-400 transition-colors hover:text-gray-600 focus:text-violet-600 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <img
+                  src={show ? '/icons/eyeOpen.svg' : '/icons/eyeClose.svg'}
+                  alt=""
+                  className="h-5 w-5"
+                />
+              </button>
+            )}
           </div>
         }
       />
-    );
+    )
   }
-);
+)
 
-PasswordInput.displayName = "PasswordInput";
+PasswordInput.displayName = 'PasswordInput'

--- a/src/components/signup/EmailSection.tsx
+++ b/src/components/signup/EmailSection.tsx
@@ -1,0 +1,128 @@
+import { Check } from 'lucide-react'
+
+import { Button } from '@/components/common/Button'
+import { CommonInputField } from '@/components/common/CommonInputField'
+import type { FieldState } from '@/components/common/CommonInput'
+import type { SignupFormData } from '@/schemas/auth'
+
+type EmailSectionProps = {
+  emailFieldState: FieldState
+  emailCodeFieldState: FieldState
+  emailSendMsg: string | null
+  emailVerifyMsg: string | null
+  emailVerified: boolean
+  emailCodeSent: boolean
+  emailTimer: {
+    mmss: string
+    isRunning: boolean
+  }
+  emailSendLabel: string
+  canSendEmail: boolean
+  canVerifyEmail: boolean
+  onSendEmailCode: () => void
+  onVerifyEmailCode: () => void
+}
+
+export function EmailSection({
+  emailFieldState,
+  emailCodeFieldState,
+  emailSendMsg,
+  emailVerifyMsg,
+  emailVerified,
+  emailCodeSent,
+  emailTimer,
+  emailSendLabel,
+  canSendEmail,
+  canVerifyEmail,
+  onSendEmailCode,
+  onVerifyEmailCode,
+}: EmailSectionProps) {
+  const EmailCodeRightSlot = (
+    <div className="flex items-center gap-2">
+      {emailVerified ? (
+        <Check className="h-5 w-5 text-green-600" />
+      ) : emailCodeSent && emailTimer.isRunning ? (
+        <span className="text-sm font-semibold text-red-500">
+          {emailTimer.mmss}
+        </span>
+      ) : null}
+    </div>
+  )
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="inline-flex items-center gap-4">
+        <label className="inline-flex items-start text-left text-[16px] leading-[22.24px] font-normal tracking-[-0.48px] text-[#121212]">
+          이메일
+          <span className="ml-0 text-[16px] leading-normal font-normal tracking-[-0.32px] text-[#EC0037]">
+            *
+          </span>
+        </label>
+        <p className="text-primary text-left text-[14px] leading-[19.6px] font-semibold tracking-[-0.42px]">
+          로그인 시 아이디로 사용합니다.
+        </p>
+      </div>
+
+      {/* 이메일 입력, 전송 버튼 */}
+      <div className="flex min-w-0 gap-3 overflow-hidden">
+        <div className="min-w-0 flex-1 overflow-hidden">
+          <CommonInputField<SignupFormData>
+            name="email"
+            type="email"
+            placeholder="example@gmail.com"
+            width="100%"
+            placeholderVariant="a"
+            state={emailFieldState}
+            helperVisibility="always"
+            helperTextByState={{
+              success: emailSendMsg,
+              error: emailSendMsg,
+            }}
+            locked={emailVerified}
+          />
+        </div>
+
+        <Button
+          type="button"
+          size="sm"
+          variant={!canSendEmail ? 'disabled' : 'secondary'}
+          className="whitespace-nowrap"
+          onClick={onSendEmailCode}
+        >
+          {emailSendLabel}
+        </Button>
+      </div>
+
+      {/* 이메일 인증 코드 + 확인 버튼 */}
+      <div className="flex min-w-0 gap-3 overflow-hidden">
+        <div className="min-w-0 flex-1 overflow-hidden">
+          <CommonInputField<SignupFormData>
+            name="emailVerificationCode"
+            type="text"
+            placeholder="전송된 코드를 입력해주세요."
+            width="100%"
+            placeholderVariant="a"
+            state={emailCodeFieldState}
+            helperVisibility="always"
+            helperTextByState={{
+              success: emailVerifyMsg,
+              error: emailVerifyMsg,
+            }}
+            rightSlot={EmailCodeRightSlot}
+            locked={emailVerified}
+          />
+        </div>
+
+        <Button
+          type="button"
+          size="sm"
+          variant={!canVerifyEmail ? 'disabled' : 'secondary'}
+          className="whitespace-nowrap"
+          onClick={onVerifyEmailCode}
+        >
+          {emailVerified ? '인증완료' : '인증번호 확인'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/signup/GenderField.tsx
+++ b/src/components/signup/GenderField.tsx
@@ -1,0 +1,44 @@
+import { useFormContext } from 'react-hook-form'
+import cn from '@/lib/cn'
+import type { SignupFormData } from '@/schemas/auth'
+
+export function GenderField() {
+  const { watch, setValue } = useFormContext<SignupFormData>()
+  const value = watch('gender')
+
+  const maleActive = value === 'male'
+  const femaleActive = value === 'female'
+
+  const base =
+    'h-[42px] w-[84px] rounded-full border text-base font-semibold transition-colors whitespace-nowrap'
+
+  return (
+    <div className="flex gap-3">
+      <button
+        type="button"
+        onClick={() => setValue('gender', 'male', { shouldValidate: true })}
+        className={cn(
+          base,
+          maleActive
+            ? 'border-primary bg-primary-100 text-primary'
+            : 'border-[#CECECE] bg-[#F2F2F2] text-[#666666] hover:bg-gray-200'
+        )}
+      >
+        남
+      </button>
+
+      <button
+        type="button"
+        onClick={() => setValue('gender', 'female', { shouldValidate: true })}
+        className={cn(
+          base,
+          femaleActive
+            ? 'border-primary bg-primary-100 text-primary'
+            : 'border-[#CECECE] bg-[#F2F2F2] text-[#666666] hover:bg-gray-200'
+        )}
+      >
+        여
+      </button>
+    </div>
+  )
+}

--- a/src/components/signup/NicknameSection.tsx
+++ b/src/components/signup/NicknameSection.tsx
@@ -1,0 +1,71 @@
+import { Check } from 'lucide-react'
+
+import { Button } from '@/components/common/Button'
+import { CommonInputField } from '@/components/common/CommonInputField'
+import type { FieldState } from '@/components/common/CommonInput'
+import type { SignupFormData } from '@/schemas/auth'
+
+type NicknameSectionProps = {
+  nicknameFieldState: FieldState
+  nicknameMsg: string | null
+  nicknameChecked: boolean
+  nickname: string
+  busy: boolean
+  onCheckNickname: () => void
+}
+
+export function NicknameSection({
+  nicknameFieldState,
+  nicknameMsg,
+  nicknameChecked,
+  nickname,
+  busy,
+  onCheckNickname,
+}: NicknameSectionProps) {
+  return (
+    <div className="flex flex-col gap-5">
+      <label className="inline-flex items-start text-left text-[16px] leading-[22.24px] font-normal tracking-[-0.48px] text-[#121212]">
+        닉네임
+        <span className="ml-0 text-[16px] leading-normal font-normal tracking-[-0.32px] text-[#EC0037]">
+          *
+        </span>
+      </label>
+      <div className="flex min-w-0 gap-3 overflow-hidden">
+        <div className="min-w-0 flex-1 overflow-hidden">
+          <CommonInputField<SignupFormData>
+            name="nickname"
+            type="text"
+            placeholder="닉네임을 입력해주세요"
+            width="100%"
+            placeholderVariant="a"
+            state={nicknameFieldState}
+            helperVisibility="always"
+            helperTextByState={{
+              success: nicknameMsg,
+              error: nicknameMsg,
+            }}
+            rightSlot={
+              nicknameChecked ? (
+                <Check className="h-5 w-5 text-green-600" />
+              ) : null
+            }
+          />
+        </div>
+
+        <Button
+          type="button"
+          size="sm"
+          variant={
+            !nickname || busy || nicknameChecked
+              ? 'disabled'
+              : 'secondary'
+          }
+          className="whitespace-nowrap"
+          onClick={onCheckNickname}
+        >
+          {nicknameChecked ? '확인완료' : '중복확인'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/signup/PasswordSection.tsx
+++ b/src/components/signup/PasswordSection.tsx
@@ -1,0 +1,66 @@
+import { Check } from 'lucide-react'
+
+import { PasswordField } from '@/components/common/PasswordField'
+import { CommonInputField } from '@/components/common/CommonInputField'
+import type { FieldState } from '@/components/common/CommonInput'
+import type { SignupFormData } from '@/schemas/auth'
+
+type PasswordSectionProps = {
+  passwordFieldState: FieldState
+  passwordConfirmState: FieldState
+  passwordConfirmMsg: string | null
+}
+
+export function PasswordSection({
+  passwordFieldState,
+  passwordConfirmState,
+  passwordConfirmMsg,
+}: PasswordSectionProps) {
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="inline-flex items-center gap-4">
+        <label className="inline-flex items-start text-left text-[16px] leading-[22.24px] font-normal tracking-[-0.48px] text-[#121212]">
+          비밀번호
+          <span className="ml-0 text-[16px] leading-normal font-normal tracking-[-0.32px] text-[#EC0037]">
+            *
+          </span>
+        </label>
+        <p className="text-primary text-left text-[14px] leading-[19.6px] font-semibold tracking-[-0.42px]">
+          6~15자의 영문/숫자/특수문자 포함
+        </p>
+      </div>
+
+      <PasswordField<SignupFormData>
+        name="password"
+        placeholder="비밀번호를 입력해주세요"
+        width="100%"
+        placeholderVariant="a"
+        state={passwordFieldState} 
+        showDefaultHelper
+        helperVisibility="focus"
+        helperTextByState={{
+          success: '* 사용 가능한 비밀번호입니다.',
+        }}
+      />
+
+      <CommonInputField<SignupFormData>
+        name="passwordConfirm"
+        type="password"
+        placeholder="비밀번호를 다시 입력해주세요"
+        width="100%"
+        placeholderVariant="a"
+        state={passwordConfirmState}
+        helperVisibility="always"
+        helperTextByState={{
+          success: passwordConfirmMsg,
+          error: passwordConfirmMsg,
+        }}
+        rightSlot={
+          passwordConfirmState === 'success' ? (
+            <Check className="h-5 w-5 text-green-600" />
+          ) : null
+        }
+      />
+    </div>
+  )
+}

--- a/src/components/signup/PhoneSection.tsx
+++ b/src/components/signup/PhoneSection.tsx
@@ -1,0 +1,186 @@
+import { Check } from 'lucide-react'
+
+import cn from '@/lib/cn'
+import { Button } from '@/components/common/Button'
+import { CommonInputField } from '@/components/common/CommonInputField'
+import type { FieldState } from '@/components/common/CommonInput'
+import type { SignupFormData } from '@/schemas/auth'
+
+type TimerLike = {
+  isRunning: boolean
+  mmss: string
+}
+
+type Props = {
+  phone1: string
+  phoneDigitsState: FieldState
+  smsCodeFieldState: FieldState
+
+  phoneSendMsg: string | null
+  phoneSendStatus: 'idle' | 'error' | 'success'
+  smsVerifyMsg: string | null
+
+  smsVerified: boolean
+  smsCodeSent: boolean
+
+  smsTimer: TimerLike
+  smsSendLabel: string
+
+  canSendSms: boolean
+  canVerifySms: boolean
+
+  formError: string | null
+
+  onSendSmsCode: () => void
+  onVerifySmsCode: () => void
+}
+
+export function PhoneSection({
+  phone1,
+  phoneDigitsState,
+  smsCodeFieldState,
+  phoneSendMsg,
+  phoneSendStatus,
+  smsVerifyMsg,
+  smsVerified,
+  smsCodeSent,
+  smsTimer,
+  smsSendLabel,
+  canSendSms,
+  canVerifySms,
+  formError,
+  onSendSmsCode,
+  onVerifySmsCode,
+}: Props) {
+  const SmsCodeRightSlot = (
+    <div className="flex items-center gap-2">
+      {smsVerified ? (
+        <Check className="h-5 w-5 text-green-600" />
+      ) : smsCodeSent && smsTimer.isRunning ? (
+        <span className="text-sm font-semibold text-red-500">
+          {smsTimer.mmss}
+        </span>
+      ) : null}
+    </div>
+  )
+
+  return (
+    <div className="flex min-w-0 flex-col gap-5">
+      <label className="inline-flex items-start text-left text-[16px] leading-[22.24px] font-normal tracking-[-0.48px] text-[#121212]">
+        휴대전화
+        <span className="ml-0 text-[16px] leading-normal font-normal tracking-[-0.32px] text-[#EC0037]">
+          *
+        </span>
+      </label>
+
+      <div className="flex min-w-0 items-start gap-3 overflow-hidden">
+        <div className="min-w-0 flex-1 overflow-hidden">
+          <div className="grid w-full min-w-0 grid-cols-[1fr_auto_1fr_auto_1fr] items-center gap-1 overflow-hidden">
+            <div className="min-w-0">
+              <CommonInputField<SignupFormData>
+                name="phone1"
+                type="text"
+                placeholder={phone1 || '010'}
+                placeholderVariant="a"
+                disabled
+                width="100%"
+              />
+            </div>
+
+            <span className="shrink-0 text-[14px] leading-normal tracking-[-0.42px] text-[#9D9D9D]">
+              -
+            </span>
+
+            <div className="min-w-0">
+              <CommonInputField<SignupFormData>
+                name="phone2"
+                type="text"
+                placeholder="0000"
+                placeholderVariant="a"
+                locked={smsVerified}
+                state={phoneDigitsState}
+                width="100%"
+              />
+            </div>
+
+            <span className="shrink-0 text-[14px] leading-normal tracking-[-0.42px] text-[#9D9D9D]">
+              -
+            </span>
+
+            <div className="min-w-0">
+              <CommonInputField<SignupFormData>
+                name="phone3"
+                type="text"
+                placeholder="0000"
+                placeholderVariant="a"
+                locked={smsVerified}
+                state={phoneDigitsState}
+                width="100%"
+              />
+            </div>
+          </div>
+
+          {phoneSendMsg && (
+            <p
+              className={cn(
+                'mt-2 px-1 text-xs font-medium',
+                phoneSendStatus === 'success'
+                  ? 'text-green-600'
+                  : phoneSendStatus === 'error'
+                    ? 'text-red-500'
+                    : 'text-gray-400'
+              )}
+            >
+              {phoneSendMsg}
+            </p>
+          )}
+        </div>
+
+        <Button
+          type="button"
+          size="sm"
+          variant={!canSendSms ? 'disabled' : 'secondary'}
+          className="whitespace-nowrap"
+          onClick={onSendSmsCode}
+        >
+          {smsSendLabel}
+        </Button>
+      </div>
+
+      {/* 인증번호 입력, 확인 버튼 */}
+      <div className="flex min-w-0 gap-3 overflow-hidden">
+        <div className="min-w-0 flex-1 overflow-hidden">
+          <CommonInputField<SignupFormData>
+            name="phoneVerificationCode"
+            type="text"
+            placeholder="인증번호 6자리를 입력해주세요"
+            width="100%"
+            placeholderVariant="a"
+            state={smsCodeFieldState}
+            helperVisibility="always"
+            helperTextByState={{
+              success: smsVerifyMsg,
+              error: smsVerifyMsg,
+            }}
+            rightSlot={SmsCodeRightSlot}
+            locked={smsVerified}
+          />
+        </div>
+
+        <Button
+          type="button"
+          size="sm"
+          variant={!canVerifySms ? 'disabled' : 'secondary'}
+          className="whitespace-nowrap"
+          onClick={onVerifySmsCode}
+        >
+          {smsVerified ? '인증완료' : '인증번호 확인'}
+        </Button>
+      </div>
+
+      {formError && (
+        <p className="px-1 text-xs font-medium text-red-500">{formError}</p>
+      )}
+    </div>
+  )
+}

--- a/src/hooks/useCountdown.ts
+++ b/src/hooks/useCountdown.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+export function useCountdown(durationSec: number) {
+  const [remain, setRemain] = useState(0)
+
+  const start = useCallback(() => {
+    setRemain(durationSec)
+  }, [durationSec])
+
+  const reset = useCallback(() => {
+    setRemain(0)
+  }, [])
+
+  useEffect(() => {
+    if (remain <= 0) return
+    const id = window.setInterval(() => {
+      setRemain((s) => (s <= 1 ? 0 : s - 1))
+    }, 1000)
+    return () => window.clearInterval(id)
+  }, [remain])
+
+  const mmss = useMemo(() => {
+    const m = Math.floor(remain / 60)
+    const s = remain % 60
+    return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+  }, [remain])
+
+  return {
+    remain,
+    mmss,
+    isRunning: remain > 0,
+    start,
+    reset,
+  }
+}

--- a/src/hooks/useSignupEmailForm.ts
+++ b/src/hooks/useSignupEmailForm.ts
@@ -1,0 +1,430 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom'
+import { zodResolver } from '@hookform/resolvers/zod'
+
+import { signupSchema, type SignupFormData } from '@/schemas/auth'
+import * as authApi from '@/api/auth'
+import { useAuthStore } from '@/store/authStore'
+import {
+  pickMessageFromAxios,
+  formatBirthday,
+  mapGender,
+  PASSWORD_REGEX,
+  emailZ,
+} from '@/utils/signupUtils'
+import type { FieldState } from '@/components/common/CommonInput'
+import { useVerificationFlow, type Status } from '@/hooks/useVerificationFlow'
+
+export function useSignupEmailForm() {
+  const navigate = useNavigate()
+  const authLogin = useAuthStore((s) => s.login)
+
+  const methods = useForm<SignupFormData>({
+    resolver: zodResolver(signupSchema),
+    defaultValues: {
+      name: '',
+      nickname: '',
+      birthdate: '',
+      gender: 'male',
+      email: '',
+      emailVerificationCode: '',
+      phone1: '010',
+      phone2: '',
+      phone3: '',
+      phoneVerificationCode: '',
+      password: '',
+      passwordConfirm: '',
+    },
+    mode: 'onChange',
+    reValidateMode: 'onChange',
+    shouldFocusError: true,
+  })
+
+  const { handleSubmit, watch, setError, clearErrors } = methods
+
+  const [busy, setBusy] = useState(false)
+
+  const [nicknameChecked, setNicknameChecked] = useState(false)
+  const [nicknameStatus, setNicknameStatus] = useState<Status>('idle')
+  const [nicknameMsg, setNicknameMsg] = useState<string | null>(null)
+
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const name = watch('name')?.trim() ?? ''
+  const nickname = watch('nickname')?.trim() ?? ''
+  const birthdate = watch('birthdate')?.trim() ?? ''
+
+  const email = watch('email')?.trim() ?? ''
+  const emailCode = watch('emailVerificationCode')?.trim() ?? ''
+
+  const phone1 = watch('phone1')?.trim() ?? ''
+  const phone2 = watch('phone2')?.trim() ?? ''
+  const phone3 = watch('phone3')?.trim() ?? ''
+  const smsCode = watch('phoneVerificationCode')?.trim() ?? ''
+
+  const password = watch('password') ?? ''
+  const passwordConfirm = watch('passwordConfirm') ?? ''
+
+  const phoneNumber = useMemo(() => {
+    return `${phone1}${phone2}${phone3}`.replace(/\D/g, '')
+  }, [phone1, phone2, phone3])
+
+  // 비밀번호 상태 관리
+  const passwordFieldState: FieldState = useMemo(() => {
+    const value = password.trim()
+    if (!value) return 'default'
+    return PASSWORD_REGEX.test(value) ? 'success' : 'error'
+  }, [password])
+
+  const passwordConfirmState: FieldState = useMemo(() => {
+    const value = passwordConfirm.trim()
+    if (!value) return 'default'
+    if (!password.trim()) return 'error'
+    return value === password ? 'success' : 'error'
+  }, [password, passwordConfirm])
+
+  const passwordConfirmMsg = useMemo(() => {
+    const value = passwordConfirm.trim()
+    if (!value) return null
+    if (!password.trim()) return '* 비밀번호를 먼저 입력해주세요.'
+    return value === password
+      ? '* 비밀번호가 일치합니다.'
+      : '* 비밀번호가 일치하지 않습니다.'
+  }, [password, passwordConfirm])
+
+  // 닉네임 입력 변경 시 초기화
+  useEffect(() => {
+    setNicknameChecked(false)
+    setNicknameStatus('idle')
+    setNicknameMsg(null)
+  }, [nickname])
+
+  // 닉네임 상태 변환
+  const toFieldState = (s: Status): FieldState =>
+    s === 'success' ? 'success' : s === 'error' ? 'error' : 'default'
+
+  const clearFieldErrors = (names: string | string[]) => {
+    if (Array.isArray(names)) {
+      clearErrors(names as (keyof SignupFormData)[])
+    } else {
+      clearErrors(names as keyof SignupFormData)
+    }
+  }
+
+  const setFieldError = (name: string, message: string) => {
+    setError(name as keyof SignupFormData, { message })
+  }
+
+  // 닉네임 중복 확인
+  const onCheckNickname = async () => {
+    setFormError(null)
+    clearErrors('nickname')
+
+    if (!nickname) {
+      setError('nickname', { message: '* 닉네임을 입력해주세요.' })
+      return
+    }
+
+    setBusy(true)
+    try {
+      await authApi.checkNickname({ nickname })
+      setNicknameChecked(true)
+      setNicknameStatus('success')
+      setNicknameMsg('* 사용 가능한 닉네임입니다.')
+    } catch (err) {
+      setNicknameChecked(false)
+      const msg = pickMessageFromAxios(
+        err,
+        {
+          409: '* 이미 사용 중인 닉네임입니다.',
+          400: '* 닉네임 형식을 확인해주세요.',
+        },
+        '* 닉네임 중복 확인에 실패했습니다.'
+      )
+      setNicknameStatus('error')
+      setNicknameMsg(msg)
+      setError('nickname', { message: msg })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  // 이메일 인증 플로우
+  const emailFlow = useVerificationFlow({
+    identity: email,
+    code: emailCode,
+    ttlSec: 5 * 60,
+    busy,
+    setBusy,
+    clearErrors: clearFieldErrors,
+    setFieldError,
+
+    identityFields: ['email'],
+    codeField: 'emailVerificationCode',
+
+    validateIdentity: (v) => {
+      const ok = emailZ.safeParse(v).success
+      return ok
+        ? { ok: true }
+        : { ok: false, message: '* 올바른 이메일 형식을 입력해주세요.' }
+    },
+
+    send: (identity) => authApi.sendEmailVerification({ email: identity }),
+    verify: (identity, code) => authApi.verifyEmail({ email: identity, code }),
+    getToken: (res) => res.email_token,
+
+    getSendErrorMessage: (err) =>
+      pickMessageFromAxios(
+        err,
+        {
+          409: '* 이미 가입된 이메일입니다.',
+          400: '* 이메일 형식을 확인해주세요.',
+        },
+        '* 이메일 인증 코드 전송에 실패했습니다.'
+      ),
+    getVerifyErrorMessage: (err) =>
+      pickMessageFromAxios(
+        err,
+        {
+          400: '* 인증코드가 일치하지 않습니다.',
+          409: '* 이미 가입된 이메일입니다.',
+        },
+        '* 이메일 인증에 실패했습니다.'
+      ),
+
+    text: {
+      sent: '* 인증코드를 전송했습니다.',
+      resent: '* 인증코드를 재전송했습니다.',
+      identityInvalid: '* 올바른 이메일 형식을 입력해주세요.',
+      codeRequired: '* 인증코드를 입력해주세요.',
+      expired: '* 인증 시간이 만료되었습니다. 인증코드를 다시 요청해주세요.',
+      verifySuccess: '* 이메일 인증이 완료되었습니다.',
+    },
+  })
+
+  // 휴대폰 인증 플로우
+  const smsFlow = useVerificationFlow({
+    identity: phoneNumber,
+    code: smsCode,
+    ttlSec: 5 * 60,
+    busy,
+    setBusy,
+    clearErrors: clearFieldErrors,
+    setFieldError,
+
+    identityFields: ['phone2', 'phone3'],
+    codeField: 'phoneVerificationCode',
+
+    validateIdentity: () => {
+      const p2ok = /^\d{4}$/.test(phone2)
+      const p3ok = /^\d{4}$/.test(phone3)
+      if (!p2ok || !p3ok) {
+        return {
+          ok: false,
+          message: '* 휴대전화 번호를 올바르게 입력해주세요.',
+          fieldErrors: {
+            ...(p2ok ? {} : { phone2: '* 4자리 입력' }),
+            ...(p3ok ? {} : { phone3: '* 4자리 입력' }),
+          },
+        }
+      }
+      if (phoneNumber.length < 10) {
+        return {
+          ok: false,
+          message: '* 휴대전화 번호를 올바르게 입력해주세요.',
+        }
+      }
+      return { ok: true }
+    },
+
+    send: (identity) => authApi.sendSmsVerification({ phone_number: identity }),
+    verify: (identity, code) =>
+      authApi.verifySms({ phone_number: identity, code }),
+    getToken: (res) => res.sms_token,
+
+    getSendErrorMessage: (err) =>
+      pickMessageFromAxios(
+        err,
+        {
+          409: '* 이미 가입에 사용된 휴대전화 번호입니다.',
+          400: '* 휴대전화 번호 형식을 확인해주세요.',
+        },
+        '* 휴대폰 인증번호 전송에 실패했습니다.'
+      ),
+    getVerifyErrorMessage: (err) =>
+      pickMessageFromAxios(
+        err,
+        {
+          400: '* 인증코드가 일치하지 않습니다.',
+          409: '* 이미 가입에 사용된 휴대전화 번호입니다.',
+        },
+        '* 휴대폰 인증에 실패했습니다.'
+      ),
+
+    text: {
+      sent: '* 인증번호를 전송했습니다.',
+      resent: '* 인증번호를 재전송했습니다.',
+      identityInvalid: '* 휴대전화 번호를 올바르게 입력해주세요.',
+      codeRequired: '* 인증번호를 입력해주세요.',
+      expired: '* 인증 시간이 만료되었습니다. 인증번호를 다시 요청해주세요.',
+      verifySuccess: '* 휴대폰 인증이 완료되었습니다.',
+    },
+  })
+
+  // 회원가입 제출
+  const onSubmit = handleSubmit(async (data) => {
+    setFormError(null)
+
+    if (!nicknameChecked)
+      return setFormError('* 닉네임 중복확인을 진행해주세요.')
+    if (!emailFlow.verified || !emailFlow.token)
+      return setFormError('* 이메일 인증을 완료해주세요.')
+    if (!smsFlow.verified || !smsFlow.token)
+      return setFormError('* 휴대폰 인증을 완료해주세요.')
+
+    const birthday = formatBirthday(data.birthdate)
+    if (!birthday) {
+      setError('birthdate', {
+        message: '* 8자리로 입력해주세요. (예: 20000101)',
+      })
+      return
+    }
+
+    setBusy(true)
+    try {
+      await authApi.signup({
+        password: data.password,
+        password_confirm: data.passwordConfirm,
+        nickname: data.nickname.trim(),
+        name: data.name.trim(),
+        birthday,
+        gender: mapGender(data.gender),
+        email_token: emailFlow.token,
+        sms_token: smsFlow.token,
+      })
+
+      await authLogin({ email: data.email.trim(), password: data.password })
+      navigate('/', { replace: true })
+    } catch (err) {
+      const msg = pickMessageFromAxios(
+        err,
+        {
+          409: '* 이미 가입된 정보이거나 중복된 회원가입 내역입니다.',
+          400: '* 입력값을 다시 확인해주세요.',
+        },
+        '* 회원가입에 실패했습니다. 입력값을 다시 확인해주세요.'
+      )
+      setFormError(msg)
+    } finally {
+      setBusy(false)
+    }
+  })
+
+  // 닉네임 상태
+  const nicknameFieldState = toFieldState(nicknameStatus)
+
+  // 휴대폰 인증 상태
+  const phoneDigitsState: FieldState = smsFlow.verified
+    ? 'success'
+    : smsFlow.sendStatus === 'error'
+      ? 'error'
+      : smsFlow.sendStatus === 'success'
+        ? 'success'
+        : 'default'
+
+  // 회원가입 제출 가능 여부
+  const canSubmit =
+    !!name &&
+    !!birthdate &&
+    nicknameChecked &&
+    emailFlow.verified &&
+    smsFlow.verified &&
+    passwordFieldState === 'success' &&
+    passwordConfirmState === 'success' &&
+    !busy
+
+  return {
+    methods,
+
+    values: {
+      name,
+      nickname,
+      birthdate,
+      email,
+      emailCode,
+      phone1,
+      phone2,
+      phone3,
+      smsCode,
+      password,
+      passwordConfirm,
+      phoneNumber,
+    },
+
+    ui: {
+      busy,
+
+      nicknameChecked,
+      nicknameFieldState,
+
+      // 이메일 인증 상태
+      emailVerified: emailFlow.verified,
+      emailCodeSent: emailFlow.codeSent,
+      emailFieldState: emailFlow.ui.fieldState as FieldState,
+      emailCodeFieldState: emailFlow.ui.codeFieldState as FieldState,
+      emailTimer: emailFlow.timer,
+      emailSendLabel: emailFlow.codeSent ? '재전송' : '인증코드전송',
+      canSendEmail: emailFlow.ui.canSend,
+      canVerifyEmail: emailFlow.ui.canVerify,
+
+      // 휴대폰 인증 상태
+      smsVerified: smsFlow.verified,
+      smsCodeSent: smsFlow.codeSent,
+      phoneDigitsState,
+      smsCodeFieldState: smsFlow.ui.codeFieldState as FieldState,
+      smsTimer: smsFlow.timer,
+      smsSendLabel: smsFlow.codeSent ? '재전송' : '인증번호 받기',
+      canSendSms: smsFlow.ui.canSend,
+      canVerifySms: smsFlow.ui.canVerify,
+      phoneSendStatus: smsFlow.sendStatus,
+
+      // 비밀번호 상태
+      passwordFieldState,
+      passwordConfirmState,
+
+      canSubmit,
+    },
+
+    messages: {
+      nicknameMsg,
+
+      // 이메일 인증 메시지
+      emailSendMsg: emailFlow.sendMsg,
+      emailVerifyMsg: emailFlow.verifyMsg,
+
+      // 휴대폰 인증 메시지
+      phoneSendMsg: smsFlow.sendMsg,
+      smsVerifyMsg: smsFlow.verifyMsg,
+
+      // 비밀번호 확인 메시지
+      passwordConfirmMsg,
+
+      formError,
+    },
+
+    actions: {
+      onCheckNickname,
+
+      // 이메일 인증 버튼
+      onSendEmailCode: emailFlow.actions.onSendCode,
+      onVerifyEmailCode: emailFlow.actions.onVerifyCode,
+
+      // 휴대폰 인증 버튼
+      onSendSmsCode: smsFlow.actions.onSendCode,
+      onVerifySmsCode: smsFlow.actions.onVerifyCode,
+
+      onSubmit,
+    },
+  }
+}

--- a/src/hooks/useVerificationFlow.ts
+++ b/src/hooks/useVerificationFlow.ts
@@ -1,0 +1,227 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useCountdown } from '@/hooks/useCountdown'
+
+export type Status = 'idle' | 'error' | 'success'
+
+type FieldErrorMap = Record<string, string>
+
+type ValidationResult = {
+  ok: boolean
+  message?: string
+  fieldErrors?: FieldErrorMap
+}
+
+type UseVerificationFlowArgs<TVerifyRes> = {
+  identity: string
+  code: string
+  ttlSec: number
+  busy: boolean
+  setBusy: (v: boolean) => void
+  clearErrors: (names: string | string[]) => void
+  setFieldError: (name: string, message: string) => void
+
+  identityFields: string[]
+  codeField: string
+
+  validateIdentity: (identity: string) => ValidationResult
+
+  send: (identity: string) => Promise<void>
+  verify: (identity: string, code: string) => Promise<TVerifyRes>
+  getToken: (res: TVerifyRes) => string
+
+  getSendErrorMessage: (err: unknown) => string
+  getVerifyErrorMessage: (err: unknown) => string
+
+  text: {
+    sent: string
+    resent: string
+    identityInvalid: string
+    codeRequired: string
+    expired: string
+    verifySuccess: string
+  }
+}
+
+export function useVerificationFlow<TVerifyRes>({
+  identity,
+  code,
+  ttlSec,
+  busy,
+  setBusy,
+  clearErrors,
+  setFieldError,
+  identityFields,
+  codeField,
+  validateIdentity,
+  send,
+  verify,
+  getToken,
+  getSendErrorMessage,
+  getVerifyErrorMessage,
+  text,
+}: UseVerificationFlowArgs<TVerifyRes>) {
+  const timer = useCountdown(ttlSec)
+
+  const [token, setToken] = useState<string | null>(null)
+
+  const [codeSent, setCodeSent] = useState(false)
+
+  const [sendStatus, setSendStatus] = useState<Status>('idle')
+  const [sendMsg, setSendMsg] = useState<string | null>(null)
+
+  const [verified, setVerified] = useState(false)
+  const [verifyStatus, setVerifyStatus] = useState<Status>('idle')
+  const [verifyMsg, setVerifyMsg] = useState<string | null>(null)
+
+  // 식별자 바뀌면 상태 초기화
+  useEffect(() => {
+    setSendStatus('idle')
+    setSendMsg(null)
+
+    setVerified(false)
+    setToken(null)
+
+    setVerifyStatus('idle')
+    setVerifyMsg(null)
+
+    setCodeSent(false)
+    timer.reset()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [identity])
+
+  const toFieldState = (s: Status) =>
+    s === 'success' ? 'success' : s === 'error' ? 'error' : 'default'
+
+  const fieldState = useMemo(() => {
+    // 식별자 input border 색 변경
+    return verified
+      ? 'success'
+      : sendStatus === 'error'
+        ? 'error'
+        : sendStatus === 'success'
+          ? 'success'
+          : 'default'
+  }, [verified, sendStatus])
+
+  const codeFieldState = useMemo(() => {
+    // 인증코드 input border 색 변경
+    return verified ? 'success' : verifyStatus === 'error' ? 'error' : 'default'
+  }, [verified, verifyStatus])
+
+  const sendLabel = codeSent ? '재전송' : '전송'
+  const canSend = useMemo(() => {
+    return validateIdentity(identity).ok && !busy && !verified
+  }, [identity, busy, verified, validateIdentity])
+
+  const canVerify = useMemo(() => {
+    return !!codeSent && !!code?.trim() && !busy && !verified
+  }, [codeSent, code, busy, verified])
+
+  const onSendCode = async () => {
+    clearErrors([...identityFields, codeField])
+
+    // 재전송/변경 시 인증 상태 초기화
+    setVerified(false)
+    setToken(null)
+    setVerifyStatus('idle')
+    setVerifyMsg(null)
+
+    const v = validateIdentity(identity)
+    if (!v.ok) {
+      const msg = v.message ?? text.identityInvalid
+      setSendStatus('error')
+      setSendMsg(msg)
+
+      if (v.fieldErrors) {
+        Object.entries(v.fieldErrors).forEach(([k, m]) => setFieldError(k, m))
+      } else {
+        identityFields.forEach((f) => setFieldError(f, msg))
+      }
+
+      setCodeSent(false)
+      timer.reset()
+      return
+    }
+
+    setBusy(true)
+    try {
+      await send(identity)
+      setSendStatus('success')
+      setSendMsg(codeSent ? text.resent : text.sent)
+      setCodeSent(true)
+      timer.start()
+    } catch (err) {
+      const msg = getSendErrorMessage(err)
+      setSendStatus('error')
+      setSendMsg(msg)
+      identityFields.forEach((f) => setFieldError(f, msg))
+      setCodeSent(false)
+      timer.reset()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const onVerifyCode = async () => {
+    clearErrors(codeField)
+
+    if (!code?.trim()) {
+      setFieldError(codeField, text.codeRequired)
+      return
+    }
+
+    if (!timer.isRunning) {
+      setVerified(false)
+      setToken(null)
+      setVerifyStatus('error')
+      setVerifyMsg(text.expired)
+      return
+    }
+
+    setBusy(true)
+    try {
+      const res = await verify(identity, code.trim())
+      setToken(getToken(res))
+      setVerified(true)
+      setVerifyStatus('success')
+      setVerifyMsg(text.verifySuccess)
+      timer.reset()
+    } catch (err) {
+      const msg = getVerifyErrorMessage(err)
+      setVerified(false)
+      setToken(null)
+      setVerifyStatus('error')
+      setVerifyMsg(msg)
+      setFieldError(codeField, msg)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return {
+    token,
+    verified,
+    codeSent,
+
+    sendStatus,
+    sendMsg,
+    verifyStatus,
+    verifyMsg,
+
+    timer,
+
+    ui: {
+      sendLabel,
+      canSend,
+      canVerify,
+      fieldState,
+      codeFieldState,
+      toFieldState,
+    },
+
+    actions: {
+      onSendCode,
+      onVerifyCode,
+    },
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,23 +5,37 @@ import { createRoot } from 'react-dom/client'
 import '@/index.css'
 import App from '@/App'
 
+import { apiClient } from '@/api/client'
+import { setupAuthInterceptor } from '@/api/setupInterceptors'
+import { useAuthStore } from '@/store/authStore'
+
 const queryClient = new QueryClient()
 
 async function enableMocking() {
   if (!import.meta.env.DEV) return
 
-  const { worker } = await import('@/mocks/browser')
-  return worker.start({
-    onUnhandledRequest: 'bypass',
+  const { worker } = await import('./mocks/browser')
+  await worker.start({
+    serviceWorker: { url: '/mockServiceWorker.js' },
+    onUnhandledRequest: 'warn',
   })
 }
 
-enableMocking().then(() => {
-  createRoot(document.getElementById('root')!).render(
+async function bootstrap() {
+  setupAuthInterceptor(apiClient, () => useAuthStore.getState().accessToken)
+
+  await enableMocking()
+
+  const rootEl = document.getElementById('root')
+  if (!rootEl) throw new Error('Root element (#root) not found')
+
+  createRoot(rootEl).render(
     <StrictMode>
       <QueryClientProvider client={queryClient}>
         <App />
       </QueryClientProvider>
     </StrictMode>
   )
-})
+}
+
+void bootstrap()

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -5,7 +5,7 @@ import { examDeploymentStatusHandler } from './handlers/quiz/examDeploymentStatu
 import { examDeploymentsHandler } from './handlers/quiz/examDeployments'
 import { examSubmissionHandler } from './handlers/quiz/examSubmission'
 import { examSubmissionResultHandler } from './handlers/quiz/examSubmissionResult'
-import { loginHandler } from './handlers/auth.mock'
+import { authHandlers } from './handlers/auth.mock'
 
 export const helloHandler = http.get('/api/hello', () => {
   return HttpResponse.json({ message: 'Hello, world!', code: 200 })
@@ -13,11 +13,12 @@ export const helloHandler = http.get('/api/hello', () => {
 
 export const handlers = [
   helloHandler,
+  ...authHandlers,
+  // Quiz 핸들러들
   examDeploymentsHandler,
   checkCodeHandler,
   examDeploymentDetailHandler,
   examDeploymentStatusHandler,
   examSubmissionHandler,
   examSubmissionResultHandler,
-  loginHandler,
 ]

--- a/src/mocks/handlers/auth.mock.ts
+++ b/src/mocks/handlers/auth.mock.ts
@@ -1,35 +1,442 @@
 import { http, HttpResponse, delay } from 'msw'
-import type { LoginPayload, LoginResult, User } from '@/types/auth'
 
-const FAKE_USER: User = {
-  id: 'user-001',
-  email: 'test@example.com',
-  name: '테스트 유저',
+const CODE_TTL_MS = 5 * 60 * 1000
+
+// 테스트용 인증코드
+const FIXED_EMAIL_CODE = 'ABCDE12345' // 이메일 코드: ABCDE12345
+const FIXED_SMS_CODE = '123456' // SMS 코드: 123456
+
+// 테스트용 아이디/비밀번호
+const SEED_EMAIL = 'test@example.com' // 아이디: test@example.com
+const SEED_PASSWORD = 'Test123!' // 비밀번호: Test123!
+
+const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const api = (path: string) => new RegExp(`(${escapeRegExp(path)})(\\?.*)?$`)
+
+type UserDto = {
+  id: number
+  email: string
+  nickname: string
+  name: string
+  phone_number: string
+  birthday: string // YYYY-MM-DD
+  gender: 'M' | 'F'
+  profile_img_url?: string | null
+  created_at?: string
 }
 
-const FAKE_PASSWORD = 'Test123!'
+type StoredUser = {
+  password: string
+  user: UserDto
+}
+
+const usersByEmail = new Map<string, StoredUser>()
+const usedNicknames = new Set<string>()
+const usedPhones = new Set<string>()
+
+const emailCodes = new Map<string, { code: string; at: number }>()
+const smsCodes = new Map<string, { code: string; at: number }>()
+
+const emailTokens = new Map<string, string>()
+const smsTokens = new Map<string, string>()
+
+const accessTokens = new Map<string, string>()
+
+let seq = 1
+
+const normEmail = (v: string) => v.trim().toLowerCase()
+const normPhone = (v: string) => v.replace(/\D/g, '')
+const now = () => Date.now()
+
+const base62 = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+const randomBase62 = (len: number) =>
+  Array.from(
+    { length: len },
+    () => base62[Math.floor(Math.random() * base62.length)]
+  ).join('')
+
+const token = (p: string) => `${p}_${randomBase62(24)}`
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+
+const error = (status: number, payload: JsonValue) =>
+  HttpResponse.json(payload, { status })
+
+// 시드 유저 추가
+if (!usersByEmail.has(SEED_EMAIL)) {
+  const user: UserDto = {
+    id: seq++,
+    email: SEED_EMAIL,
+    nickname: '테스트유저',
+    name: '테스트 유저',
+    phone_number: '01012345678',
+    birthday: '2000-01-01',
+    gender: 'M',
+    profile_img_url: null,
+    created_at: new Date().toISOString(),
+  }
+  usersByEmail.set(SEED_EMAIL, { password: SEED_PASSWORD, user })
+  usedNicknames.add(user.nickname.toLowerCase())
+  usedPhones.add(user.phone_number)
+}
 
 export const loginHandler = http.post(
-  '/api/v1/accounts/login/',
+  api('/api/v1/accounts/login/'),
   async ({ request }) => {
-    await delay(300)
+    await delay(120)
+    const body = (await request.json()) as { email?: string; password?: string }
+    const email = normEmail(String(body.email ?? ''))
+    const password = String(body.password ?? '')
 
-    const body = (await request.json()) as LoginPayload
-    const emailOk = body.email.trim().toLowerCase() === FAKE_USER.email
-    const pwOk = body.password === FAKE_PASSWORD
-
-    if (!emailOk || !pwOk) {
-      return HttpResponse.json(
-        { message: 'INVALID_CREDENTIALS' },
-        { status: 400 }
-      )
+    const found = usersByEmail.get(email)
+    if (!found || found.password !== password) {
+      return error(400, {
+        error_detail: {
+          password: ['이메일 또는 비밀번호가 올바르지 않습니다.'],
+        },
+      })
     }
 
-    const result: LoginResult = {
-      accessToken: 'fake-access-token',
-      user: FAKE_USER,
-    }
+    const access_token = token('access')
+    accessTokens.set(access_token, email)
 
-    return HttpResponse.json(result, { status: 200 })
+    return HttpResponse.json({ access_token }, { status: 200 })
   }
 )
+
+export const logoutHandler = http.post(
+  api('/api/v1/accounts/logout/'),
+  async () => {
+    await delay(80)
+    return HttpResponse.json(
+      { detail: '로그아웃 되었습니다.' },
+      { status: 200 }
+    )
+  }
+)
+
+export const meHandler = http.get(
+  api('/api/v1/accounts/me/'),
+  async ({ request }) => {
+    await delay(80)
+
+    const auth = request.headers.get('authorization') ?? ''
+    const access = auth.startsWith('Bearer ')
+      ? auth.slice('Bearer '.length)
+      : ''
+    const email = accessTokens.get(access)
+
+    if (!email) {
+      return error(401, { error_detail: '인증 정보가 없습니다.' })
+    }
+
+    const found = usersByEmail.get(email)
+    if (!found) {
+      return error(401, { error_detail: '사용자를 찾을 수 없습니다.' })
+    }
+
+    return HttpResponse.json(found.user, { status: 200 })
+  }
+)
+
+export const checkNicknameHandler = http.post(
+  api('/api/v1/accounts/check-nickname/'),
+  async ({ request }) => {
+    await delay(80)
+    const body = (await request.json()) as { nickname?: string }
+    const nickname = String(body.nickname ?? '').trim()
+
+    if (!nickname) {
+      return error(400, {
+        error_detail: { nickname: ['닉네임을 입력해주세요.'] },
+      })
+    }
+
+    if (usedNicknames.has(nickname.toLowerCase())) {
+      return error(409, {
+        error_detail: { nickname: ['이미 사용 중인 닉네임입니다.'] },
+      })
+    }
+
+    return HttpResponse.json(
+      { detail: '사용가능한 닉네임 입니다.' },
+      { status: 200 }
+    )
+  }
+)
+
+export const sendEmailHandler = http.post(
+  api('/api/v1/accounts/verification/send-email/'),
+  async ({ request }) => {
+    await delay(80)
+    const body = (await request.json()) as { email?: string }
+    const email = normEmail(String(body.email ?? ''))
+
+    if (!email) {
+      return error(400, { error_detail: { email: ['이메일을 입력해주세요.'] } })
+    }
+
+    if (usersByEmail.has(email)) {
+      return error(409, { error_detail: '이미 가입된 이메일입니다.' })
+    }
+
+    emailCodes.set(email, { code: FIXED_EMAIL_CODE, at: now() })
+
+    return HttpResponse.json(
+      { detail: '이메일 인증 코드가 전송되었습니다.' },
+      { status: 200 }
+    )
+  }
+)
+
+export const verifyEmailHandler = http.post(
+  api('/api/v1/accounts/verification/verify-email/'),
+  async ({ request }) => {
+    await delay(80)
+    const body = (await request.json()) as { email?: string; code?: string }
+    const email = normEmail(String(body.email ?? ''))
+    const code = String(body.code ?? '').trim()
+
+    if (!email) {
+      return error(400, { error_detail: { email: ['이메일을 입력해주세요.'] } })
+    }
+    if (!code) {
+      return error(400, {
+        error_detail: { code: ['인증코드를 입력해주세요.'] },
+      })
+    }
+
+    if (usersByEmail.has(email)) {
+      return error(409, { error_detail: '이미 가입된 이메일입니다.' })
+    }
+
+    const saved = emailCodes.get(email)
+    if (!saved) {
+      return error(400, {
+        error_detail: { code: ['인증코드가 일치하지 않습니다.'] },
+      })
+    }
+
+    if (now() - saved.at > CODE_TTL_MS) {
+      emailCodes.delete(email)
+      return error(400, {
+        error_detail: { code: ['인증 시간이 만료되었습니다.'] },
+      })
+    }
+
+    if (saved.code !== code) {
+      return error(400, {
+        error_detail: { code: ['인증코드가 일치하지 않습니다.'] },
+      })
+    }
+
+    const email_token = token('email')
+    emailTokens.set(email_token, email)
+
+    return HttpResponse.json(
+      { detail: '이메일 인증에 성공하였습니다.', email_token },
+      { status: 200 }
+    )
+  }
+)
+
+export const sendSmsHandler = http.post(
+  api('/api/v1/accounts/verification/send-sms/'),
+  async ({ request }) => {
+    await delay(80)
+    const body = (await request.json()) as { phone_number?: string }
+    const phone = normPhone(String(body.phone_number ?? ''))
+
+    if (phone.length < 10) {
+      return error(400, {
+        error_detail: { phone_number: ['휴대폰 번호를 확인해주세요.'] },
+      })
+    }
+
+    if (usedPhones.has(phone)) {
+      return error(409, {
+        error_detail: '이미 가입에 사용된 휴대전화 번호입니다.',
+      })
+    }
+
+    smsCodes.set(phone, { code: FIXED_SMS_CODE, at: now() })
+
+    return HttpResponse.json(
+      { detail: '회원가입을 위한 휴대폰 인증 코드가 전송되었습니다.' },
+      { status: 200 }
+    )
+  }
+)
+
+export const verifySmsHandler = http.post(
+  api('/api/v1/accounts/verification/verify-sms/'),
+  async ({ request }) => {
+    await delay(80)
+    const body = (await request.json()) as {
+      phone_number?: string
+      code?: string
+    }
+
+    const phone = normPhone(String(body.phone_number ?? ''))
+    const code = String(body.code ?? '').trim()
+
+    if (phone.length < 10) {
+      return error(400, {
+        error_detail: { phone_number: ['휴대폰 번호를 확인해주세요.'] },
+      })
+    }
+    if (!code) {
+      return error(400, {
+        error_detail: { code: ['인증번호를 입력해주세요.'] },
+      })
+    }
+
+    if (usedPhones.has(phone)) {
+      return error(409, {
+        error_detail: '이미 가입에 사용된 휴대전화 번호입니다.',
+      })
+    }
+
+    const saved = smsCodes.get(phone)
+    if (!saved) {
+      return error(400, {
+        error_detail: { code: ['인증코드가 일치하지 않습니다.'] },
+      })
+    }
+
+    if (now() - saved.at > CODE_TTL_MS) {
+      smsCodes.delete(phone)
+      return error(400, {
+        error_detail: { code: ['인증 시간이 만료되었습니다.'] },
+      })
+    }
+
+    if (saved.code !== code) {
+      return error(400, {
+        error_detail: { code: ['인증코드가 일치하지 않습니다.'] },
+      })
+    }
+
+    const sms_token = token('sms')
+    smsTokens.set(sms_token, phone)
+
+    return HttpResponse.json(
+      { detail: '회원가입을 위한 휴대폰 인증에 성공하였습니다.', sms_token },
+      { status: 200 }
+    )
+  }
+)
+
+export const signupHandler = http.post(
+  api('/api/v1/accounts/signup/'),
+  async ({ request }) => {
+    await delay(120)
+    const body = (await request.json()) as {
+      password?: string
+      password_confirm?: string
+      nickname?: string
+      name?: string
+      birthday?: string
+      gender?: 'M' | 'F'
+      email_token?: string
+      sms_token?: string
+    }
+
+    const password = String(body.password ?? '')
+    const password_confirm =
+      body.password_confirm == null ? null : String(body.password_confirm)
+
+    const nickname = String(body.nickname ?? '').trim()
+    const name = String(body.name ?? '').trim()
+    const birthday = String(body.birthday ?? '').trim()
+    const gender = body.gender
+
+    const email_token = String(body.email_token ?? '')
+    const sms_token = String(body.sms_token ?? '')
+
+    if (
+      !password ||
+      !nickname ||
+      !name ||
+      !birthday ||
+      !gender ||
+      !email_token ||
+      !sms_token
+    ) {
+      return error(400, { error_detail: '필수 입력값을 확인해주세요.' })
+    }
+
+    if (password_confirm !== null && password_confirm !== password) {
+      return error(400, {
+        error_detail: { password_confirm: ['비밀번호가 일치하지 않습니다.'] },
+      })
+    }
+
+    const email = emailTokens.get(email_token)
+    const phone = smsTokens.get(sms_token)
+
+    if (!email) {
+      return error(400, {
+        error_detail: { email_token: ['이메일 인증을 다시 진행해주세요.'] },
+      })
+    }
+    if (!phone) {
+      return error(400, {
+        error_detail: { sms_token: ['휴대폰 인증을 다시 진행해주세요.'] },
+      })
+    }
+
+    if (usersByEmail.has(email)) {
+      return error(409, {
+        error_detail: '이미 중복된 회원가입 내역이 존재합니다.',
+      })
+    }
+    if (usedPhones.has(phone)) {
+      return error(409, {
+        error_detail: '이미 가입에 사용된 휴대전화 번호입니다.',
+      })
+    }
+    if (usedNicknames.has(nickname.toLowerCase())) {
+      return error(409, { error_detail: '이미 사용 중인 닉네임입니다.' })
+    }
+
+    const user: UserDto = {
+      id: seq++,
+      email,
+      nickname,
+      name,
+      phone_number: phone,
+      birthday,
+      gender,
+      profile_img_url: null,
+      created_at: new Date().toISOString(),
+    }
+
+    usersByEmail.set(email, { password, user })
+    usedPhones.add(phone)
+    usedNicknames.add(nickname.toLowerCase())
+
+    return HttpResponse.json(
+      { detail: '회원가입이 완료되었습니다.' },
+      { status: 201 }
+    )
+  }
+)
+
+export const authHandlers = [
+  loginHandler,
+  logoutHandler,
+  meHandler,
+  checkNicknameHandler,
+  sendEmailHandler,
+  verifyEmailHandler,
+  sendSmsHandler,
+  verifySmsHandler,
+  signupHandler,
+]

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -5,7 +5,7 @@ import { PasswordField } from '@/components/common/PasswordField'
 import { Button } from '@/components/common/Button'
 import SocialLoginSection from '@/components/auth/SocialLoginSection'
 import type { SocialProviderId } from '@/types/social'
-import { PASSWORD_HELPER, type LoginFormData } from '@/schemas/auth'
+import { type LoginFormData } from '@/schemas/auth'
 
 import { useLoginPage } from '@/hooks/useLoginPage'
 
@@ -23,8 +23,8 @@ export default function LoginPage() {
     goFindPw,
   } = useLoginPage()
 
-  const handleSocialLogin = (provider: SocialProviderId) => {
-    console.log(`${provider} 로그인`)
+  const handleSocialLogin = (_provider: SocialProviderId) => {
+    // TODO: 소셜 로그인 구현
   }
 
   return (
@@ -90,7 +90,7 @@ export default function LoginPage() {
                       helperVisibility="focus"
                       showDefaultHelper={false}
                       helperTextByState={{
-                        default: PASSWORD_HELPER,
+                        default: '* 6~15자의 영문/숫자/특수문자 조합',
                       }}
                     />
 

--- a/src/pages/SignupEmailPage.tsx
+++ b/src/pages/SignupEmailPage.tsx
@@ -1,0 +1,167 @@
+import { FormProvider } from 'react-hook-form'
+import { Link } from 'react-router-dom'
+
+import { Button } from '@/components/common/Button'
+import { CommonInputField } from '@/components/common/CommonInputField'
+import type { SignupFormData } from '@/schemas/auth'
+
+import { useSignupEmailForm } from '@/hooks/useSignupEmailForm'
+
+import { NicknameSection } from '@/components/signup/NicknameSection'
+import { EmailSection } from '@/components/signup/EmailSection'
+import { PhoneSection } from '@/components/signup/PhoneSection'
+import { PasswordSection } from '@/components/signup/PasswordSection'
+import { GenderField } from '@/components/signup/GenderField'
+
+export default function SignupEmailPage() {
+  const { methods, values, ui, messages, actions } = useSignupEmailForm()
+
+  return (
+    <FormProvider {...methods}>
+      <div className="flex min-h-[calc(100vh-96px)] items-center justify-center bg-gray-100 pt-20 pb-24">
+        <div className="bg-white px-6 py-10">
+          <div className="flex w-[480px] flex-col gap-9">
+            {/* 상단 */}
+            <div className="flex flex-col items-center gap-4">
+              <p className="text-center text-[18px] leading-normal font-bold tracking-[-0.36px] text-[#000a30]">
+                마법같이 빠르게 성장시켜줄
+              </p>
+              <img
+                className="h-6 w-[180px] object-contain"
+                alt="OZ. 오즈코딩스쿨"
+                src="/LoginPage_img/ozcoding_logo.png"
+              />
+            </div>
+
+            <h1 className="text-left text-[18px] leading-[25.2px] font-semibold tracking-[-0.54px] text-[#121212]">
+              회원가입
+            </h1>
+
+            <form onSubmit={actions.onSubmit} className="flex flex-col gap-11">
+              {/* 이름 */}
+              <FieldBlock label="이름">
+                <CommonInputField<SignupFormData>
+                  name="name"
+                  type="text"
+                  placeholder="이름을 입력해주세요"
+                  width="100%"
+                  placeholderVariant="a"
+                  helperVisibility="always"
+                />
+              </FieldBlock>
+
+              {/* 닉네임, 중복확인 */}
+              <NicknameSection
+                nicknameFieldState={ui.nicknameFieldState}
+                nicknameMsg={messages.nicknameMsg}
+                nicknameChecked={ui.nicknameChecked}
+                nickname={values.nickname}
+                busy={ui.busy}
+                onCheckNickname={actions.onCheckNickname}
+              />
+
+              {/* 생년월일 */}
+              <FieldBlock label="생년월일">
+                <CommonInputField<SignupFormData>
+                  name="birthdate"
+                  type="text"
+                  placeholder="8자리 입력해주세요 (ex.20000101)"
+                  width="100%"
+                  placeholderVariant="a"
+                  helperVisibility="always"
+                />
+              </FieldBlock>
+
+              {/* 성별 */}
+              <FieldBlock label="성별">
+                <GenderField />
+              </FieldBlock>
+
+              {/* 이메일 */}
+              <EmailSection
+                emailFieldState={ui.emailFieldState}
+                emailCodeFieldState={ui.emailCodeFieldState}
+                emailSendMsg={messages.emailSendMsg}
+                emailVerifyMsg={messages.emailVerifyMsg}
+                emailVerified={ui.emailVerified}
+                emailCodeSent={ui.emailCodeSent}
+                emailTimer={ui.emailTimer}
+                emailSendLabel={ui.emailSendLabel}
+                canSendEmail={ui.canSendEmail}
+                canVerifyEmail={ui.canVerifyEmail}
+                onSendEmailCode={actions.onSendEmailCode}
+                onVerifyEmailCode={actions.onVerifyEmailCode}
+              />
+
+              {/* 휴대전화 */}
+              <PhoneSection
+                phone1={values.phone1}
+                phoneDigitsState={ui.phoneDigitsState}
+                smsCodeFieldState={ui.smsCodeFieldState}
+                phoneSendMsg={messages.phoneSendMsg}
+                phoneSendStatus={ui.phoneSendStatus}
+                smsVerifyMsg={messages.smsVerifyMsg}
+                smsVerified={ui.smsVerified}
+                smsCodeSent={ui.smsCodeSent}
+                smsTimer={ui.smsTimer}
+                smsSendLabel={ui.smsSendLabel}
+                canSendSms={ui.canSendSms}
+                canVerifySms={ui.canVerifySms}
+                formError={messages.formError}
+                onSendSmsCode={actions.onSendSmsCode}
+                onVerifySmsCode={actions.onVerifySmsCode}
+              />
+
+              {/* 비밀번호 */}
+              <PasswordSection
+                passwordFieldState={ui.passwordFieldState}
+                passwordConfirmState={ui.passwordConfirmState}
+                passwordConfirmMsg={messages.passwordConfirmMsg}
+              />
+
+              {/* 제출 */}
+              <Button
+                type="submit"
+                size="xxl"
+                variant={ui.canSubmit ? 'primary' : 'disabled'}
+                className="whitespace-nowrap"
+              >
+                {ui.busy ? '처리 중...' : '가입하기'}
+              </Button>
+            </form>
+
+            <p className="mt-6 text-center">
+              <Link
+                to="/signup"
+                className="text-mono-600 text-[16px] leading-[22.4px] tracking-[-0.48px] underline hover:no-underline"
+              >
+                소셜/일반 선택으로 돌아가기
+              </Link>
+            </p>
+          </div>
+        </div>
+      </div>
+    </FormProvider>
+  )
+}
+
+// UI 레이아웃 컴포넌트
+function FieldBlock({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-5">
+      <label className="inline-flex items-start text-left text-[16px] leading-[22.24px] font-normal tracking-[-0.48px] text-[#121212]">
+        {label}
+        <span className="ml-0 text-[16px] leading-normal font-normal tracking-[-0.32px] text-[#EC0037]">
+          *
+        </span>
+      </label>
+      {children}
+    </div>
+  )
+}

--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -1,24 +1,94 @@
 import { z } from 'zod'
 
 const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).{6,15}$/
+const NICKNAME_REGEX = /^[A-Za-z0-9가-힣]{2,10}$/
+
+function isValidYYYYMMDD(v: string) {
+  const raw = v.replace(/\D/g, '')
+  if (!/^\d{8}$/.test(raw)) return false
+
+  const y = Number(raw.slice(0, 4))
+  const m = Number(raw.slice(4, 6))
+  const d = Number(raw.slice(6, 8))
+
+  if (y < 1900 || y > 2100) return false
+  if (m < 1 || m > 12) return false
+  if (d < 1 || d > 31) return false
+
+  const dt = new Date(y, m - 1, d)
+  return dt.getFullYear() === y && dt.getMonth() === m - 1 && dt.getDate() === d
+}
 
 export const loginSchema = z.object({
   email: z
     .string()
     .trim()
-    .min(1, '이메일을 입력해주세요.')
-    .email('올바른 이메일 형식을 입력해주세요.'),
+    .min(1, '* 이메일을 입력해주세요.')
+    .email('* 올바른 이메일 형식을 입력해주세요.'),
 
   password: z
     .string()
     .min(1, '비밀번호를 입력해주세요.')
     .regex(
       PASSWORD_REGEX,
-      '비밀번호는 6~15자이며 영문/숫자/특수문자를 모두 포함해야 합니다.'
+      '* 비밀번호는 6~15자이며 영문/숫자/특수문자를 모두 포함해야 합니다.'
     ),
 })
 
 export type LoginFormData = z.infer<typeof loginSchema>
 
-export const PASSWORD_HELPER =
-  '* 6~15자의 영문 대/소문자, 숫자 및 특수문자 조합'
+export const signupSchema = z
+  .object({
+    name: z.string().trim().min(1, '* 이름을 입력해주세요.'),
+
+    nickname: z
+      .string()
+      .trim()
+      .regex(NICKNAME_REGEX, '* 닉네임은 2~10자, 한글/영문/숫자만 가능합니다.'),
+
+    birthdate: z
+      .string()
+      .trim()
+      .regex(/^\d{8}$/, '* 생년월일은 8자리로 입력해주세요. (예: 20000101)')
+      .refine(isValidYYYYMMDD, '* 존재하지 않는 날짜입니다. (예: 20000101)'),
+
+    gender: z.enum(['male', 'female'], { message: '* 성별을 선택해주세요.' }),
+
+    email: z
+      .string()
+      .trim()
+      .min(1, '* 이메일을 입력해주세요.')
+      .email('* 올바른 이메일 형식을 입력해주세요.'),
+
+    emailVerificationCode: z
+      .string()
+      .trim()
+      .min(1, '* 인증코드를 입력해주세요.'),
+
+    phone1: z.string().trim().length(3, '* 3자리 입력'),
+    phone2: z
+      .string()
+      .trim()
+      .regex(/^\d{4}$/, '* 4자리 입력'),
+    phone3: z
+      .string()
+      .trim()
+      .regex(/^\d{4}$/, '* 4자리 입력'),
+    phoneVerificationCode: z
+      .string()
+      .trim()
+      .min(1, '* 인증번호를 입력해주세요.'),
+
+    password: z
+      .string()
+      .min(1, '* 비밀번호를 입력해주세요.')
+      .regex(PASSWORD_REGEX, '* 6~15자의 영문/숫자/특수문자를 포함해주세요.'),
+
+    passwordConfirm: z.string().min(1, '* 비밀번호를 다시 입력해주세요.'),
+  })
+  .refine((data) => data.password === data.passwordConfirm, {
+    message: '* 비밀번호가 일치하지 않습니다.',
+    path: ['passwordConfirm'],
+  })
+
+export type SignupFormData = z.infer<typeof signupSchema>

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,15 +1,20 @@
-export type User = {
-  id: string
-  email: string
-  name: string
-}
-
 export type LoginPayload = {
   email: string
   password: string
 }
 
 export type LoginResult = {
-  accessToken: string
-  user: User
+  access_token: string
+}
+
+export type User = {
+  id: number
+  email: string
+  nickname: string
+  name: string
+  phone_number: string
+  birthday: string
+  gender: 'M' | 'F'
+  profile_img_url?: string | null
+  created_at?: string
 }

--- a/src/utils/signupUtils.ts
+++ b/src/utils/signupUtils.ts
@@ -1,0 +1,44 @@
+import axios from 'axios'
+import { z } from 'zod'
+
+export const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).{6,15}$/
+
+export const emailZ = z.string().trim().email()
+
+export function formatBirthday(yyyymmdd: string) {
+  const raw = yyyymmdd.replace(/\D/g, '')
+  if (raw.length !== 8) return null
+  return `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)}`
+}
+
+export function mapGender(g: 'male' | 'female'): 'M' | 'F' {
+  return g === 'male' ? 'M' : 'F'
+}
+
+type ErrorResponseData =
+  | {
+      error_detail?: string | Record<string, string | string[]>
+    }
+  | undefined
+
+export function pickMessageFromAxios(
+  err: unknown,
+  byStatus: Record<number, string>,
+  fallback: string
+) {
+  if (axios.isAxiosError(err)) {
+    const status = err.response?.status
+    if (status && byStatus[status]) return byStatus[status]
+
+    const data = err.response?.data as ErrorResponseData
+    const ed = data?.error_detail
+    if (typeof ed === 'string') return ed
+    if (ed && typeof ed === 'object') {
+      const first = Object.values(ed)[0]
+      if (typeof first === 'string') return first
+      if (Array.isArray(first) && typeof first[0] === 'string')
+        return first[0]
+    }
+  }
+  return fallback
+}


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #84


## 📑 구현 사항

- 이메일 기반 회원가입 페이지(`SignupEmailPage`) 구현 및 폼 구성
- React Hook Form + Zod(`signupSchema`)로 회원가입 입력값 검증(이름/닉네임/생년월일/성별/이메일/휴대폰/비밀번호)
- 닉네임 중복 확인 기능 구현 (`authApi.checkNickname`)
- 이메일 인증 플로우 구현
  - 인증코드 전송 → 타이머(5분) 시작 → 인증코드 확인 → `email_token` 저장
- 휴대폰 인증 플로우 구현
  - 인증번호 전송 → 타이머(5분) 시작 → 인증코드 확인 → `sms_token` 저장
- 공통 인증 로직을 `useVerificationFlow`로 분리해 이메일/휴대폰 인증에서 재사용
- 회원가입 제출 시 사전 조건(닉네임 중복확인/이메일 인증/휴대폰 인증) 완료 여부 검증
- 회원가입 성공 시 자동 로그인(`useAuthStore().login`) 후 `/`로 이동
- 입력 상태에 따른 UX 개선
  - `busy`로 중복 요청 방지
  - `canSend/canVerify/canSubmit` 등 버튼 활성화 조건 제어
  - 인증/검증 결과에 따른 안내 메시지 및 필드 상태 표시


## 🌀 어려웠던 점 / 고민했던 부분

- 이메일/휴대폰 인증 로직이 거의 동일해 중복 구현을 피하기 위해 공통 훅(`useVerificationFlow`)로 추상화했습니다.
- 인증 유효시간(타이머) 만료 처리와 “재전송/식별자 변경 시 기존 인증 상태 무효화”의 경계가 헷갈릴 수 있어,
  `identity` 변경 시 `verified/token/codeSent` 등을 초기화하도록 설계했습니다.
- 에러 메시지 UX를 위해 서버 에러(axios)를 사용자 친화적인 문구로 매핑(`pickMessageFromAxios`)하고,
  필드 에러(RHF)와 페이지 상단 에러(`formError`)를 분리해 노출했습니다.
- `busy` 상태를 이메일/휴대폰 인증과 제출에서 공유하도록 하여, 동시에 여러 요청이 발생하는 상황을 방지했습니다.


## 📸 구현 이미지

![무제](https://github.com/user-attachments/assets/4920e075-a062-48dc-a337-cb651efd9849)

## ❇️ 코드 설명

- `schemas/auth.ts`
  - `signupSchema`로 회원가입 입력값 유효성 검사 정의
- `hooks/useVerificationFlow.ts`
  - 인증코드 전송/검증 공통 로직(타이머 포함)
  - 성공 시 token 저장(`email_token` / `sms_token`) 및 `verified=true` 처리
  - UI 제어용 상태(`canSend`, `canVerify`, `fieldState`, `codeFieldState`) 제공
- `hooks/useSignupEmailForm.ts`
  - 회원가입 페이지 전용 “컨트롤 타워” 훅
  - watch 기반 입력값/파생 UI 상태 계산 + 닉네임/이메일/휴대폰 인증 상태 및 제출 조건 관리
  - 제출 시 `authApi.signup` 호출(payload에 `email_token`, `sms_token` 포함) 후 자동 로그인/라우팅 처리
- `pages/SignupEmailPage.tsx` 및 `components/signup/*Section.tsx`
  - 섹션 단위로 UI 분리(닉네임/이메일/휴대폰/비밀번호/성별)
  - 페이지는 `useSignupEmailForm`에서 내려주는 `values/ui/messages/actions`만 받아 렌더링


## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

- 다른 페이지에서도 로그인 잘 작동하는지 확인 부탁드립니다. 
- .env 변경사항 있습니다. 디스코드 -> 자료공유 확인해주세요.
아래는 회원가입 할때 인증코드랑 중복에러 뜨는 이름, 아이디, 휴대번호 정보입니다 나머지는 유효성 검사 내에서 자유입니다
- 이메일 인증코드: ABCDE12345
- SMS 인증코드: 123456
- 이름: 테스트유저(중복 에러)
- 아이디: test@example.com (중복 에러) 
- 휴대번호:010-1234-5678 (중복 에러)
