### PR TITLE
[refactor] 문제 헤더 UI 컴포넌트 분리로 유지보수성 개선 (#126)

### DIFF
--- a/src/components/quiz/FillBlank.tsx
+++ b/src/components/quiz/FillBlank.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
 import QuizResultExplanation from './QuizResultExplanation'
+import QuestionHeader from './QuestionHeader'
 
 interface FillBlankProps {
   question: ExamDeploymentDetailResult['questions'][0]
@@ -91,13 +92,12 @@ export default function FillBlank({
   return (
     <div className={containerClass}>
       {/* 문제 헤더 */}
-      <div className="quiz-header">
-        <span className="quiz-header-title">
-          {question.number}. {question.question}
-        </span>
-        <span className="quiz-header-badge">{question.point}점</span>
-        <span className="quiz-header-badge">빈칸식</span>
-      </div>
+      <QuestionHeader
+        number={question.number}
+        title={question.question}
+        point={question.point}
+        typeLabel="빈칸식"
+      />
 
       {/* 지문 박스 */}
       {question.prompt && (

--- a/src/components/quiz/MultipleChoice.tsx
+++ b/src/components/quiz/MultipleChoice.tsx
@@ -1,5 +1,6 @@
 import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
 import QuizResultExplanation from './QuizResultExplanation'
+import QuestionHeader from './QuestionHeader'
 
 interface MultipleChoiceProps {
   question: ExamDeploymentDetailResult['questions'][0]
@@ -39,13 +40,13 @@ export default function MultipleChoice({
 
   return (
     <div className={containerClass}>
-      <div className="quiz-header">
-        <span className="quiz-header-title">
-          {question.number}. {question.question}
-        </span>
-        <span className="quiz-header-badge">{question.point}점</span>
-        <span className="quiz-header-badge">다중선택</span>
-      </div>
+      {/* 문제 헤더 */}
+      <QuestionHeader
+        number={question.number}
+        title={question.question}
+        point={question.point}
+        typeLabel="다중선택"
+      />
 
       <div className="ml-8 space-y-4">
         {question.options?.map((option, index) => {

--- a/src/components/quiz/OX.tsx
+++ b/src/components/quiz/OX.tsx
@@ -1,5 +1,6 @@
 import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
 import QuizResultExplanation from './QuizResultExplanation'
+import QuestionHeader from './QuestionHeader'
 
 interface OXProps {
   question: ExamDeploymentDetailResult['questions'][0]
@@ -187,13 +188,12 @@ export default function OX({
   return (
     <div className={containerClass}>
       {/* 문제 헤더 */}
-      <div className="quiz-header">
-        <span className="quiz-header-title">
-          {question.number}. {question.question}
-        </span>
-        <span className="quiz-header-badge">{question.point}점</span>
-        <span className="quiz-header-badge">OX선택</span>
-      </div>
+      <QuestionHeader
+        number={question.number}
+        title={question.question}
+        point={question.point}
+        typeLabel="OX선택"
+      />
 
       {/* 옵션 */}
       <div className="flex flex-col gap-[18px] ml-8">

--- a/src/components/quiz/Ordering.tsx
+++ b/src/components/quiz/Ordering.tsx
@@ -14,6 +14,7 @@ import { CSS } from '@dnd-kit/utilities'
 import { Button } from '@/components/common/Button'
 import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
 import QuizResultExplanation from './QuizResultExplanation'
+import QuestionHeader from './QuestionHeader'
 
 interface OrderingProps {
   question: ExamDeploymentDetailResult['questions'][0]
@@ -241,13 +242,12 @@ export default function Ordering({
   return (
     <div className={containerClass}>
       {/* 문제 헤더 */}
-      <div className="quiz-header">
-        <span className="quiz-header-title">
-          {question.number}. {question.question}
-        </span>
-        <span className="quiz-header-badge">{question.point}점</span>
-        <span className="quiz-header-badge">순서배열</span>
-      </div>
+      <QuestionHeader
+        number={question.number}
+        title={question.question}
+        point={question.point}
+        typeLabel="순서배열"
+      />
 
       <DndContext
         sensors={sensors}

--- a/src/components/quiz/QuestionHeader.tsx
+++ b/src/components/quiz/QuestionHeader.tsx
@@ -1,0 +1,24 @@
+interface QuestionHeaderProps {
+  number: number
+  title: string
+  point: number
+  typeLabel: string
+}
+
+export default function QuestionHeader({
+  number,
+  title,
+  point,
+  typeLabel,
+}: QuestionHeaderProps) {
+  return (
+    <div className="quiz-header">
+      <span className="quiz-header-title">
+        {number}. {title}
+      </span>
+      <span className="quiz-header-badge">{point}점</span>
+      <span className="quiz-header-badge">{typeLabel}</span>
+    </div>
+  )
+}
+

--- a/src/components/quiz/ShortAnswer.tsx
+++ b/src/components/quiz/ShortAnswer.tsx
@@ -1,5 +1,6 @@
 import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
 import QuizResultExplanation from './QuizResultExplanation'
+import QuestionHeader from './QuestionHeader'
 
 interface ShortAnswerProps {
   question: ExamDeploymentDetailResult['questions'][0]
@@ -28,13 +29,12 @@ export default function ShortAnswer({
   return (
     <div className={containerClass}>
       {/* 문제 헤더 */}
-      <div className="quiz-header">
-        <span className="quiz-header-title">
-          {question.number}. {question.question}
-        </span>
-        <span className="quiz-header-badge">{question.point}점</span>
-        <span className="quiz-header-badge">단답형</span>
-      </div>
+      <QuestionHeader
+        number={question.number}
+        title={question.question}
+        point={question.point}
+        typeLabel="단답형"
+      />
 
       <div className="ml-8">
         <input

--- a/src/components/quiz/SingleChoice.tsx
+++ b/src/components/quiz/SingleChoice.tsx
@@ -1,5 +1,6 @@
 import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
 import QuizResultExplanation from './QuizResultExplanation'
+import QuestionHeader from './QuestionHeader'
 
 interface SingleChoiceProps {
   question: ExamDeploymentDetailResult['questions'][0]
@@ -108,13 +109,12 @@ export default function SingleChoice({
   return (
     <div className={containerClass}>
       {/* 문제 헤더 */}
-      <div className="quiz-header">
-        <span className="quiz-header-title">
-          {question.number}. {question.question}
-        </span>
-        <span className="quiz-header-badge">{question.point}점</span>
-        <span className="quiz-header-badge">단일선택</span>
-      </div>
+      <QuestionHeader
+        number={question.number}
+        title={question.question}
+        point={question.point}
+        typeLabel="단일선택"
+      />
 
       {/* 옵션 */}
       <div className="min-h-[96px] rounded-lg ml-8">        {renderOptions()}


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #126 

## 📑 구현 사항

- 문제 헤더 공통 컴포넌트 분리: 각 문제 컴포넌트에 있던 `{/* 문제 헤더 */}` 영역을 공통 컴포넌트로 분리
- `QuestionHeader` 컴포넌트 추가 (`QuestionHeader.tsx`): props `number`, `title`, `point`, `typeLabel` 사용, `quiz-header` / `quiz-header-title` / `quiz-header-badge` 클래스로 공통 스타일 적용
- 단일선택·다중선택·OX·단답형·빈칸식·순서배열 문제 컴포넌트에서 기존 헤더 JSX 제거 후 `QuestionHeader` 사용 (`typeLabel`만 각 타입에 맞게 전달)

## 🌀 어려웠던 점 / 고민했던 부분

- 문제 유형별로 다른 라벨(단일선택, 다중선택, OX선택, 단답형, 빈칸식, 순서배열)을 공통 컴포넌트에서 어떻게 받을지 고민했고, `typeLabel` prop으로 각 문제 컴포넌트에서 전달하는 방식으로 결정함
- 기존 헤더 마크업/클래스를 통일하면서도 화면상 UI가 기존과 동일하게 보이도록 유지함

## 📸 구현 이미지

- 

## ❇️ 코드 설명

- `QuestionHeader`: 문제 번호·제목·점수·유형 배지를 공통으로 렌더하는 프레젠테이션 컴포넌트. `number`·`title`·`point`·`typeLabel`을 받아 `"{number}. {title}"`와 배지 두 개(점수, 유형)를 표시함
- 각 문제 컴포넌트에서는 `question.number`, `question.question`, `question.point`와 해당 타입 라벨을 넘겨 사용함. 헤더 UI 변경 시 `QuestionHeader.tsx` 한 곳만 수정하면 모든 문제 타입에 반영되도록 리팩터링함

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.