### PR TITLE
fix: Ordering 컴포넌트 useEffect 무한 실행 오류 수정 (#108)

### DIFF
--- a/src/components/quiz/Ordering.tsx
+++ b/src/components/quiz/Ordering.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import {
   DndContext,
   closestCenter,
@@ -128,9 +128,15 @@ export default function Ordering({ question, answer, onAnswerChange }: OrderingP
     initializeSlots(options, answer, optionLabels)
   )
 
+  // 부모에서 넘긴 answer와 동기화. answer/options/optionLabels는 매 렌더마다 새 참조가 될 수 있어
+  // 의존 배열에 넣으면 무한 루프 → questionId, options 길이, answer 값(직렬화)만으로 동기화 여부 판단.
+  const prevSyncKey = useRef<string | null>(null)
   useEffect(() => {
+    const syncKey = `${question.questionId}:${options.length}:${JSON.stringify(answer)}`
+    if (prevSyncKey.current === syncKey) return
+    prevSyncKey.current = syncKey
     setSlots(initializeSlots(options, answer, optionLabels))
-  }, [answer, options, optionLabels])
+  }, [question.questionId, answer, options, optionLabels])
 
   const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor))
 
@@ -148,9 +154,13 @@ export default function Ordering({ question, answer, onAnswerChange }: OrderingP
     const { active, over } = event
     if (!over) return
 
-    const draggedLabel = (active.id as string).replace('label-', '')
-    const slotIndex = parseInt((over.id as string).replace('slot-', ''), 10)
+    // 슬롯이 아닌 곳(예: 다른 라벨 위)에 드롭한 경우 무시
+    const overId = over.id as string
+    if (!overId.startsWith('slot-')) return
+    const slotIndex = parseInt(overId.replace('slot-', ''), 10)
+    if (Number.isNaN(slotIndex) || slotIndex < 0 || slotIndex >= slots.length) return
 
+    const draggedLabel = (active.id as string).replace('label-', '')
     const newSlots = [...slots]
     const existingSlotIndex = newSlots.findIndex((label) => label === draggedLabel)
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,8 +12,8 @@ import { useAuthStore } from '@/store/authStore'
 const queryClient = new QueryClient()
 
 async function enableMocking() {
-  if (!import.meta.env.DEV || import.meta.env.VITE_USE_MSW !== 'true')
-    return
+  // VITE_USE_MSW=true → 목 데이터(MSW), false → 실백엔드
+  if (!import.meta.env.DEV || import.meta.env.VITE_USE_MSW !== 'true') return
 
   const { worker } = await import('./mocks/browser')
   await worker.start({


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #108 

## 📑 구현 사항

- **Ordering 컴포넌트 useEffect 무한 실행 오류 수정**
  - `useEffect` 의존 배열에 `answer`, `options`, `optionLabels`가 들어가 있어 매 렌더마다 새 참조로 인식되어 `setSlots` → 리렌더 → effect 재실행이 반복되던 문제를 수정했습니다.
  - `prevSyncKey` ref로 `questionId`, `options.length`, `answer`(직렬화)가 실제로 바뀔 때만 슬롯을 동기화하도록 변경해 무한 루프를 제거했습니다.
- **handleDragEnd 검증 추가**
  - 슬롯이 아닌 곳(다른 라벨 위 등)에 드롭했을 때 `over.id`가 `slot-`으로 시작하지 않거나 `slotIndex`가 유효하지 않으면 early return 하도록 처리해, 잘못된 상태 업데이트를 막았습니다.
- **.env / MSW 토글**
  - `VITE_USE_MSW`로 목 데이터(MSW) / 실백엔드 전환을 할 수 있도록 정리했습니다.

## 🌀 어려웠던 점 / 고민했던 부분

- `answer`, `options`, `optionLabels`는 부모에서 넘어오는 값이라 매 렌더마다 새 배열/참조가 되어, 의존 배열에 그대로 넣으면 effect가 끝없이 돌았습니다. “실제로 의미 있는 값이 바뀌었을 때만” 동기화하려고 `syncKey`를 ref로 두고 `questionId`·`options.length`·`JSON.stringify(answer)` 조합으로 비교하는 방식으로 바꿨습니다.

## 📸 구현 이미지

-

## ❇️ 코드 설명


- **prevSyncKey + syncKey**: `questionId`, `options.length`, `answer`(직렬화)를 이어 붙인 문자열을 `syncKey`로 두고, 이전 값(`prevSyncKey.current`)과 같으면 `setSlots`를 호출하지 않아 불필요한 리렌더와 무한 루프를 막습니다.
- **handleDragEnd**: `over.id`가 `slot-`으로 시작하는지, 파싱한 `slotIndex`가 `0 <= slotIndex < slots.length`인지 확인한 뒤에만 슬롯을 갱신하고 `onAnswerChange`를 호출합니다.

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.