### PR TITLE
[feat] 응시페이지 제출하기 모달창 추가 (#128)

### DIFF
--- a/public/icons/check.svg
+++ b/public/icons/check.svg
@@ -1,0 +1,4 @@
+<svg width="60" height="60" viewBox="0 0 60 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="60" height="60" rx="30" fill="#5EB669"/>
+<path d="M42 21.5L24.8125 38.5L17 30.7727" stroke="#FAFAFA" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -322,7 +322,7 @@ Modal.Footer = function ModalFooter({
   return (
     <div
       className={cn(
-        'flex items-center justify-end gap-3 p-6 border-t border-gray-200',
+        'flex items-center justify-end gap-3 p-6',
         className
       )}
     >

--- a/src/components/common/Modal/variants/QuizSubmitCompleteModal.tsx
+++ b/src/components/common/Modal/variants/QuizSubmitCompleteModal.tsx
@@ -1,0 +1,77 @@
+import { Modal } from '../Modal'
+import { Button } from '../../Button'
+
+interface QuizSubmitCompleteModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onConfirm?: () => void
+}
+
+const HEADER_TITLE_STYLE: React.CSSProperties = {
+  fontSize: '18px',
+  fontWeight: 600,
+  color: '#121212',
+  textAlign: 'center',
+}
+
+const HEADER_SUBTITLE_STYLE: React.CSSProperties = {
+  fontSize: '14px',
+  fontWeight: 400,
+  color: '#303030',
+  textAlign: 'center',
+  whiteSpace: 'pre-line',
+}
+
+const COMPLETE_COLOR = '#5EB669'
+
+export function QuizSubmitCompleteModal({
+  isOpen,
+  onClose,
+  onConfirm,
+}: QuizSubmitCompleteModalProps) {
+  const handleConfirm = () => {
+    onConfirm?.()
+    onClose()
+  }
+
+  const renderTitle = () => (
+    <h2 style={HEADER_TITLE_STYLE}>
+      시험 제출이 <span style={{ color: COMPLETE_COLOR }}>완료</span> 되었습니다
+    </h2>
+  )
+
+  const renderSubtitle = () => (
+    <p style={HEADER_SUBTITLE_STYLE}>
+      {`시험이 종료 되었습니다.
+시험 제출이 완료 되었습니다!
+정답 확인 페이지로 넘어갑니다.`}
+    </p>
+  )
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} className="w-[396px] min-h-[341px]">
+      <Modal.Header>
+        <div className="flex flex-col items-center justify-center gap-4 flex-1 min-h-0">
+          <img
+            src="/icons/check.svg"
+            alt="제출 완료"
+            className="h-[60px] w-[60px] shrink-0"
+          />
+          {renderTitle()}
+          {renderSubtitle()}
+        </div>
+      </Modal.Header>
+      <Modal.Footer>
+        <Button
+          variant="primary"
+          size="md"
+          rounded="default"
+          className="w-full"
+          onClick={handleConfirm}
+        >
+          확인
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/src/components/common/Modal/variants/index.ts
+++ b/src/components/common/Modal/variants/index.ts
@@ -9,3 +9,4 @@ export { WithdrawalReasonModal } from './WithdrawalReasonModal' // 탈퇴 사유
 export { StartQuizModal } from './StartQuizModal' // 시험 시작 모달 
 export { CheatingWarningModal } from './CheatingWarningModal' // 부정행위 경고 모달
 export { QuizEndModal } from './QuizEndModal' // 관리자에 의한 시험 종료 모달
+export { QuizSubmitCompleteModal } from './QuizSubmitCompleteModal' // 시험 제출 완료 모달

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -1,11 +1,21 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { Button, Loading, Modal, NotFound } from '@/components/common'
-import { CheatingWarningModal } from '@/components/common/Modal/variants/CheatingWarningModal'
-import { QuizEndModal } from '@/components/common/Modal/variants/QuizEndModal'
+import {
+  Button,
+  CheatingWarningModal,
+  Loading,
+  Modal,
+  NotFound,
+  QuizEndModal,
+  QuizSubmitCompleteModal,
+} from '@/components/common'
 import QuizHeader from '@/components/quiz/QuizHeader'
 import QuizWarningBox from '@/components/QuizWarningBox'
-import { useExamDeploymentDetailQuery, useExamDeploymentStatusQuery } from '@/hooks/useQuiz'
+import {
+  useExamDeploymentDetailQuery,
+  useExamDeploymentStatusQuery,
+  useExamSubmissionMutation,
+} from '@/hooks/useQuiz'
 import {
   SingleChoice,
   MultipleChoice,
@@ -28,7 +38,11 @@ function QuizPage() {
   const [cheatingCount, setCheatingCount] = useState(0)
   const [isCheatingModalOpen, setIsCheatingModalOpen] = useState(false)
   const [isFullscreenModalOpen, setIsFullscreenModalOpen] = useState(false)
+  const [isSubmitCompleteModalOpen, setIsSubmitCompleteModalOpen] = useState(false)
+  const [submittedSubmissionId, setSubmittedSubmissionId] = useState<number | null>(null)
   const lastCheatingAtRef = useRef(0)
+
+  const submissionMutation = useExamSubmissionMutation()
 
   const { data, isLoading } = useExamDeploymentDetailQuery(
     deploymentIdNumber,
@@ -119,6 +133,7 @@ function QuizPage() {
     console.log('부정행위 자동 제출:', { deploymentId: deploymentIdNumber, answers })
   }
 
+  
   const handleCheatingDetected = useCallback(() => {
     if (isEnded) return
     const now = Date.now()
@@ -142,10 +157,41 @@ function QuizPage() {
     handleAutoSubmit();
   }
 
+  // 제출 데이터 생성
+  const buildSubmitPayload = () => {
+    if (!data?.questions) return null
+    const answerList = data.questions.map((q) => ({
+      question_id: q.questionId,
+      type: q.type,
+      submitted_answer: answers[q.questionId] ?? null,
+    }))
+    return {
+      deployment_id: deploymentIdNumber,
+      started_at: new Date().toISOString(),
+      cheating_count: cheatingCount,
+      answers: answerList,
+    }
+  }
+
   const handleSubmit = () => {
-    // 제출 로직은 추후 구현 예정
-    console.log('제출된 답변:', answers)
-    alert('시험이 제출되었습니다.')
+    const payload = buildSubmitPayload()
+    if (!payload) return
+    submissionMutation.mutate(payload, {
+      onSuccess: (result) => {
+        setSubmittedSubmissionId(result.submissionId)
+        setIsSubmitCompleteModalOpen(true)
+      },
+    })
+  }
+
+  const handleSubmitCompleteConfirm = () => {
+    setIsSubmitCompleteModalOpen(false)
+    if (submittedSubmissionId !== null) {
+      navigate(`/quiz/result/${submittedSubmissionId}`)
+      setSubmittedSubmissionId(null)
+    } else {
+      navigate('/mypage/quiz')
+    }
   }
 
   useEffect(() => {
@@ -310,8 +356,14 @@ function QuizPage() {
 
       <footer>
         <div className="flex justify-center mb-10">
-          <Button variant="primary" size="md" rounded="default" onClick={handleSubmit}>
-            제출하기
+          <Button
+            variant="primary"
+            size="md"
+            rounded="default"
+            onClick={handleSubmit}
+            disabled={submissionMutation.isPending}
+          >
+            {submissionMutation.isPending ? '제출 중...' : '제출하기'}
           </Button>
         </div>
       </footer>
@@ -374,6 +426,13 @@ function QuizPage() {
         isOpen={showQuizEndModal}
         onClose={handleEndConfirm}
         onConfirm={handleEndConfirm}
+      />
+
+      {/* 제출하기 완료 모달 */}
+      <QuizSubmitCompleteModal
+        isOpen={isSubmitCompleteModalOpen}
+        onClose={() => setIsSubmitCompleteModalOpen(false)}
+        onConfirm={handleSubmitCompleteConfirm}
       />
     </div>
   )


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #128 

## 📑 구현 사항

- 응시 페이지 제출 완료 모달 추가: 제출하기 클릭 후 서버 제출 성공 시 QuizSubmitCompleteModal 표시 (check.svg 아이콘, 제목·부제목, 396×341px, 확인 시 결과 페이지 이동)
- 제출 API 연동: useExamSubmissionMutation으로 POST /api/v1/exams/submissions 호출, buildSubmitPayload로 payload 구성 후 제출, 성공 시 submissionId 저장 후 모달 오픈
- 제출 중 버튼 비활성화 및 "제출 중..." 문구 표시
- 모달 열릴 때 배경 스크롤 방지(html/body overflow hidden), 제출 완료 모달 내부 overflow hidden
- Modal variants index에 QuizSubmitCompleteModal export, QuizPage 등에서 @/components/common로 import

## 🌀 어려웠던 점 / 고민했던 부분

- 제출 완료 후 바로 결과 페이지로 갈지, 확인 모달을 한 번 보여줄지 고민했고, 명세/UX에 맞춰 모달로 완료 안내 후 확인 시 결과 페이지 이동으로 정함
- 모달 열린 상태에서 배경 스크롤이 되던 문제를 Modal에서 document.documentElement/body overflow hidden으로 해결함
- 제출 payload(question_id, type, submitted_answer)를 문제 타입/데이터 구조에 맞게 구성함

## 📸 구현 이미지

https://github.com/user-attachments/assets/75e58559-276d-4808-8bbd-03b48873f4ec

## ❇️ 코드 설명

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.