### PR TITLE
feat: 수강생 등록 API 연동 및 과정/기수 조회 (#130)

### DIFF
--- a/src/api/info.ts
+++ b/src/api/info.ts
@@ -1,5 +1,5 @@
 import { apiClient } from './client'
-import type { CourseEnrollment } from '@/types/info'
+import type { CourseEnrollment, Course, Cohort } from '@/types/info'
 
 export async function getMyCourses(): Promise<CourseEnrollment[]> {
   const { data } = await apiClient.get<CourseEnrollment[]>(
@@ -17,4 +17,25 @@ export async function withdraw(payload: WithdrawPayload) {
   await apiClient.delete('/api/v1/accounts/withdrawal/', {
     data: payload,
   })
+}
+
+export async function fetchCourses(): Promise<Course[]> {
+  const { data } = await apiClient.get<Course[]>('/api/v1/course/')
+  return data
+}
+
+/** 기수 리스트 조회 (GET /api/v1/:course_id/cohorts) */
+export async function fetchCohorts(courseId: number): Promise<Cohort[]> {
+  const { data } = await apiClient.get<Cohort[]>(
+    `/api/v1/${courseId}/cohorts`
+  )
+  return data
+}
+
+export async function enrollStudent(cohortId: number): Promise<{ detail: string }> {
+  const { data } = await apiClient.post<{ detail: string }>(
+    '/api/v1/accounts/enroll-student/',
+    { cohort_id: cohortId }
+  )
+  return data
 }

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import clsx from 'clsx'
 
 /**
@@ -25,6 +26,8 @@ type DropdownProps = {
   disabled?: boolean
   /** 값이 선택될 때 호출 */
   onChange?: (value: string) => void
+  /** true면 리스트를 modal-root에 포털로 렌더 (모달 안에서 사용할 때만 true 권장) */
+  renderListInPortal?: boolean
 }
 
 /**
@@ -50,18 +53,24 @@ function Dropdown({
   placeholder = '해당되는 항목을 선택해 주세요.',
   disabled = false,
   onChange,
+  renderListInPortal = false,
 }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement | null>(null)
+  const dropdownListRef = useRef<HTMLDivElement | null>(null)
+  const modalRootRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    modalRootRef.current = document.getElementById('modal-root')
+  }, [])
 
   const selectedOption = useMemo(
     () => options.find((option) => option.value === value),
     [options, value]
   )
 
-  let textColor = '#BDBDBD'
-  if (disabled) textColor = '#BDBDBD'
-  if (!disabled && (selectedOption || isOpen)) textColor = '#000000'
+  const textColor =
+    disabled ? '#BDBDBD' : (selectedOption || isOpen ? '#000000' : '#BDBDBD')
 
   let iconSrc = '/icons/arrow_down_gray.svg'
   if (!disabled && (selectedOption || isOpen)) {
@@ -70,15 +79,20 @@ function Dropdown({
 
   useEffect(() => {
     const handleOutsideClick = (event: MouseEvent) => {
-      if (!containerRef.current) return
-      if (!containerRef.current.contains(event.target as Node)) {
+      const target = event.target as Node
+      if (
+        !containerRef.current?.contains(target) &&
+        !dropdownListRef.current?.contains(target)
+      ) {
         setIsOpen(false)
       }
     }
 
-    document.addEventListener('mousedown', handleOutsideClick)
+    if (isOpen) {
+      document.addEventListener('mousedown', handleOutsideClick)
+    }
     return () => document.removeEventListener('mousedown', handleOutsideClick)
-  }, [])
+  }, [isOpen])
 
   const handleToggle = () => {
     if (disabled) return
@@ -94,7 +108,7 @@ function Dropdown({
   return (
     <div
       ref={containerRef}
-      className="relative w-full max-w-[288px] text-[14px]"
+      className="relative w-full text-[14px]"
     >
       <button
         type="button"
@@ -126,38 +140,86 @@ function Dropdown({
         </span>
       </button>
 
-      <div
-        className={clsx(
-          'dropdown-scrollbar absolute top-[calc(100%+4px)] left-0 z-10 flex w-full flex-col gap-[5px] overflow-x-hidden overflow-y-auto',
-          'border-mono-400 rounded-[4px] border bg-white py-[5px]',
-          'origin-top transition-all duration-200 ease-out',
-          isOpen
-            ? 'max-h-[240px] scale-100 opacity-100'
-            : 'pointer-events-none max-h-0 scale-95 opacity-0'
-        )}
-      >
-        {options.map((option) => {
-          const isSelected = option.value === value
-          return (
-            <button
-              key={option.value}
-              type="button"
-              onClick={() => handleSelect(option.value)}
+      {renderListInPortal && isOpen && modalRootRef.current
+        ? createPortal(
+            <div
+              ref={dropdownListRef}
               className={clsx(
-                'mx-auto flex h-[48px] w-[calc(100%-10px)] items-center justify-between px-[11px] py-[10px]',
-                'gap-[16px] text-left',
-                'hover:bg-primary-100 rounded-[4px]',
-                isSelected ? 'text-primary font-semibold' : 'text-black'
+                'dropdown-scrollbar fixed z-[110] flex flex-col gap-[5px] overflow-x-hidden overflow-y-auto',
+                'border-mono-400 rounded-[4px] border bg-white py-[5px]',
+                'origin-top transition-all duration-200 ease-out',
+                'scale-100 opacity-100'
+              )}
+              style={
+                containerRef.current
+                  ? {
+                      top: `${containerRef.current.getBoundingClientRect().bottom + 4}px`,
+                      left: `${containerRef.current.getBoundingClientRect().left}px`,
+                      width: `${containerRef.current.getBoundingClientRect().width}px`,
+                      maxHeight: '240px',
+                    }
+                  : undefined
+              }
+            >
+              {options.map((option) => {
+                const isSelected = option.value === value
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => handleSelect(option.value)}
+                    className={clsx(
+                      'mx-auto flex h-[48px] w-[calc(100%-10px)] items-center justify-between px-[11px] py-[10px]',
+                      'gap-[16px] text-left',
+                      'hover:bg-primary-100 rounded-[4px]',
+                      isSelected ? 'text-primary font-semibold' : 'text-black'
+                    )}
+                  >
+                    <span className="flex-1 truncate">{option.label}</span>
+                    {isSelected && (
+                      <img src="/icons/check_purple.svg" alt="" className="h-[11px] w-[13px]" />
+                    )}
+                  </button>
+                )
+              })}
+            </div>,
+            modalRootRef.current
+          )
+        : (
+            <div
+              ref={dropdownListRef}
+              className={clsx(
+                'dropdown-scrollbar absolute top-[calc(100%+4px)] left-0 z-10 flex w-full flex-col gap-[5px] overflow-x-hidden overflow-y-auto',
+                'border-mono-400 rounded-[4px] border bg-white py-[5px]',
+                'origin-top transition-all duration-200 ease-out',
+                isOpen
+                  ? 'max-h-[240px] scale-100 opacity-100'
+                  : 'pointer-events-none max-h-0 scale-95 opacity-0'
               )}
             >
-              <span className="flex-1 truncate">{option.label}</span>
-              {isSelected && (
-                <img src="/icons/check_purple.svg" alt="" className="h-[11px] w-[13px]" />
-              )}
-            </button>
-          )
-        })}
-      </div>
+              {options.map((option) => {
+                const isSelected = option.value === value
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => handleSelect(option.value)}
+                    className={clsx(
+                      'mx-auto flex h-[48px] w-[calc(100%-10px)] items-center justify-between px-[11px] py-[10px]',
+                      'gap-[16px] text-left',
+                      'hover:bg-primary-100 rounded-[4px]',
+                      isSelected ? 'text-primary font-semibold' : 'text-black'
+                    )}
+                  >
+                    <span className="flex-1 truncate">{option.label}</span>
+                    {isSelected && (
+                      <img src="/icons/check_purple.svg" alt="" className="h-[11px] w-[13px]" />
+                    )}
+                  </button>
+                )
+              })}
+            </div>
+          )}
     </div>
   )
 }

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -212,9 +212,6 @@ export default function Header() {
       <RegisterStudentModal
         isOpen={registerStudentModalOpen}
         onClose={() => setRegisterStudentModalOpen(false)}
-        onSuccess={() => {
-          setRegisterStudentModalOpen(false)
-        }}
       />
     </header>
   )

--- a/src/components/common/Modal/variants/RegisterStudentModal.tsx
+++ b/src/components/common/Modal/variants/RegisterStudentModal.tsx
@@ -1,253 +1,24 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
+import { useEffect } from 'react'
 import { useForm, FormProvider } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { useQuery, useMutation } from '@tanstack/react-query'
 import { Button } from '@/components/common/Button'
+import Dropdown from '@/components/common/Dropdown'
 import { Modal } from '@/components/common/Modal'
 import {
   registerStudentSchema,
   type RegisterStudentFormData,
 } from '@/schemas/modalSchemas'
-import clsx from 'clsx'
+import { fetchCourses, fetchCohorts, enrollStudent } from '@/api/info'
 
 interface RegisterStudentModalProps {
   isOpen: boolean
   onClose: () => void
-  onSuccess?: (data: RegisterStudentFormData) => void
-}
-
-// Mock 데이터 , 나중에 API에서 가져올 데이터 구조
-type CourseData = {
-  id: string
-  name: string
-  batches: number[]
-}
-// 과정 목록
-const mockCourses: CourseData[] = [
-  {
-    id: 'frontend-bootcamp',
-    name: '개발 초격차 프론트엔드 부트캠프',
-    batches: Array.from({ length: 12 }, (_, i) => i + 1), // 1~12기
-  },
-  {
-    id: 'backend-bootcamp',
-    name: '웹 개발 초격차 백엔드 부트캠프',
-    batches: Array.from({ length: 12 }, (_, i) => i + 1), // 1~12기
-  },
-  {
-    id: 'bd-bootcamp',
-    name: 'IT 스타트업 실무형 사업 개발자(BD) 부트캠프',
-    batches: Array.from({ length: 11 }, (_, i) => i + 1), // 1~11기
-  },
-  {
-    id: 'product-designer',
-    name: '스타트업 맞춤형 프로덕트 디자이너',
-    batches: Array.from({ length: 3 }, (_, i) => i + 1), // 1~3기
-  },
-  {
-    id: 'fullstack-bootcamp',
-    name: 'IT스타트업 실무형 풀스택 웹 개발 부트캠프 (React + Node.js)',
-    batches: Array.from({ length: 2 }, (_, i) => i + 1), // 1~2기
-  },
-]
-
-const courseOptions = mockCourses.map((course) => ({
-  label: course.name,
-  value: course.id,
-}))
-
-type ModalDropdownOption = {
-  label: string
-  value: string
-}
-
-type ModalDropdownProps = {
-  options: ModalDropdownOption[]
-  value?: string
-  placeholder?: string
-  disabled?: boolean
-  onChange?: (value: string) => void
-}
-
-function ModalDropdown({
-  options,
-  value,
-  placeholder = '해당되는 항목을 선택해 주세요.',
-  disabled = false,
-  onChange,
-}: ModalDropdownProps) {
-  const [isOpen, setIsOpen] = useState(false)
-  const containerRef = useRef<HTMLDivElement | null>(null)
-  const dropdownListRef = useRef<HTMLDivElement | null>(null)
-  const modalRootRef = useRef<HTMLElement | null>(null)
-
-  useEffect(() => {
-    modalRootRef.current = document.getElementById('modal-root')
-  }, [])
-
-  const selectedOption = useMemo(
-    () => options.find((option) => option.value === value),
-    [options, value]
-  )
-
-  let textColor = '#BDBDBD'
-  if (disabled) textColor = '#BDBDBD'
-  else if (selectedOption) textColor = '#000000'
-  else if (isOpen) textColor = '#000000'
-
-  let iconSrc = '/icons/arrow_down_gray.svg'
-  if (!disabled && (selectedOption || isOpen)) {
-    iconSrc = '/icons/arrow_down_black.svg'
-  }
-  useEffect(() => {
-    const handleOutsideClick = (event: MouseEvent) => {
-      const target = event.target as Node
-      if (
-        !containerRef.current?.contains(target) &&
-        !dropdownListRef.current?.contains(target)
-      ) {
-        setIsOpen(false)
-      }
-    }
-
-    if (isOpen) {
-      document.addEventListener('mousedown', handleOutsideClick)
-    }
-    return () => document.removeEventListener('mousedown', handleOutsideClick)
-  }, [isOpen])
-
-  const handleToggle = () => {
-    if (disabled) return
-    setIsOpen((prev) => !prev)
-  }
-
-  const handleSelect = (nextValue: string, event: React.MouseEvent) => {
-    if (disabled) return
-    event.stopPropagation()
-    onChange?.(nextValue)
-    setIsOpen(false)
-  }
-
-  const itemCount = options.length
-  const maxVisibleItems = 4
-  const visibleItems = Math.min(itemCount, maxVisibleItems)
-  const calculatedHeight =
-    visibleItems > 0
-      ? visibleItems * 48 + (visibleItems - 1) * 5 + 10 // 항목 높이 + gap + padding
-      : 0
-
-  const dropdownListStyle =
-    isOpen && containerRef.current
-      ? {
-          top: `${containerRef.current.getBoundingClientRect().bottom + 4}px`,
-          left: `${containerRef.current.getBoundingClientRect().left}px`,
-          width: `${containerRef.current.getBoundingClientRect().width}px`,
-          height: `${calculatedHeight}px`,
-        }
-      : undefined
-
-  return (
-    <>
-      <div
-        ref={containerRef}
-        className="relative w-full text-[14px]"
-        style={{ minWidth: '348px' }}
-      >
-        <button
-          type="button"
-          onClick={handleToggle}
-          disabled={disabled}
-          className={clsx(
-            'flex h-[48px] w-full items-center justify-between px-[16px] py-[10px]',
-            'border-mono-400 rounded-[4px] border bg-white',
-            disabled ? 'bg-mono-200 cursor-not-allowed' : 'cursor-pointer'
-          )}
-          style={
-            disabled
-              ? { backgroundColor: '#ECECEC', borderColor: '#BDBDBD' }
-              : undefined
-          }
-        >
-          <span className="block truncate" style={{ color: textColor }}>
-            {selectedOption ? selectedOption.label : placeholder}
-          </span>
-          <span className="inline-flex items-center">
-            <img
-              src={iconSrc}
-              alt=""
-              className={clsx(
-                'h-[8px] w-[14px] transition-transform duration-200 ease-out',
-                isOpen ? 'rotate-180' : 'rotate-0'
-              )}
-            />
-          </span>
-        </button>
-      </div>
-      {/* 드롭다운 리스트를 모달 외부에 포털로 렌더링 */}
-      {isOpen &&
-        modalRootRef.current &&
-        createPortal(
-          <div
-            ref={dropdownListRef}
-            className={clsx(
-              'dropdown-scrollbar fixed z-[60] flex flex-col gap-[5px] overflow-x-hidden overflow-y-auto',
-              'border-mono-400 rounded-[4px] border bg-white py-[5px]',
-              'origin-top transition-all duration-200 ease-out',
-              'scale-100 opacity-100'
-            )}
-            style={dropdownListStyle}
-          >
-            {options.map((option) => {
-              const isSelected =
-                String(option.value) === String(value) &&
-                value !== undefined &&
-                value !== ''
-              return (
-                <button
-                  key={option.value}
-                  type="button"
-                  onClick={(e) => handleSelect(option.value, e)}
-                  className={clsx(
-                    'mx-auto flex h-[48px] w-[calc(100%-10px)] items-center justify-between px-[11px] py-[10px]',
-                    'gap-[16px] rounded-[4px] text-left font-normal',
-                    isSelected ? 'bg-white' : 'bg-white hover:bg-[#EFE6FC]'
-                  )}
-                  style={{
-                    color: isSelected ? '#6201E0' : '#4D4D4D',
-                  }}
-                >
-                  <span className="flex-1 truncate">{option.label}</span>
-                  {isSelected && (
-                    <svg
-                      width="13"
-                      height="11"
-                      viewBox="0 0 13 11"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M1 5.5L4.5 9L12 1"
-                        stroke="#6201E0"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      />
-                    </svg>
-                  )}
-                </button>
-              )
-            })}
-          </div>,
-          modalRootRef.current
-        )}
-    </>
-  )
 }
 
 export function RegisterStudentModal({
   isOpen,
   onClose,
-  onSuccess,
 }: RegisterStudentModalProps) {
   const methods = useForm<RegisterStudentFormData>({
     resolver: zodResolver(registerStudentSchema),
@@ -260,39 +31,64 @@ export function RegisterStudentModal({
   const courseValue = methods.watch('course')
   const batchValue = methods.watch('batch')
 
-  // 선택된 과정에 해당하는 기수 옵션 필터링
-  const selectedCourse = mockCourses.find((course) => course.id === courseValue)
-  const batchOptions = selectedCourse
-    ? selectedCourse.batches.map((batch) => ({
-        label: `${batch}기`,
-        value: `${batch}`,
-      }))
-    : []
+  // 과정 리스트 (모달 열릴 때만) / 기수는 과정 선택 시 해당 과정의 기수 목록 조회
+  const { data: courses = [] } = useQuery({
+    queryKey: ['courses'],
+    queryFn: fetchCourses,
+    enabled: isOpen,
+  })
 
-  // 과정이 변경되면 기수 선택 초기화
+  const selectedCourseId = courseValue ? Number(courseValue) : null
+  const { data: cohorts = [] } = useQuery({
+    queryKey: ['cohorts', selectedCourseId],
+    queryFn: () => {
+      if (!selectedCourseId) throw new Error('과정을 선택해주세요.')
+      return fetchCohorts(selectedCourseId)
+    },
+    enabled: isOpen && selectedCourseId != null,
+  })
+
+  const enrollMutation = useMutation({
+    mutationFn: enrollStudent,
+    onSuccess: onClose,
+  })
+
+  // 과정 옵션: API 과정 목록
+  const courseOptions = courses.map((c) => ({
+    label: c.name, 
+    value: String(c.id),
+  }))
+
+  const batchOptions = cohorts.map((c) => ({
+    label: `${c.number}기`,
+    value: String(c.id),
+  }))
+
   useEffect(() => {
-    if (courseValue && batchValue) {
-      const selectedCourseData = mockCourses.find(
-        (course) => course.id === courseValue
-      )
-      if (
-        selectedCourseData &&
-        !selectedCourseData.batches.includes(Number(batchValue))
-      ) {
-        methods.setValue('batch', '')
-      }
-    } else if (!courseValue) {
-      methods.setValue('batch', '')
+    methods.setValue('batch', '')
+    // courseValue 변경 시에만 기수 초기화 (methods 의존 시 매 렌더마다 실행 방지)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [courseValue])
+
+  useEffect(() => {
+    if (!isOpen) {
+      methods.reset()
+      enrollMutation.reset()
     }
-  }, [courseValue, batchValue, methods])
+    // isOpen만 의존 (methods, enrollMutation 포함 시 불필요한 리셋 방지)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen])
 
   const onSubmit = (data: RegisterStudentFormData) => {
-    onSuccess?.(data)
-    onClose()
+    enrollMutation.mutate(Number(data.batch))
   }
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      className="min-w-[396px] min-h-[410px]"
+    >
       <Modal.Header>
         <div className="flex flex-col items-center gap-2">
           <img
@@ -318,12 +114,15 @@ export function RegisterStudentModal({
         <FormProvider {...methods}>
           <form onSubmit={methods.handleSubmit(onSubmit)} className="space-y-4">
             <Modal.InputRow label="">
-              <ModalDropdown
-                options={courseOptions}
-                value={courseValue}
-                onChange={(value) => methods.setValue('course', value)}
-                placeholder="과정을 선택해주세요"
-              />
+              <div className="w-full">
+                <Dropdown
+                  options={courseOptions}
+                  value={courseValue}
+                  onChange={(value) => methods.setValue('course', value)}
+                  placeholder="과정을 선택해주세요"
+                  renderListInPortal
+                />
+              </div>
               {methods.formState.errors.course && (
                 <p className="text-error mt-1 text-sm">
                   {methods.formState.errors.course.message}
@@ -332,13 +131,16 @@ export function RegisterStudentModal({
             </Modal.InputRow>
 
             <Modal.InputRow label="">
-              <ModalDropdown
-                options={batchOptions}
-                value={batchValue}
-                onChange={(value) => methods.setValue('batch', value)}
-                placeholder="기수를 선택해주세요"
-                disabled={!courseValue}
-              />
+              <div className="w-full">
+                <Dropdown
+                  options={batchOptions}
+                  value={batchValue}
+                  onChange={(value) => methods.setValue('batch', value)}
+                  placeholder="기수를 선택해주세요"
+                  disabled={!courseValue}
+                  renderListInPortal
+                />
+              </div>
               {methods.formState.errors.batch && (
                 <p className="text-error mt-1 text-sm">
                   {methods.formState.errors.batch.message}
@@ -346,15 +148,20 @@ export function RegisterStudentModal({
               )}
             </Modal.InputRow>
 
+            {enrollMutation.isError && (
+              <p className="text-sm text-red-500">
+                등록 신청에 실패했습니다. 다시 시도해 주세요.
+              </p>
+            )}
             <div className="pt-4">
               <Button
                 type="submit"
                 variant="primary"
                 size="xl"
                 className="w-full"
-                style={{ minWidth: '348px' }}
+                disabled={enrollMutation.isPending}
               >
-                등록 신청 하기
+                {enrollMutation.isPending ? '등록 중...' : '등록신청'}
               </Button>
             </div>
           </form>

--- a/src/components/common/Modal/variants/RegisterStudentModal.tsx
+++ b/src/components/common/Modal/variants/RegisterStudentModal.tsx
@@ -354,7 +354,7 @@ export function RegisterStudentModal({
                 className="w-full"
                 style={{ minWidth: '348px' }}
               >
-                등록하기
+                등록 신청 하기
               </Button>
             </div>
           </form>

--- a/src/mocks/data/cohorts.json
+++ b/src/mocks/data/cohorts.json
@@ -1,0 +1,16 @@
+[
+  { "id": 101, "course_id": 1, "number": 10, "status": "FINISHED" },
+  { "id": 102, "course_id": 1, "number": 11, "status": "IN_PROGRESS" },
+  { "id": 103, "course_id": 1, "number": 12, "status": "PREPARING" },
+  { "id": 201, "course_id": 2, "number": 10, "status": "FINISHED" },
+  { "id": 202, "course_id": 2, "number": 11, "status": "PREPARING" },
+  { "id": 203, "course_id": 2, "number": 12, "status": "PREPARING" },
+  { "id": 301, "course_id": 3, "number": 9, "status": "FINISHED" },
+  { "id": 302, "course_id": 3, "number": 10, "status": "IN_PROGRESS" },
+  { "id": 303, "course_id": 3, "number": 11, "status": "PREPARING" },
+  { "id": 401, "course_id": 4, "number": 1, "status": "FINISHED" },
+  { "id": 402, "course_id": 4, "number": 2, "status": "PREPARING" },
+  { "id": 403, "course_id": 4, "number": 3, "status": "PREPARING" },
+  { "id": 501, "course_id": 5, "number": 1, "status": "FINISHED" },
+  { "id": 502, "course_id": 5, "number": 2, "status": "PREPARING" }
+]

--- a/src/mocks/data/courses.json
+++ b/src/mocks/data/courses.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": 1,
+    "name": "웹 개발 초격차 프론트엔드 부트캠프",
+    "tag": "frontend",
+    "thumbnail_img_url": ""
+  },
+  {
+    "id": 2,
+    "name": "웹 개발 초격차 백엔드 부트캠프",
+    "tag": "backend",
+    "thumbnail_img_url": ""
+  },
+  {
+    "id": 3,
+    "name": "IT 스타트업 실무형 사업 개발자(BD) 부트캠프",
+    "tag": "bd",
+    "thumbnail_img_url": ""
+  },
+  {
+    "id": 4,
+    "name": "스타트업 맞춤형 프로덕트 디자이너",
+    "tag": "designer",
+    "thumbnail_img_url": ""
+  },
+  {
+    "id": 5,
+    "name": "IT스타트업 실무형 풀스택 웹 개발 부트캠프 (React + Node.js)",
+    "tag": "fullstack",
+    "thumbnail_img_url": ""
+  }
+]

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -6,6 +6,11 @@ import { examDeploymentsHandler } from './handlers/quiz/examDeployments'
 import { examSubmissionHandler } from './handlers/quiz/examSubmission'
 import { examSubmissionResultHandler } from './handlers/quiz/examSubmissionResult'
 import { authHandlers } from './handlers/auth.mock'
+import {
+  coursesHandler,
+  cohortsHandler,
+  enrollStudentHandler,
+} from './handlers/info'
 
 export const helloHandler = http.get('/api/hello', () => {
   return HttpResponse.json({ message: 'Hello, world!', code: 200 })
@@ -21,4 +26,8 @@ export const handlers = [
   examDeploymentStatusHandler,
   examSubmissionHandler,
   examSubmissionResultHandler,
+  // Info (수강생 등록) 핸들러들
+  coursesHandler,
+  cohortsHandler,
+  enrollStudentHandler,
 ]

--- a/src/mocks/handlers/info/cohorts.ts
+++ b/src/mocks/handlers/info/cohorts.ts
@@ -1,0 +1,25 @@
+import { http, HttpResponse } from 'msw'
+import cohorts from '@/mocks/data/cohorts.json'
+import type { Cohort } from '@/types/info'
+import { unauthorizedResponse } from './constants'
+
+const list = cohorts as Cohort[]
+
+export const cohortsHandler = http.get(
+  '/api/v1/:courseId/cohorts',
+  ({ request, params }) => {
+    const res = unauthorizedResponse(request)
+    if (res) return res
+
+    const courseId = Number(params.courseId)
+    if (Number.isNaN(courseId)) {
+      return HttpResponse.json(
+        { error_detail: 'course_id는 숫자여야 합니다.' },
+        { status: 400 }
+      )
+    }
+
+    const filtered: Cohort[] = list.filter((c) => c.course_id === courseId)
+    return HttpResponse.json(filtered)
+  }
+)

--- a/src/mocks/handlers/info/constants.ts
+++ b/src/mocks/handlers/info/constants.ts
@@ -1,0 +1,11 @@
+import { HttpResponse } from 'msw'
+
+export const UNAUTHORIZED_MESSAGE = '자격 인증 데이터가 제공되지 않았습니다.'
+export const FORBIDDEN_MESSAGE = '이 리소스를 조회할 권한이 없습니다.'
+
+export function unauthorizedResponse(request: Request) {
+  if (!request.headers.get('Authorization')?.startsWith('Bearer ')) {
+    return HttpResponse.json({ error_detail: UNAUTHORIZED_MESSAGE }, { status: 401 })
+  }
+  return null
+}

--- a/src/mocks/handlers/info/courses.ts
+++ b/src/mocks/handlers/info/courses.ts
@@ -1,0 +1,12 @@
+import { http, HttpResponse } from 'msw'
+import courses from '@/mocks/data/courses.json'
+import { FORBIDDEN_MESSAGE, unauthorizedResponse } from './constants'
+
+export const coursesHandler = http.get('/api/v1/course/', ({ request }) => {
+  const res = unauthorizedResponse(request)
+  if (res) return res
+  if (request.headers.get('X-Mock-Forbidden') === 'true') {
+    return HttpResponse.json({ error_detail: FORBIDDEN_MESSAGE }, { status: 403 })
+  }
+  return HttpResponse.json(courses)
+})

--- a/src/mocks/handlers/info/enrollStudent.ts
+++ b/src/mocks/handlers/info/enrollStudent.ts
@@ -1,0 +1,18 @@
+import { http, HttpResponse } from 'msw'
+import { unauthorizedResponse } from './constants'
+
+const COHORT_ID_REQUIRED = { error_detail: { cohort_id: ['이 필드는 필수 항목입니다.'] } }
+
+export const enrollStudentHandler = http.post(
+  '/api/v1/accounts/enroll-student/',
+  async ({ request }) => {
+    const res = unauthorizedResponse(request)
+    if (res) return res
+
+    const body = (await request.json()) as { cohort_id?: number }
+    if (body.cohort_id == null || typeof body.cohort_id !== 'number') {
+      return HttpResponse.json(COHORT_ID_REQUIRED, { status: 400 })
+    }
+    return HttpResponse.json({ detail: '수강 신청이 완료되었습니다.' })
+  }
+)

--- a/src/mocks/handlers/info/index.ts
+++ b/src/mocks/handlers/info/index.ts
@@ -1,0 +1,4 @@
+export * from './constants'
+export * from './courses'
+export * from './cohorts'
+export * from './enrollStudent'

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -158,6 +158,17 @@ function QuizPage() {
     handleAutoSubmit();
   }
 
+  // 응시 페이지를 떠날 때 전체화면 해제 (제출 완료, 시간/상태 종료 )
+  const exitFullscreenIfActive = useCallback(async () => {
+    if (document.fullscreenElement) {
+      try {
+        await document.exitFullscreen()
+      } catch {
+        // ignore
+      }
+    }
+  }, [])
+
   // 제출 데이터 생성
   const buildSubmitPayload = () => {
     if (!data?.questions) return null
@@ -187,12 +198,15 @@ function QuizPage() {
 
   const handleSubmitCompleteConfirm = () => {
     setIsSubmitCompleteModalOpen(false)
-    if (submittedSubmissionId !== null) {
-      navigate(`/quiz/result/${submittedSubmissionId}`)
-      setSubmittedSubmissionId(null)
-    } else {
-      navigate('/mypage/quiz')
+    const goTo = () => {
+      if (submittedSubmissionId !== null) {
+        navigate(`/quiz/result/${submittedSubmissionId}`)
+        setSubmittedSubmissionId(null)
+      } else {
+        navigate('/mypage/quiz')
+      }
     }
+    exitFullscreenIfActive().then(goTo)
   }
 
   useEffect(() => {
@@ -280,17 +294,17 @@ function QuizPage() {
   const showQuizEndModal = isEnded && endReason === 'status'
 
   const handleEndConfirm = () => {
-    navigate('/mypage/quiz')
+    exitFullscreenIfActive().then(() => navigate('/mypage/quiz'))
   }
 
   // 상태 종료 시 QuizEndModal 표시 후 5초 뒤 쪽지시험 리스트로 이동
   useEffect(() => {
     if (!showQuizEndModal) return
     const timer = window.setTimeout(() => {
-      navigate('/mypage/quiz')
+      exitFullscreenIfActive().then(() => navigate('/mypage/quiz'))
     }, 5000)
     return () => window.clearTimeout(timer)
-  }, [showQuizEndModal, navigate])
+  }, [showQuizEndModal, navigate, exitFullscreenIfActive])
 
   const handleTimeEndTest = () => {
     setRemainingSeconds(0)
@@ -308,7 +322,7 @@ function QuizPage() {
       await document.documentElement.requestFullscreen()
       setIsFullscreenModalOpen(false)
     } catch {
-      // ignore
+      //전체화면 해제 실패 시 무시
     }
   }
 

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -211,9 +211,6 @@ function TestPage() {
       <RegisterStudentModal
         isOpen={registerStudentOpen}
         onClose={() => setRegisterStudentOpen(false)}
-        onSuccess={() => {
-          setRegisterStudentOpen(false)
-        }}
       />
 
       <WithdrawalReasonModal

--- a/src/types/info.ts
+++ b/src/types/info.ts
@@ -13,6 +13,23 @@ export type CourseEnrollment = {
     thumbnail_img_url: string
   }
 }
+
+/** 과정 리스트 조회 응답 항목 (GET /api/v1/course/) */
+export type Course = {
+  id: number
+  name: string
+  tag: string
+  thumbnail_img_url: string
+}
+
+/** 기수 리스트 조회 응답 항목 (GET /api/v1/:course_id/cohorts) */
+export type Cohort = {
+  id: number
+  course_id: number
+  number: number
+  status: 'PREPARING' | 'IN_PROGRESS' | 'FINISHED'
+}
+
 export type ApiErrorResponse = {
   error_detail: string
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -9,6 +9,7 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #130 

## 📑 구현 사항

- **타입·API**
  - `Course`, `Cohort` 타입 추가 (`src/types/info.ts`)
  - 과정 목록 조회 `fetchCourses()`, 기수 목록 조회 `fetchCohorts(courseId)`, 수강생 등록 `enrollStudent(cohortId)` API 함수 추가 (`src/api/info.ts`)
- **수강생 등록 모달**
  - 새 API 스펙에 맞게 과정 → 기수 2단계 선택으로 리팩터링
  - React Query `useMutation`으로 등록 처리 및 로딩/에러 상태 처리
  - 불필요한 콜백·코드 제거
- **Dropdown**
  - 모달 내부에서 리스트가 잘리지 않도록 `renderListInPortal` 옵션 추가 (포털 렌더링)
- **MSW 모킹**
  - 과정 목록 `GET /api/v1/course/`, 기수 목록 `GET /api/v1/:courseId/cohorts`, 수강생 등록 `POST /api/v1/accounts/enroll-student/` 핸들러 및 mock 데이터 추가
- **기타**
  - `tsconfig.app.json`에 `resolveJsonModule: true` 추가 (JSON mock import)
  - `TestPage`에서 `RegisterStudentModal`의 `onSuccess` prop 제거

## 🌀 어려웠던 점 / 고민했던 부분

- 모달의 `overflow` 때문에 드롭다운 리스트가 잘리는 문제 → Dropdown에 포털 렌더링 옵션을 두어 모달 바깥에 리스트를 그리도록 처리했습니다.
- API 연결 후 확인을 위해 백엔드에 기수 데이터가 생성이 필요했고, 과정 조회(스웨거) > 기수 데이터 추가(스웨거) > 수강등록요청(FE) > 수강등록요청수락(스웨거) > 수강생등록확인(스웨거) 하는 과정이 너무 어려웠습니다.

## 📸 구현 이미지

- (스크린샷 첨부)

## ❇️ 코드 설명

- **과정/기수 API**: `GET /api/v1/course/`로 과정 목록, `GET /api/v1/:courseId/cohorts`로 해당 과정의 기수 목록을 조회합니다. 수강생 등록은 `POST /api/v1/accounts/enroll-student/`에 `cohort_id`를 담아 요청합니다.
- **Cohort status**: `PREPARING` | `IN_PROGRESS` | `FINISHED` 기준으로 모달에서 노출/필터링합니다.


## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.