### PR TITLE
feat: 소셜 로그인 콜백 페이지 및 라우트 추가, 인증 상태 업데이트 로직 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import TestPage from '@/pages/TestPage'
 import LoginPage from '@/pages/LoginPage'
 import SignupPage from '@/pages/SignupPage'
 import SignupEmailPage from '@/pages/SignupEmailPage'
+import SocialLoginCallbackPage from '@/pages/SocialLoginCallbackPage'
 import MyPage from '@/pages/MyPage'
 import MyPageQuiz from '@/components/MyPageQuiz'
 import QuizPage from '@/pages/QuizPage'
@@ -26,6 +27,11 @@ function App() {
           <Route path="/qna" element={<div>질의응답 페이지</div>} />
           <Route path="/test" element={<TestPage />} />
           <Route path="/login" element={<LoginPage />} />
+          <Route path="/auth/callback" element={<SocialLoginCallbackPage />} />
+          <Route
+            path="/auth/callback/:provider"
+            element={<SocialLoginCallbackPage />}
+          />
           <Route path="/signup" element={<SignupPage />} />
           <Route path="/signup/email" element={<SignupEmailPage />} />
 

--- a/src/pages/SocialLoginCallbackPage.tsx
+++ b/src/pages/SocialLoginCallbackPage.tsx
@@ -1,0 +1,93 @@
+﻿import { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { Button } from '@/components/common/Button'
+import Loading from '@/components/common/Loading'
+import * as authApi from '@/api/auth'
+import { useAuthStore } from '@/store/authStore'
+
+const getCookie = (name: string): string | null => {
+  const raw = document.cookie
+    .split(';')
+    .find((cookie) => cookie.trim().startsWith(`${name}=`))
+    ?.split('=')
+    .slice(1)
+    .join('=')
+
+  if (!raw) return null
+  return decodeURIComponent(raw)
+}
+
+const SOCIAL_ERROR_MESSAGE: Record<string, string> = {
+  KAKAO_ERROR_001: '토큰 또는 사용자 정보를 불러오지 못했습니다.',
+  KAKAO_ERROR_002: '카카오 로그인 중 알 수 없는 오류가 발생했습니다.',
+  NAVER_ERROR_001: '토큰 또는 사용자 정보를 불러오지 못했습니다.',
+  NAVER_ERROR_002: '네이버 로그인 중 알 수 없는 오류가 발생했습니다.',
+}
+
+export default function SocialLoginCallbackPage() {
+  const navigate = useNavigate()
+  const setAuth = useAuthStore((s) => s.setAuth)
+  const hasRunRef = useRef(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (hasRunRef.current) return
+    hasRunRef.current = true
+
+    const params = new URLSearchParams(window.location.search)
+    const errorCode = params.get('error_code')
+
+    if (errorCode) {
+      setErrorMessage(
+        SOCIAL_ERROR_MESSAGE[errorCode] ??
+          '소셜 로그인 중 알 수 없는 오류가 발생했습니다.'
+      )
+      return
+    }
+
+    const token = getCookie('access_token')
+
+    if (!token) {
+      setErrorMessage('인증 토큰을 찾을 수 없습니다. 다시 로그인해주세요.')
+      return
+    }
+
+    const restoreSession = async () => {
+      try {
+        const user = await authApi.me(token)
+        setAuth({ accessToken: token, user })
+        navigate('/', { replace: true })
+      } catch {
+        setErrorMessage(
+          '로그인 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.'
+        )
+      }
+    }
+
+    void restoreSession()
+  }, [navigate, setAuth])
+
+  if (!errorMessage) {
+    return (
+      <div className="flex h-[calc(100vh-96px)] flex-col items-center justify-center gap-6 bg-white px-4">
+        <p className="text-mono-700 text-base">로그인 처리 중입니다.</p>
+        <Loading />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-[calc(100vh-96px)] flex-col items-center justify-center gap-6 bg-white px-4">
+      <p className="text-center text-base text-red-500">{errorMessage}</p>
+      <Button
+        type="button"
+        variant="primary"
+        className="h-12 w-[220px]"
+        onClick={() => navigate('/login', { replace: true })}
+      >
+        로그인 페이지로 이동
+      </Button>
+    </div>
+  )
+}

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -9,7 +9,7 @@ type AuthState = {
   user: User | null
   isAuthenticated: boolean
 
-  setAuth: (payload: { accessToken: string; user: User }) => void
+  setAuth: (payload: { accessToken: string | null; user: User }) => void
   clearAuth: () => void
 
   login: (payload: LoginPayload) => Promise<void>


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #113 

## 📑 구현 사항

- 소셜 로그인 콜백 처리 페이지 추가
   - 콜백 진입 시 access_token 쿠키를 읽어 로그인 세션 복원 처리
   - authApi.me(token)으로 사용자 정보 조회 후 useAuthStore.setAuth로 전역 상태 저장
   - 처리 중에는 로딩 UI 표시 (Loading 컴포넌트 사용)
   - 실패 시 에러 메시지 + 로그인 페이지 이동 버튼 제공
- 소셜 로그인 에러 코드 매핑
   - error_code 쿼리 파라미터를 읽어 카카오/네이버 에러 코드별 사용자 메시지 매핑
   - 미등록 코드에 대한 기본 에러 메시지 fallback 처리
- 콜백 라우트 연결


## 🌀 어려웠던 점 / 고민했던 부분

-

## 📸 구현 이미지

-

## ❇️ 코드 설명

- 소셜로그인 성공 후 callback 페이지 구현( 쿠키로 내려온 access token 으로 로그인 상태 저장 )

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1. 백엔드에 callback url 넘겨둔 상태입니다.
    - http://localhost:5173/auth/callback
    - https://my.ozcodingschool.site/auth/callback
2. 쿠키 내려줄때 access token이 일반 쿠키 형태로 내려오는지 확인 요청해두었습니다.