### PR TITLE
[feat] 쪽지시험 리스트 무한스트롤 추가 (#107)

### DIFF
--- a/src/components/MyPageQuiz.tsx
+++ b/src/components/MyPageQuiz.tsx
@@ -1,47 +1,46 @@
 import { useState, useMemo } from 'react'
-import { useExamDeploymentsQuery } from '@/hooks/useQuiz'
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { fetchExamDeployments } from '@/api/quiz'
 import QuizTabs, { Tabs } from '@/components/quiz/QuizTabs'
 import QuizContent from '@/components/quiz/QuizContent'
 
 type TabKey = 'all' | 'done' | 'todo'
 
 const INITIAL_TAB: TabKey = 'all'
-const INITIAL_PAGE = 1
 const TITLE_CLASS = 'title-xl text-[#121212] min-w-[744px] mb-8'
 const CONTAINER_CLASS = 'space-y-6'
 
 const MyPageQuiz = () => {
   const [currentTab, setCurrentTab] = useState<TabKey>(INITIAL_TAB)
-
-  // 현재 탭에 맞는 API status 값 계산
   const currentStatus = useMemo(
     () => Tabs.find((tab) => tab.key === currentTab)?.status || 'all',
     [currentTab]
   )
 
-  // 쪽지시험 목록 조회 : 탭(전체/응시완료/미응시)에 따라 status 바꿔서 조회
-  const { data, isLoading, isError } = useExamDeploymentsQuery(
-    {
-      page: INITIAL_PAGE,
-      status: currentStatus, // 'all' | 'done' | 'pending'
-    },
-    true
+  // 무한 스크롤: 페이지 단위로 목록 조회, 스크롤 시 다음 페이지 자동 요청
+  const deploymentsQuery = useInfiniteQuery({
+    queryKey: ['examDeployments', 'infinite', currentStatus],
+    queryFn: ({ pageParam }) =>
+      fetchExamDeployments({ page: pageParam as number, status: currentStatus }),
+    initialPageParam: 1,
+    getNextPageParam: (last) => (last.hasNext ? last.page + 1 : undefined),
+  })
+  const quizzes = useMemo(
+    () => deploymentsQuery.data?.pages.flatMap((p) => p.results) ?? [],
+    [deploymentsQuery.data?.pages]
   )
-
-  // QuizContent에 전달해서 카드 목록 렌더링 하기 위해 데이터 추출
-  const quizzes = useMemo(() => data?.results || [], [data?.results])
 
   return (
     <div className={CONTAINER_CLASS}>
       <h1 className={TITLE_CLASS}>쪽지시험</h1>
-
       <QuizTabs currentTab={currentTab} onTabChange={setCurrentTab} />
-
       <QuizContent
         quizzes={quizzes}
-        isLoading={isLoading}
-        isError={isError}
+        isLoading={deploymentsQuery.isLoading}
+        isError={deploymentsQuery.isError}
         currentTab={currentTab}
+        onLoadMore={deploymentsQuery.hasNextPage ? deploymentsQuery.fetchNextPage : undefined}
+        isFetchingNextPage={deploymentsQuery.isFetchingNextPage}
       />
     </div>
   )

--- a/src/components/quiz/Ordering.tsx
+++ b/src/components/quiz/Ordering.tsx
@@ -204,20 +204,11 @@ export default function Ordering({ question, answer, onAnswerChange }: OrderingP
         collisionDetection={closestCenter}
         onDragEnd={handleDragEnd}
       >
-        {/* 지문 및 옵션 박스 */}
-        {question.prompt ? (
+        {/* 옵션 박스 */}
+        {options.length > 0 && (
           <div className="w-[648px] min-h-[228px] bg-[#F2F3F5]/50 p-[20px] rounded-lg mb-4 ml-6">
-            <p className="text-[16px] font-normal text-[#222222] mb-[18px]">
-              {question.prompt}
-            </p>
             {renderOptions()}
           </div>
-        ) : (
-          options.length > 0 && (
-            <div className="w-[648px] min-h-[228px] bg-[#F2F3F5]/50 p-[20px] rounded-lg mb-4 ml-6">
-              {renderOptions()}
-            </div>
-          )
         )}
 
         {/* 빈칸 영역 */}

--- a/src/components/quiz/QuizContent.tsx
+++ b/src/components/quiz/QuizContent.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react'
 import QuizCard from './QuizCard'
 import { Loading } from '@/components/common'
 import type { ExamDeploymentsResult } from '@/mappers/examDeployments'
@@ -10,17 +11,54 @@ const EMPTY_MESSAGES: Record<TabKey, string> = {
   todo: '응시할 쪽지시험이 없습니다.',
 }
 
+const CENTER_MESSAGE_CLASS = 'flex justify-center items-center py-20'
+const INFINITE_SCROLL_ROOT_MARGIN = '100px'
+
 interface QuizContentProps {
   quizzes: ExamDeploymentsResult['results']
   isLoading: boolean
   isError: boolean
   currentTab: TabKey
+  // 무한 스크롤: 리스트 하단 도달 시 호출되는 다음 페이지 로드 콜백
+  onLoadMore?: () => void
+  // 무한 스크롤: 다음 페이지 로딩 중이면 true (중복 요청 방지)
+  isFetchingNextPage?: boolean
 }
 
-export default function QuizContent({ quizzes, isLoading, isError, currentTab }: QuizContentProps) {
+export default function QuizContent({
+  quizzes,
+  isLoading,
+  isError,
+  currentTab,
+  onLoadMore,
+  isFetchingNextPage = false,
+}: QuizContentProps) {
+  // 무한 스크롤: 하단 센티넬이 화면에 보이면 onLoadMore 호출 (IntersectionObserver)
+  const sentinelRef = useRef<HTMLDivElement>(null)
+  const loadingRef = useRef(false)
+  useEffect(() => {
+    loadingRef.current = isFetchingNextPage
+  }, [isFetchingNextPage])
+  useEffect(() => {
+    if (!onLoadMore) return
+    const el = sentinelRef.current
+    if (!el) return
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries[0]?.isIntersecting || loadingRef.current) return
+        loadingRef.current = true
+        onLoadMore()
+      },
+      { rootMargin: INFINITE_SCROLL_ROOT_MARGIN, threshold: 0 }
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [onLoadMore, isFetchingNextPage])
+
+  // 상태별 UI: 로딩 / 에러 / 빈 목록
   if (isLoading) {
     return (
-      <div className="flex justify-center items-center py-20">
+      <div className={CENTER_MESSAGE_CLASS}>
         <Loading />
       </div>
     )
@@ -28,7 +66,7 @@ export default function QuizContent({ quizzes, isLoading, isError, currentTab }:
 
   if (isError) {
     return (
-      <div className="flex justify-center items-center py-20">
+      <div className={CENTER_MESSAGE_CLASS}>
         <p className="text-gray-200">데이터를 불러오는 중 오류가 발생했습니다.</p>
       </div>
     )
@@ -36,7 +74,7 @@ export default function QuizContent({ quizzes, isLoading, isError, currentTab }:
 
   if (quizzes.length === 0) {
     return (
-      <div className="flex justify-center items-center py-20">
+      <div className={CENTER_MESSAGE_CLASS}>
         <p className="text-gray-500">{EMPTY_MESSAGES[currentTab]}</p>
       </div>
     )
@@ -47,6 +85,14 @@ export default function QuizContent({ quizzes, isLoading, isError, currentTab }:
       {quizzes.map((quiz) => (
         <QuizCard key={quiz.id} quiz={quiz} />
       ))}
+      {/* 무한 스크롤: 이 요소가 보이면 다음 페이지 요청 (ref로 IntersectionObserver 감지) */}
+      {onLoadMore && <div ref={sentinelRef} className="h-4" aria-hidden />}
+      {/* 무한 스크롤: 다음 페이지 로딩 중일 때 하단에 로딩 표시 */}
+      {isFetchingNextPage && (
+        <div className="flex justify-center py-6">
+          <Loading />
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/quiz/SingleChoice.tsx
+++ b/src/components/quiz/SingleChoice.tsx
@@ -116,14 +116,8 @@ export default function SingleChoice({
         <span className="quiz-header-badge">단일선택</span>
       </div>
 
-      {/* 지문 및 옵션 */}
-      <div className="min-h-[96px] rounded-lg ml-8">
-        {question.prompt && (
-          <p className="text-[16px] font-normal text-[#222222] mb-[26px]">
-            {question.prompt}
-          </p>
-        )}
-        {renderOptions()}
+      {/* 옵션 */}
+      <div className="min-h-[96px] rounded-lg ml-8">        {renderOptions()}
         {isResult && explanation && (
           <div className="mt-5">
             <QuizResultExplanation explanation={explanation} isCorrect={isCorrect} />


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #107 

## 📑 구현 사항

### 1. 마이페이지 쪽지시험 목록 무한 스크롤
- **MyPageQuiz**: `useExamDeploymentsQuery`(단일 페이지) → `useInfiniteQuery`로 변경하여 페이지 단위로 목록 조회, 스크롤 시 다음 페이지 자동 요청
- **QuizContent**: 리스트 하단에 센티넬 요소 배치 후 `IntersectionObserver`로 감지, 보이면 `onLoadMore` 호출
- 뷰포트 100px 전에 미리 다음 페이지 요청 (`rootMargin`)하여 끊김 없이 로드
- 다음 페이지 로딩 중에는 `onLoadMore` 호출 방지 및 하단 로딩 UI 표시
- **전체보기 / 응시완료 / 미응시 탭 모두 동일한 무한 스크롤 쿼리 사용**  
  → `queryKey`와 API `status`만 탭별로(`all` / `done` / `pending`) 바꿔서, 탭을 바꿔도 각 탭에서 스크롤 시 다음 페이지가 이어서 로드되도록 구현

### 2. prompt 표시 범위 정리
- `question.prompt`는 빈칸 채우기(FillBlank)에서만 사용하도록 정리
- **SingleChoice**, **OX**, **Ordering**에서 지문(prompt) 표시 제거

## 🌀 어려웠던 점 / 고민했던 부분

- IntersectionObserver 콜백이 짧은 시간에 두 번 호출될 수 있어, `loadingRef`로 중복 `fetchNextPage` 호출 방지

## 📸 구현 이미지

https://github.com/user-attachments/assets/81748f7d-afcb-419c-9e68-7e8e842f40fe

## ❇️ 코드 설명

| 파일 | 변경 요약 |
|------|-----------|
| `MyPageQuiz.tsx` | `useInfiniteQuery`로 목록 조회, `quizzes`는 `pages.flatMap(results)`로 합침. `onLoadMore`, `isFetchingNextPage`를 QuizContent에 전달. **탭(전체/응시완료/미응시)마다 동일 쿼리 사용, `currentStatus`만 변경** |
| `QuizContent.tsx` | optional props `onLoadMore`, `isFetchingNextPage` 추가. 센티넬 ref + IntersectionObserver로 하단 도달 시 `onLoadMore` 호출, 다음 페이지 로딩 시 하단에 로딩 표시 |
| `SingleChoice.tsx`, `Ordering.tsx` | `question.prompt` 표시 블록 제거 (FillBlank에서만 prompt 사용) |

## 💬 리뷰 요청사항
> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.