### PR TITLE
feat:내 정보 페이지, 수강목록, 회원탈퇴 api 연결

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -83,7 +83,7 @@
 .infoText {
   @apply mr-[85px] w-[100px] text-[18px];
 }
-.infoborder {
+.info-border {
   @apply rounded-[7px] border border-[#D1D1D1] px-[44px] py-[52px];
 }
 /* 문제 헤더 공통 스타일 */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,10 @@ function App() {
         <Route element={<RequireAuth />}>
           <Route path="/quiz" element={<QuizPage />} />
           <Route path="/quiz/:deploymentId" element={<QuizPage />} />
-          <Route path="/quiz/result/:submissionId" element={<QuizResultPage />} />
+          <Route
+            path="/quiz/result/:submissionId"
+            element={<QuizResultPage />}
+          />
         </Route>
       </Routes>
       <ReactQueryDevtools initialIsOpen={false} />

--- a/src/api/info.ts
+++ b/src/api/info.ts
@@ -1,0 +1,20 @@
+import { apiClient } from './client'
+import type { CourseEnrollment } from '@/types/info'
+
+export async function getMyCourses(): Promise<CourseEnrollment[]> {
+  const { data } = await apiClient.get<CourseEnrollment[]>(
+    '/api/v1/accounts/me/enrolled-courses/'
+  )
+  return data
+}
+
+export type WithdrawPayload = {
+  reason: string
+  reason_detail: string
+}
+
+export async function withdraw(payload: WithdrawPayload) {
+  await apiClient.delete('/api/v1/accounts/withdrawal/', {
+    data: payload,
+  })
+}

--- a/src/components/MyInfo.tsx
+++ b/src/components/MyInfo.tsx
@@ -1,19 +1,66 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Button } from './common'
 import { ViewMyInfo } from './myinfo/ViewMyInfo'
 import { EditMyInfo } from './myinfo/EditMyInfo'
+import type { User } from '@/types/auth'
+import type { CourseEnrollment } from '@/types/info'
+import { me } from '@/api/auth'
+import { getMyCourses } from '@/api/info'
 
 export default function MyInfo() {
   const [isEdit, setIsEdit] = useState(false)
+  const [user, setUser] = useState<User | null>(null)
+  const [courses, setCourses] = useState<CourseEnrollment[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [userData, courseData] = await Promise.all([me(), getMyCourses()])
+        setUser(userData)
+        setCourses(courseData)
+      } catch (e) {
+        console.error('내 정보 조회 실패', e)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchData()
+  }, [])
+
+  const handleSave = async () => {
+    if (!user) return
+    try {
+      // await updateMyInfo(user)
+      setIsEdit(false)
+    } catch (e) {
+      console.error('내 정보 저장 실패', e)
+    }
+  }
+
+  if (loading) return <div>로딩중...</div>
+  if (!user) return <div>정보를 불러올 수 없습니다.</div>
+
   return (
     <>
       <div className="flex w-[744px] items-center justify-between">
         <div className="title-xl">내 정보</div>
-        <Button size={'md'} onClick={() => setIsEdit(!isEdit)}>
-          {!isEdit ? '수정하기' : '저장하기'}
+        <Button
+          size="md"
+          onClick={() => (isEdit ? handleSave() : setIsEdit(true))}
+        >
+          {isEdit ? '저장하기' : '수정하기'}
         </Button>
       </div>
-      {!isEdit ? <ViewMyInfo /> : <EditMyInfo />}
+
+      {isEdit ? (
+        <EditMyInfo user={user} onChange={setUser} />
+      ) : (
+        <>
+          <ViewMyInfo user={user} courses={courses} />
+        </>
+      )}
     </>
   )
 }

--- a/src/components/PasswordChange.tsx
+++ b/src/components/PasswordChange.tsx
@@ -36,7 +36,7 @@ export default function PasswordChange() {
   return (
     <>
       <p className="title-xl mb-[20px]">비밀번호 변경</p>
-      <div className="infoborder mt-[20px] w-[74fpx] px-[44px] py-[52px]">
+      <div className="info-border mt-[20px] px-[44px] py-[52px]">
         <div className="flex flex-col gap-[20px]">
           {/* 기존 비밀번호 */}
           <div className="flex items-center justify-between">

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -17,7 +17,8 @@ const dropdownButtonClass =
 
 export default function Header() {
   const [open, setOpen] = useState(false)
-  const [registerStudentModalOpen, setRegisterStudentModalOpen] = useState(false)
+  const [registerStudentModalOpen, setRegisterStudentModalOpen] =
+    useState(false)
   const dropdownRef = useRef<HTMLDivElement | null>(null)
 
   const navigate = useNavigate()

--- a/src/components/common/Modal/variants/WithdrawalReasonModal.tsx
+++ b/src/components/common/Modal/variants/WithdrawalReasonModal.tsx
@@ -1,4 +1,6 @@
-import { useState, useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuthStore } from '@/store/authStore'
 import { useForm, FormProvider } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Modal } from '../Modal'
@@ -30,8 +32,9 @@ export function WithdrawalReasonModal({
   onClose,
   onSuccess,
 }: WithdrawalReasonModalProps) {
-  const [showToast, setShowToast] = useState(false)
   const toastTimerRef = useRef<NodeJS.Timeout | null>(null)
+  const navigate = useNavigate()
+  const logout = useAuthStore((state) => state.logout)
 
   useEffect(() => {
     return () => {
@@ -53,7 +56,7 @@ export function WithdrawalReasonModal({
   const methods = useForm<WithdrawalReasonFormData>({
     resolver: zodResolver(withdrawalReasonSchema),
     defaultValues: {
-      reason: '',
+      reason: undefined,
       otherReason: '',
       feedback: '',
     },
@@ -61,62 +64,38 @@ export function WithdrawalReasonModal({
 
   const reasonValue = methods.watch('reason')
   const isOtherSelected = reasonValue === 'other'
-  const isFormValid = reasonValue && (!isOtherSelected || methods.watch('otherReason'))
+  const isFormValid =
+    reasonValue && (!isOtherSelected || methods.watch('otherReason'))
   const isDropdownSelected = !!reasonValue
 
-  const onSubmit = (data: WithdrawalReasonFormData) => {
-    onSuccess?.(data)
-    setShowToast(true)
-    
-    // 기존 타이머가 있으면 정리
+  const onSubmit = async (data: WithdrawalReasonFormData) => {
+    if (onSuccess) {
+      await onSuccess(data)
+      logout()
+      navigate('/login', { replace: true })
+    }
     if (toastTimerRef.current) {
       clearTimeout(toastTimerRef.current)
     }
     toastTimerRef.current = setTimeout(() => {
-      setShowToast(false)
       onClose()
       toastTimerRef.current = null
-    }, 5000) // 5초 후 토스트 사라지고 모달 닫기
+    }, 1000)
   }
 
   return (
     <Modal
       isOpen={isOpen}
       onClose={onClose}
-      className="max-w-[646px] min-h-[537px]"
+      className="min-h-[537px] max-w-[646px]"
       toastPosition="top-far"
-      toast={
-        showToast ? (
-          <div className="bg-white border border-gray-200 text-black px-5 py-4 gap-3 rounded-lg shadow-lg flex-center min-w-[270px] min-h-[60px]">
-            {/* 초록색 원형 체크마크 아이콘 */}
-            <div className="flex-shrink-0 w-6 h-6 bg-green-500 rounded-full flex items-center justify-center">
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 14 14"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M11.6667 3.5L5.25 9.91667L2.33334 7"
-                  stroke="white"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-            <p className="text-[14px] font-normal" style={{ color: '#4D4D4D' }}>
-              전송 완료! 이메일을 확인해주세요.
-            </p>
-          </div>
-        ) : undefined
-      }
     >
       <Modal.Header>
-        <div className="flex flex-col items-center gap-2 w-full">
-          <div className="flex flex-col items-start gap-2 w-full">
-            <h2 className="title-l">오즈코딩스쿨을 탈퇴하시는 이유는 무엇인가요?</h2>
+        <div className="flex w-full flex-col items-center gap-2">
+          <div className="flex w-full flex-col items-start gap-2">
+            <h2 className="title-l">
+              오즈코딩스쿨을 탈퇴하시는 이유는 무엇인가요?
+            </h2>
           </div>
         </div>
       </Modal.Header>
@@ -124,32 +103,37 @@ export function WithdrawalReasonModal({
       <Modal.Body>
         <FormProvider {...methods}>
           <form onSubmit={methods.handleSubmit(onSubmit)} className="space-y-4">
-            <p 
+            <p
               className="mb-10"
               style={{
                 fontSize: '16px',
                 fontWeight: 'normal',
-                color: '#BDBDBD'
+                color: '#BDBDBD',
               }}
             >
-              계정을 삭제하시면 회원님의 모든 콘텐츠와 활동 기록, 수강 기간 / 포인트 / 쿠폰 내역이 사라지며 환불되지 않습니다. 삭제된 정보는 복구할 수 없습니다.
+              계정을 삭제하시면 회원님의 모든 콘텐츠와 활동 기록, 수강 기간 /
+              포인트 / 쿠폰 내역이 사라지며 환불되지 않습니다. 삭제된 정보는
+              복구할 수 없습니다.
             </p>
-              <Dropdown
-                options={withdrawalReasons}
-                value={reasonValue}
-                onChange={(value) => {
-                  methods.setValue('reason', value)
-                  if (value !== 'other') {
-                    methods.setValue('otherReason', '')
-                  }
-                }}
-                placeholder="탈퇴 사유를 선택해주세요"
-              />
-              {methods.formState.errors.reason && (
-                <p className="text-sm text-red-500 mt-1">
-                  {methods.formState.errors.reason.message}
-                </p>
-              )}
+            <Dropdown
+              options={withdrawalReasons}
+              value={reasonValue}
+              onChange={(value) => {
+                methods.setValue(
+                  'reason',
+                  value as WithdrawalReasonFormData['reason']
+                )
+                if (value !== 'other') {
+                  methods.setValue('otherReason', '')
+                }
+              }}
+              placeholder="탈퇴 사유를 선택해주세요"
+            />
+            {methods.formState.errors.reason && (
+              <p className="mt-1 text-sm text-red-500">
+                {methods.formState.errors.reason.message}
+              </p>
+            )}
 
             {isOtherSelected && (
               <Modal.InputRow label="기타 의견">
@@ -164,7 +148,7 @@ export function WithdrawalReasonModal({
 
             {isDropdownSelected && (
               <>
-                <p 
+                <p
                   className="mt-6 mb-4"
                   style={{
                     fontSize: '16px',
@@ -172,13 +156,15 @@ export function WithdrawalReasonModal({
                     color: '#121212',
                   }}
                 >
-                  서비스를 이용하시면서 불편했 점이나 보완할 수 있는 방안을 알려주시면, 서비스 개선에 적극적으로 반영하겠습니다. 감사합니다!
+                  서비스를 이용하시면서 불편했 점이나 보완할 수 있는 방안을
+                  알려주시면, 서비스 개선에 적극적으로 반영하겠습니다.
+                  감사합니다!
                 </p>
                 <div className="mb-4">
                   <textarea
                     {...methods.register('feedback')}
                     placeholder="소중한 의견을 반영해 더 좋은 서비스를 위해 노력하겠습니다."
-                    className="px-4 py-3 rounded-lg resize-none focus:outline-none focus:ring-1 focus:ring-violet-600 focus:border-violet-600"
+                    className="resize-none rounded-lg px-4 py-3 focus:border-violet-600 focus:ring-1 focus:ring-violet-600 focus:outline-none"
                     style={{
                       minWidth: '598px',
                       minHeight: '134px',

--- a/src/components/myinfo/EditMyInfo.tsx
+++ b/src/components/myinfo/EditMyInfo.tsx
@@ -1,102 +1,110 @@
-import { useState } from 'react'
 import { Button, CommonInput } from '../common'
-import type { FieldState } from '../common/CommonInput'
+import type { User } from '@/types/auth'
+import { unmapGender } from '@/utils/gender'
 
-export function EditMyInfo() {
-  const [nickname, setNickname] = useState('오즈오즈')
-  const [nicknameState, setNicknameState] = useState<FieldState>('default')
+type GenderUI = 'male' | 'female'
+
+type Props = {
+  user: User
+  onChange: (v: User) => void
+}
+
+export function EditMyInfo({ user, onChange }: Props) {
+  const handleChange = <K extends keyof User>(key: K, value: User[K]) => {
+    onChange({ ...user, [key]: value })
+  }
+
+  const currentGender = unmapGender(user.gender)
 
   return (
-    <>
-      <div className="infoborder mt-[20px] h-[1194px] w-[747px]">
-        <p className="text-primary title-l">프로필 수정</p>
-        <hr className="border-mono-400 mt-[16px]" />
+    <div className="info-border mt-[20px] w-[747px]">
+      <Section title="프로필 수정">
         <div className="flex justify-center">
           <img
-            src="../public/프로필 사진.svg"
+            src={
+              user.profile_img_url ? user.profile_img_url : '/프로필 사진.svg'
+            }
             alt="프로필 사진"
-            className="m-[52px] h-[184px] rounded-full"
+            className="mb-[52px] h-[184px] rounded-full"
           />
         </div>
-        <p>닉네임</p>
-        <div className="mt-[15px] flex gap-[12px]">
+
+        <Label>닉네임</Label>
+        <div className="flex gap-[12px]">
           <CommonInput
-            value={nickname}
-            placeholder={nickname}
+            value={user.nickname}
+            onChange={(v) => handleChange('nickname', v)}
             width={532}
-            onChange={setNickname}
-            state={nicknameState}
-            helperText="*한글 8자, 영문 및 숫자 16자까지 혼용할 수 있어요."
-            helperVisibility="always"
           />
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => {
-              const isDuplicated = false
-              setNicknameState(isDuplicated ? 'error' : 'success')
-            }}
-          >
+          <Button size="sm" variant="secondary">
             중복확인
           </Button>
         </div>
-        <div className="mt-[40px] flex flex-col gap-[12px]">
-          <p>이메일(아이디)</p>
-          <CommonInput
-            value={''}
-            width={656}
-            disabled
-            placeholderVariant="b"
-            placeholder={'ozschool1234@gmail.com'}
-            onChange={() => {}}
-          />
-        </div>
-        <p className="text-primary title-l mt-[80px]">개인 정보 수정</p>
-        <hr className="border-mono-400 mt-[16px]" />
-        <div className="mt-[40px] flex flex-col gap-[12px]">
-          <p>이름</p>
-          <CommonInput
-            value={''}
-            width={656}
-            disabled
-            placeholderVariant="b"
-            placeholder={'김오즈'}
-            onChange={() => {}}
-          />
-        </div>
-        <p className="my-[15px]">휴대전화</p>
-        <div className="flex gap-[12px]">
-          <CommonInput
-            value={'010-1234-1234'}
-            placeholder={'010-1234-1234'}
-            width={532}
-            onChange={() => {}}
-          />
-          <Button variant="secondary" size="sm" onClick={() => {}}>
-            변경
-          </Button>
-        </div>
-        <p className="my-[15px]">성별</p>
+
+        <Label>이메일</Label>
+        <CommonInput
+          value={user.email}
+          locked
+          width={656}
+          onChange={() => {}}
+          disabled
+        />
+      </Section>
+
+      <Section title="개인 정보 수정">
+        <Label>휴대전화</Label>
+        <CommonInput
+          value={user.phone_number}
+          onChange={(v) => handleChange('phone_number', v)}
+          width={656}
+        />
+
+        <Label>성별</Label>
         <div className="flex gap-[20px]">
-          <Button variant={'secondary'} size={'xxs'} disabled rounded="full">
-            남
-          </Button>
-          <Button variant={'disabled'} size={'xxs'} disabled rounded="full">
-            여
-          </Button>
+          {(['male', 'female'] as GenderUI[]).map((g) => (
+            <Button
+              key={g}
+              size="xxs"
+              rounded="full"
+              variant={currentGender === g ? 'secondary' : 'disabled'}
+              onClick={() => {}}
+            >
+              {g === 'male' ? '남성' : '여성'}
+            </Button>
+          ))}
         </div>
-        <div className="mt-[15px] flex flex-col gap-[12px]">
-          <p>생년월일</p>
-          <CommonInput
-            value={''}
-            width={656}
-            disabled
-            placeholderVariant="b"
-            placeholder={'2000.12.25'}
-            onChange={() => {}}
-          />
-        </div>
-      </div>
-    </>
+
+        <Label>생년월일</Label>
+        <CommonInput
+          value={user.birthday}
+          locked
+          width={656}
+          onChange={() => {}}
+          disabled
+        />
+      </Section>
+    </div>
   )
+}
+
+/* ===== sub ===== */
+
+function Section({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <section className="mb-[80px]">
+      <p className="text-primary title-l">{title}</p>
+      <hr className="border-mono-400 mt-[16px] mb-[40px]" />
+      <div className="flex flex-col gap-[15px]">{children}</div>
+    </section>
+  )
+}
+
+function Label({ children }: { children: React.ReactNode }) {
+  return <p className="mt-[10px]">{children}</p>
 }

--- a/src/components/myinfo/EnrolledCourses.tsx
+++ b/src/components/myinfo/EnrolledCourses.tsx
@@ -1,0 +1,35 @@
+import type { CourseEnrollment } from '@/types/info'
+
+type Props = {
+  courses: CourseEnrollment[]
+}
+
+export function EnrolledCourses({ courses }: Props) {
+  return (
+    <div className="info-border mt-[20px] w-[747px]">
+      <p className="text-primary title-l-b">수강중인 과정</p>
+      <hr className="border-mono-400 mt-[16px] mb-[40px]" />
+
+      {courses.length === 0 ? (
+        <p className="text-mono-400">수강 중인 과정이 없습니다.</p>
+      ) : (
+        courses.map(({ cohort, course }) => (
+          <div key={cohort.id} className="mb-[24px] flex justify-between">
+            <div className="flex flex-col justify-center">
+              <p className="text-mono-400 placeholder-a mb-[10px]">
+                {cohort.number}기 • {course.tag}
+              </p>
+              <p className="text-mono-900">{course.name}</p>
+            </div>
+
+            <img
+              src={course.thumbnail_img_url}
+              alt={course.name}
+              className="h-[102px] w-[152px] rounded-[8px] object-cover"
+            />
+          </div>
+        ))
+      )}
+    </div>
+  )
+}

--- a/src/components/myinfo/ViewMyInfo.tsx
+++ b/src/components/myinfo/ViewMyInfo.tsx
@@ -1,66 +1,162 @@
-function InfoRow({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="flex">
-      <p className="infoText">{label}</p>
-      <p>{value}</p>
-    </div>
-  )
+import type { User } from '@/types/auth'
+import { unmapGender } from '@/utils/gender'
+import { useState } from 'react'
+import { WithdrawalReasonModal } from '../common'
+import { withdraw } from '@/api/info'
+import type { CourseEnrollment } from '@/types/info'
+import { WITHDRAW_REASON_MAP } from '@/constants/withdrawReason'
+import type { WithdrawalReasonFormData } from '@/schemas/modalSchemas'
+type Props = {
+  user: User
+  courses: CourseEnrollment[]
 }
-export function ViewMyInfo() {
+
+export function ViewMyInfo({ user, courses }: Props) {
+  const gender = unmapGender(user.gender)
+  const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false)
+
+  /* ================= 회원 탈퇴 ================= */
+
+  const handleWithdraw = async (
+    data: WithdrawalReasonFormData
+  ): Promise<void> => {
+    try {
+      const reason = WITHDRAW_REASON_MAP[data.reason]
+
+      const reasonDetail =
+        data.reason === 'other'
+          ? data.otherReason?.trim()
+          : data.feedback?.trim()
+
+      await withdraw({
+        reason,
+        reason_detail: reasonDetail || '선택 안함',
+      })
+
+      alert('회원 탈퇴가 완료되었습니다.')
+    } catch (error) {
+      console.error(error)
+    }
+  }
   return (
     <>
-      <div className="infoborder mt-[20px] h-[844px] w-[747px]">
-        <p className="text-primary title-l">프로필</p>
-        <hr className="border-mono-400 mt-[16px]" />
-        <div className="flex justify-center">
-          <img
-            src="../public/프로필 사진.svg"
-            alt="프로필 사진"
-            className="m-[52px] h-[184px] rounded-full"
-          />
-        </div>
-        <div className="flex h-[66px] flex-col justify-between gap-[20px]">
-          <InfoRow label="닉네임" value="닉네임" />
-          <InfoRow label="이메일" value="이메일" />
-        </div>
-        <p className="text-primary title-l mt-[90px]">개인 정보</p>
-        <hr className="border-mono-400 mt-[16px] mb-[28px]" />
-        <div className="flex h-[172px] flex-col justify-between gap-[20px]">
-          <InfoRow label="이름" value="김오즈" />
-          <InfoRow label="휴대전화" value="010-1234-1234" />
-          <InfoRow label="성별" value="남자" />
-          <InfoRow label="생년월일" value="2000.12.25" />
-        </div>
-      </div>
-      <div className="infoborder mt-[20px] w-[747px]">
-        <p className="text-primary title-l">수강중인 과정</p>
-        <hr className="border-mono-400 mt-[16px] mb-[40px]" />
-        <div className="flex justify-between">
-          <div className="flex flex-col justify-center">
-            <p className="text-mono-400 placeholder-a mb-[10px]">
-              익스턴십 개발 <span>캠프</span> • <span>오즈코딩</span>
-            </p>
-            <p>
-              {
-                'IT스타트업 실무형 풀스택 웹 개발 부트캠프 (React + Node.js) < 1기 >'
+      {/* ================= 프로필 / 개인 정보 ================= */}
+      <div className="info-border mt-[20px] w-[747px]">
+        <InfoSection title="프로필">
+          <div className="flex justify-center">
+            <img
+              src={
+                user.profile_img_url ? user.profile_img_url : '/프로필 사진.svg'
               }
-            </p>
+              alt="프로필 사진"
+              className="mb-[52px] h-[184px] rounded-full"
+            />
           </div>
-          <img src="" alt="" className="h-[102px] w-[152px]" />
-        </div>
+
+          <div className="mb-[90px] flex flex-col gap-[20px]">
+            <InfoRow label="닉네임" value={user.nickname} />
+            <InfoRow label="이메일" value={user.email} />
+          </div>
+        </InfoSection>
+
+        <InfoSection title="개인 정보">
+          <div className="flex flex-col gap-[20px]">
+            <InfoRow label="이름" value={user.name} />
+            <InfoRow label="휴대전화" value={user.phone_number} />
+            <InfoRow label="성별" value={gender === 'male' ? '남자' : '여자'} />
+            <InfoRow label="생년월일" value={user.birthday} />
+          </div>
+        </InfoSection>
       </div>
+      {/* ================= 수강중 / 수강완료 과정 ================= */}
+      <div className="info-border mt-[20px] w-[747px]">
+        <p className="text-primary title-l-b">수강중인 과정</p>
+        <hr className="border-mono-400 mt-[16px] mb-[40px]" />
+
+        {courses.length === 0 ? (
+          <p className="text-mono-400">현재 수강 중인 과정이 없습니다.</p>
+        ) : (
+          <div className="flex flex-col gap-[24px]">
+            {courses.map((item) => (
+              <div
+                key={`${item.course.id}-${item.cohort.id}`}
+                className="flex justify-between"
+              >
+                <div className="flex flex-col justify-center">
+                  <p className="text-mono-400 placeholder-a mb-[10px]">
+                    {item.course.tag} • {item.cohort.status}
+                  </p>
+                  <p className="text-mono-900">
+                    {item.course.name} &lt; {item.cohort.number}기 &gt;
+                  </p>
+                </div>
+
+                {/* 썸네일 */}
+                {item.course.thumbnail_img_url ? (
+                  <img
+                    src={item.course.thumbnail_img_url}
+                    alt="과정 썸네일"
+                    className="h-[102px] w-[152px] rounded-[8px] object-cover"
+                  />
+                ) : (
+                  <div className="bg-mono-200 h-[102px] w-[152px] rounded-[8px]" />
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+      {/* ================= 회원 탈퇴 ================= */}
       <div className="my-[48px] flex h-[147px] items-center justify-between">
         <div className="flex w-[365px] flex-col">
           <p className="text-mono-600 text-[20px]">회원탈퇴 안내</p>
-          <p className="text-mono-400 placeholder-a mt-[20px] text-[13px]">
+          <p className="text-mono-400 placeholder-a mt-[20px] text-[13px] leading-[18px]">
             탈퇴 처리 시, 수강 기간 / 포인트 / 쿠폰은 소멸되며 환불되지
-            않습니다.필요한 경우, 반드시 탈퇴 전에 문의 바랍니다.
+            않습니다. 필요한 경우, 반드시 탈퇴 전에 문의 바랍니다.
           </p>
         </div>
-        <button className="flex-center border-mono-250 bg-mono-200 h-[48px] w-[142px] rounded-[4px] border">
+
+        <button
+          className="flex-center border-mono-250 bg-mono-200 h-[48px] w-[142px] rounded-[4px] border"
+          onClick={() => setIsWithdrawModalOpen(true)}
+        >
           회원 탈퇴하기
         </button>
       </div>
+
+      {/* ================= 회원 탈퇴 사유 모달 ================= */}
+      <WithdrawalReasonModal
+        isOpen={isWithdrawModalOpen}
+        onClose={() => setIsWithdrawModalOpen(false)}
+        onSuccess={handleWithdraw}
+      />
     </>
+  )
+}
+
+/* ===== sub ===== */
+
+function InfoSection({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <section>
+      <p className="text-primary title-l-b">{title}</p>
+      <hr className="border-mono-400 mt-[16px] mb-[40px]" />
+      {children}
+    </section>
+  )
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center">
+      <p className="infoText w-[120px] shrink-0">{label}</p>
+      <p className="text-mono-900">{value}</p>
+    </div>
   )
 }

--- a/src/constants/withdrawReason.ts
+++ b/src/constants/withdrawReason.ts
@@ -1,0 +1,9 @@
+export const WITHDRAW_REASON_MAP = {
+  inconvenience: 'SERVICE_DISSATISFACTION',
+  lack_of_content: 'NO_LONGER_NEEDED',
+  other_service: 'TRANSFER',
+  privacy: 'PRIVACY_CONCERN',
+  other: 'OTHER',
+} as const
+
+export type WithdrawReasonKey = keyof typeof WITHDRAW_REASON_MAP

--- a/src/mocks/handlers/auth.mock.ts
+++ b/src/mocks/handlers/auth.mock.ts
@@ -121,27 +121,28 @@ export const logoutHandler = http.post(
   }
 )
 
+// 1. 기존의 meHandler (약 10줄 정도 되는 것)를 찾아서 지웁니다.
+// 2. 그 자리에 아래 코드를 복사해서 넣으세요.
+
 export const meHandler = http.get(
   api('/api/v1/accounts/me/'),
   async ({ request }) => {
     await delay(80)
 
     const auth = request.headers.get('authorization') ?? ''
-    const access = auth.startsWith('Bearer ')
-      ? auth.slice('Bearer '.length)
-      : ''
-    const email = accessTokens.get(access)
 
-    if (!email) {
-      return error(401, { error_detail: '인증 정보가 없습니다.' })
+    // [핵심] 새로고침 시 MSW 메모리가 초기화되어도
+    // 브라우저가 보낸 토큰(헤더)만 있으면 로그인된 것으로 간주합니다.
+    if (auth.startsWith('Bearer ') && auth.length > 10) {
+      const found = usersByEmail.get(SEED_EMAIL)
+
+      // 혹시 모르니 유저 데이터가 있는지 확인 후 반환
+      if (found) {
+        return HttpResponse.json(found.user, { status: 200 })
+      }
     }
 
-    const found = usersByEmail.get(email)
-    if (!found) {
-      return error(401, { error_detail: '사용자를 찾을 수 없습니다.' })
-    }
-
-    return HttpResponse.json(found.user, { status: 200 })
+    return error(401, { error_detail: '인증 정보가 올바르지 않습니다.' })
   }
 )
 

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,26 +1,25 @@
-import clsx from "clsx";
-import { NavLink, Outlet } from "react-router";
+import clsx from 'clsx'
+import { NavLink, Outlet } from 'react-router-dom'
 
 const sideNavClass = ({ isActive }: { isActive: boolean }) =>
   clsx(
     // 공통 스타일
-    "w-[180px] h-[32px] flex items-center pl-4",
-    "font-pretendard font-semibold text-[18px] leading-[140%] tracking-[-0.03em]",
-    "transition-colors",
+    'w-[180px] h-[32px] flex items-center pl-4',
+    'font-pretendard font-semibold text-[18px] leading-[140%] tracking-[-0.03em]',
+    'transition-colors',
 
     // 활성 / 비활성 구분 스타일
     isActive
-      ? "border-l-[3px] border-[#6201E0] text-[#6201E0]"
-      : "text-[#9D9D9D]"
-  );
-
+      ? 'border-l-[3px] border-[#6201E0] text-[#6201E0]'
+      : 'text-[#9D9D9D]'
+  )
 
 const MyPage = () => {
   return (
-    <div className="w-full flex-center">
-      <div className="flex justify-center p-10 w-full">
+    <div className="flex-center w-full">
+      <div className="flex w-full justify-center p-10">
         {/* 좌측 nav */}
-        <aside className="pt-2 max-w-[180px]">
+        <aside className="max-w-[180px] pt-2">
           <nav className="space-y-4">
             <NavLink to="quiz" className={sideNavClass}>
               쪽지시험
@@ -43,4 +42,4 @@ const MyPage = () => {
   )
 }
 
-export default MyPage;
+export default MyPage

--- a/src/schemas/modalSchemas.ts
+++ b/src/schemas/modalSchemas.ts
@@ -1,3 +1,4 @@
+import { WITHDRAW_REASON_MAP } from '@/constants/withdrawReason'
 import { z } from 'zod'
 
 /**
@@ -52,7 +53,7 @@ export const resetPasswordSchema = z
           // 영문 대소문자 모두 포함하는지 확인
           const hasLower = /[a-z]/.test(password)
           const hasUpper = /[A-Z]/.test(password)
-          
+
           // 대소문자 모두 포함하는지 확인
           return hasLower && hasUpper
         },
@@ -106,13 +107,21 @@ export type RegisterStudentFormData = z.infer<typeof registerStudentSchema>
  * 회원 탈퇴 사유 스키마
  */
 export const withdrawalReasonSchema = z.object({
-  reason: z.string().min(1, '탈퇴 사유를 선택해주세요.'),
+  reason: z
+    .enum(
+      Object.keys(WITHDRAW_REASON_MAP) as [
+        keyof typeof WITHDRAW_REASON_MAP,
+        ...(keyof typeof WITHDRAW_REASON_MAP)[],
+      ]
+    )
+    .refine((val) => !!val, {
+      message: '탈퇴 사유를 선택해주세요.',
+    }),
   otherReason: z.string().optional(),
   feedback: z.string().optional(),
 })
 
 export type WithdrawalReasonFormData = z.infer<typeof withdrawalReasonSchema>
-
 /**
  * 쪽지시험 시작 스키마
  * 참가 코드는 Base62 인코딩된 값 (영문 대소문자, 숫자 포함)

--- a/src/types/info.ts
+++ b/src/types/info.ts
@@ -1,0 +1,18 @@
+export type CourseEnrollment = {
+  cohort: {
+    id: number
+    number: number
+    start_date: string
+    end_date: string
+    status: 'ONGOING' | 'COMPLETED' | 'DROPPED' | string
+  }
+  course: {
+    id: number
+    name: string
+    tag: string
+    thumbnail_img_url: string
+  }
+}
+export type ApiErrorResponse = {
+  error_detail: string
+}

--- a/src/utils/gender.ts
+++ b/src/utils/gender.ts
@@ -1,0 +1,3 @@
+export function unmapGender(g: 'M' | 'F'): 'male' | 'female' {
+  return g === 'M' ? 'male' : 'female'
+}


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #92 

## 📑 구현 사항
- 내 정보, 내 정보 수정 리팩토링
-내 정보 조회 api 연결
- 수강목록 api 연결
-회원 탈퇴 api 연결 및 네비게이트login

## 🌀 어려웠던 점 / 고민했던 부분

-

## 📸 구현 이미지

<img width="1178" height="885" alt="스크린샷 2026-02-02 163333" src="https://github.com/user-attachments/assets/1b719793-0603-4c38-85c1-241c14496ba4" />

<img width="703" height="659" alt="image" src="https://github.com/user-attachments/assets/bdd10b3b-fef8-4951-aa3c-6c996c255f75" />


## ❇️ 코드 설명
- 내 정보 및 내 정보 수정 리팩토링  했습니다
-내 정보 조회, 수강목록 조회, 회원탈퇴 api 붙였습니다

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.