### PR TITLE
[feat] 쪽지시험 응시/결과 페이지 리팩토링 및 API연결 & 푸터 추가 (#134)

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -142,3 +142,8 @@ export async function resetPassword(
     new_password: payload.newPassword,
   })
 }
+
+export async function updateMyInfo(payload: Partial<User>): Promise<User> {
+  const { data } = await apiClient.patch<User>('/api/v1/accounts/me/', payload)
+  return data
+}

--- a/src/api/quiz.ts
+++ b/src/api/quiz.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/api/client'
+import { useAuthStore } from '@/store/authStore'
 import {
   mapExamDeploymentsResult,
   type ExamDeploymentsResponse,
@@ -99,9 +100,17 @@ export interface ExamSubmissionPayload {
  * const data = await submitExam(payload)
  */
 export const submitExam = async (payload: ExamSubmissionPayload) => {
+  // 로그인 상태의 액세스 토큰을 Authorization 헤더로 포함
+  const accessToken = useAuthStore.getState().accessToken
+  const config =
+    accessToken && accessToken !== ''
+      ? { headers: { Authorization: `Bearer ${accessToken}` } }
+      : undefined
+
   const response = await apiClient.post<ExamSubmissionResponse>(
     '/api/v1/exams/submissions',
-    payload
+    payload,
+    config
   )
   return mapExamSubmissionResult(response.data)
 }

--- a/src/api/refresh.ts
+++ b/src/api/refresh.ts
@@ -1,0 +1,9 @@
+import { apiClient } from '@/api/client'
+
+export async function refreshToken(refreshToken: string) {
+  const { data } = await apiClient.post<{ access_token: string }>(
+    '/api/v1/accounts/me/refresh/',
+    { refresh_token: refreshToken }
+  )
+  return data.access_token
+}

--- a/src/components/MyInfo.tsx
+++ b/src/components/MyInfo.tsx
@@ -3,22 +3,21 @@ import { Button } from './common'
 import { ViewMyInfo } from './myinfo/ViewMyInfo'
 import { EditMyInfo } from './myinfo/EditMyInfo'
 import type { User } from '@/types/auth'
-import type { CourseEnrollment } from '@/types/info'
 import { me } from '@/api/auth'
 import { getMyCourses } from '@/api/info'
+import { updateMyInfo } from '@/api/auth'
+import { useMyInfoStore } from '@/store/myInfoStore'
 
 export default function MyInfo() {
   const [isEdit, setIsEdit] = useState(false)
   const [user, setUser] = useState<User | null>(null)
-  const [courses, setCourses] = useState<CourseEnrollment[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const [userData, courseData] = await Promise.all([me(), getMyCourses()])
+        const [userData] = await Promise.all([me(), getMyCourses()])
         setUser(userData)
-        setCourses(courseData)
       } catch (e) {
         console.error('내 정보 조회 실패', e)
       } finally {
@@ -31,13 +30,37 @@ export default function MyInfo() {
 
   const handleSave = async () => {
     if (!user) return
+    const { nickname, phone, nicknameStatus, phoneStatus, error } =
+      useMyInfoStore.getState()
+    // 닉네임 중복검사 통과 또는 전화번호 인증 완료 시만 저장
+    const canPatch = nicknameStatus === 'success' || phoneStatus === 'success'
+    if (!canPatch) {
+      if (error) {
+        alert(error)
+        return
+      }
+      setIsEdit(false)
+      return
+    }
     try {
-      // await updateMyInfo(user)
+      const updated = await updateMyInfo({
+        nickname: nicknameStatus === 'success' ? nickname : user.nickname,
+        phone_number: phoneStatus === 'success' ? phone : user.phone_number,
+      })
+      setUser(updated)
       setIsEdit(false)
     } catch (e) {
       console.error('내 정보 저장 실패', e)
     }
   }
+
+  const handleEdit = () => {
+    // 번호 인증 관련 zustand 상태 초기화
+    useMyInfoStore.getState().reset()
+    setIsEdit(true)
+  }
+
+  // 저장 버튼 활성화 조건 계산 관련 미사용 변수 삭제
 
   if (loading) return <div>로딩중...</div>
   if (!user) return <div>정보를 불러올 수 없습니다.</div>
@@ -48,17 +71,17 @@ export default function MyInfo() {
         <div className="title-xl">내 정보</div>
         <Button
           size="md"
-          onClick={() => (isEdit ? handleSave() : setIsEdit(true))}
+          onClick={() => (isEdit ? handleSave() : handleEdit())}
         >
           {isEdit ? '저장하기' : '수정하기'}
         </Button>
       </div>
 
       {isEdit ? (
-        <EditMyInfo user={user} onChange={setUser} />
+        <EditMyInfo user={user} />
       ) : (
         <>
-          <ViewMyInfo user={user} courses={courses} />
+          <ViewMyInfo />
         </>
       )}
     </>

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,0 +1,151 @@
+export default function Footer() {
+    return (
+      <footer className="w-full bg-[#222222]">
+        {/* 
+          - 피그마: 바깥 1920 기준 / 안쪽 content 1200
+          - 반응형: 1200은 유지하되, 작은 화면에서는 w-full + px만 줄이기
+        */}
+        <div className="mx-auto w-full max-w-[1920px] px-[20px] py-[80px] sm:px-[32px] md:px-[48px] lg:px-[80px] xl:px-[360px]">
+          {/* content width = 1200 (큰 화면에선 정확히 1200, 작은 화면에선 꽉 차게) */}
+          <div className="mx-auto w-full max-w-[1200px]">
+            {/*
+                TOP (logo + camp list)*/}
+            <div className="w-full">
+              {/* OZ logo*/}
+              <div className="h-[24px] w-[159px]">
+                <svg
+                  width="159"
+                  height="24"
+                  viewBox="0 0 159 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                >
+                  <rect
+                    width="159"
+                    height="23.7105"
+                    fill="url(#pattern0_91_14382)"
+                  />
+                  <defs>
+                    <pattern
+                      id="pattern0_91_14382"
+                      patternContentUnits="objectBoundingBox"
+                      width="1"
+                      height="1"
+                    >
+                      <use
+                        xlinkHref="#image0_91_14382"
+                        transform="scale(0.00438596 0.0294118)"
+                      />
+                    </pattern>
+                    <image
+                      id="image0_91_14382"
+                      width="228"
+                      height="34"
+                      preserveAspectRatio="none"
+                      xlinkHref="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOQAAAAiCAYAAABP5nUkAAAACXBIWXMAABYlAAAWJQFJUiTwAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAi1SURBVHgB7ZxNdts2EMdHfV10V/cEQU4Q9QSRT1D3BKF33dk5gZUT2Nl10yf6BHZOIPUEdk5A3kDOru1min8A2hQ0AEGQVOiYv/f4KJH45mAwGIAkmpiYGA0zmpgYAcy80KcL5/LH2Wx2Sy+IH2kCwqD0STmXH7Qw3NPEoVD6WDjXrmlEWKWxon4ptZwdV39eZIfUDXukT5k+ftPHXB9HnnA4bcgIxkY3XEnx6c9pGLyKwiqWBfUPhGYj5Ic6nlAaVzrNBxoIXbY17bfFqc4zp24oGpAX1yH1gzrTpyV5OqHAwh6Iu9QP9ENEHAjqmoZho49jzz1F/WvwKs+NcB31vKA0cn0M1iGfK40d0mrBurYvyWjMkp4RdtSCsKZqdLDU6WT6fPzc6j/RC1AgG+qG1yIDYoe0pg9Gkoz85lypTxgtvKacNRsUpYF0T6k/fJ0RjQwT8DPtauw3ZEZGt/5KH2tdt1+HNLkmOqOEa7FWkYidKhxTB7TcFNSmQ+oIl/p0Ts0oMkJe6jgfPLa5ovQOqagn7KgmdUYolOBcxsa9cMqj7LX3nmilTTvEKzIKrw7K8bEhXtlwL8akbgLKOFV40SaNzrAhLQyPkw7AZ3BFaWmiPfDMQ+1y1HBfUaxcI0N93HE6F0KaBafT2xzMU46sRXylj62QRrLGRf5CelsaAUJ7rT3hpDosKAFPWhkloONdsMy24zMbgrt6Hj/UfmO06+IZxPwqZmQ9KGwERDmX8zbeNqvNpZEro3TeCteOOFGge0bRM4XN6Jh5bqMzdpHRkvpnxzr7arKy36SrR6rMkNCk9EKndduTOVJSP0hl/Zvak9O+R1FRAg1C8466Ow5eMu70Yu++bv+NtIwTwX0t7Qfa7Uz1/2Xt+pfadcjimZPml/qfag55ESjAe7fwtgNf0r6wV3Z25YxpmgAjDUkRlNTPXKgq05jSAaGlAphu120Fxppide3/ygmiar+luY4iP1/oGcBm2pQ5l9EZ3LqudNjWnnId/nfqgLV+3A65M9/+0XYuJcQvybj3H4SC5ToeEsLcwq3sib6HTvwQqjCb9UDfqHza46S/FK6lmObzyLSDeITGJUlgKH1NsIlRzG198JPDRTJH4WSC1bGoXVNkPOWnTYrPdqIF9cMb6ZrOY2l/PyDDG89kU1EDSMgT96Qhns9JwrXC9QIbZ5Wb1zamfk4ahVDWVh2bZWcDynLluZ61TL/gYVh68hMdMWyeb/2Y62Nh753r45KN3BVV2pzo1LHpFp5yX9kwKhBmxQFZYL+MD0GBDCXPapSHk42gSlw1xCm8BRoAlhsVZVARcZWnje5a5A+hWXvqfG7D+O6vOLLjs1+5SmxtGxQ277XNa+0ro5Bfxt1ZBdLKPPlChs7Z32bgzokDpbANlYMFhxofuENiDik97M8UAcxSNhsElHPr50A036QbpnGnRdcAUBDvaH8tsdDl3+jzJzK2fDUxV/bAutWC9s1yhAnOJ9h09pNaGhJYv62UF9KDInSfR0ZmXnlvyxlySGDP7WeSHQzV+aFh3fVcKG9Jw/FLbEDbpjGbTdAOO0oEi/o6PuTrxhM/I9PO+J33vCklHk9PXbaIXwjxV56wZwHtMOiSCYfNljYETUk2o+E2Ip2lEBeaP+c4+nQy1csgmc9zT9g+Rsh1IK1MyHMdSAvtHpQjNnKw5jBZLfwR75vgvkOqw1WL+AojpOSFekXxRAkGG+229NzOayPFIMBBwkZDLsmMlilsyHid7wP5bHQ+UptWlGScVhshLuLhoeJeyH2ft922x2YH1tzJT7JI3gjl8tU3tLezPkqDyv1f1s5lwvZDeN8XwvWcjMVRhiLb+8cs78AiW6a8Fv6xHmyUYEjepbowNbBTZpZHjaj5ke3VEksnXHDeyC0cLH3AZhRrM99ac4Ojyklf0pTQ3ktuMbLZdAohLUUtYWFU8IRzR/fouXIXuN0ccl2VrW2bCmlhVSCv1TsLhI21XloRm8kiojKrmLhsvGqcms9QsFEU6JySmbZi87CSHjY/OUyuutaRjUMCTgwokSUlwBEdkmUn3S11xJYfbZk5B9p+bsMo+79++F5sUDyAyc4NzjM+UIdceMIVHHYHv/PE2zrhQvPGJY0ATxtk9B3BcR0Sgo4RZ2XD36W0A+96QWPm02zDZjRi+AAdcmYzwnKDEspQkrHZbytbn41mql7ylXj0ULHp0DB5JG3W6Kmk2tvxf/xUKPfmn/+8LqkH2Ixg7lJPH2+XjwYW3qDX9ZtRz7Ax7eHUSx3BSjLz9M4jc9/Yus2pG663f+c5VFvnsJvhRoiMiGjcFZvljaZJLcLUt7zdBMLjetN6Z052G95//84KIa/XNDEarMDeUDcU0sBoqeX0msbFhiJeLWsALxUo382vHRLaSDcA3mY4CySkqJn3jpdrENf8xPiw1tClcAuWEDpWSU/eVQDZQByMOJKQYu79aWQvgV9Ruoc+iscXlHXFz605e0ZpnI7JzGDBzR9AUhyY+0Y3PpYQ2KyBpbZfCli2qKYQTSj3AnvWixu49mxMmAt5QB5OYzoVm91d9XqgXhhx81qYLl+gaEvpWRYalJ0vBthOWZJpGEVxIHzjJt1vAARkQemkzBUqrX9IkGdGaWTUHt+ra1J7tRnh0HldxaKE/4q+Y/Y+4YEFejau7gWZBpIaGo0MW7rpQ7YIU1I6j1v4Zu4CNEzjxiXXiQNSCtfeUDxvI9McG/BxlNQT4keu7Dwwx8H73xiN/uJc1/fH6vzFatd8mDrj2IBidk1gWFyQnWoOWTr3K9lyX4+q2ND4wb5tRR2wDqwcv3t3e48Fbt7m1Cuz/t7fbAUP+1FmiXufGWrn0JfUD9gGt6QRgXVIGsipM8QS1MQEhHbJ3WjcIP6t4IE2BgCamBgKNjt+ILxFC5ms9voqGil8gA45DZMTg8JmDqno6eNo1buy9bc/Nt/K5G+Drcsg06ARrlJMTExMTEyMiP8BD5Nl8NPTP/8AAAAASUVORK5CYII="
+                    />
+                  </defs>
+                </svg>
+              </div>
+  
+              {/* Camp list: 18px / 140% / -3% / #CECECE */}
+              <ul className="font-pretendard mt-[24px] space-y-[16px] text-[18px] leading-[24px] font-[300] tracking-[-0.03em] text-[#CECECE]">
+                <li>
+                  <a href="#" className="hover:text-white">
+                    초격차캠프
+                  </a>
+                </li>
+                <li>
+                  <a href="#" className="hover:text-white">
+                    사업개발캠프
+                  </a>
+                </li>
+                <li>
+                  <a href="#" className="hover:text-white">
+                    프로젝트 디자이너 캠프
+                  </a>
+                </li>
+              </ul>
+            </div>
+  
+            {/* ======================
+                Divider + Policy + Company info
+                ====================== */}
+            <div className="mt-[40px] border-t border-[#707070] pt-[40px]">
+              {/* Policy row: 원본은 1200 x 64, 반응형에서는 w-full로 */}
+              <div className="flex min-h-[64px] w-full flex-col gap-[16px] sm:flex-row sm:items-center sm:justify-between">
+                {/* 정책 링크: 16px / 140% / -3% / #CECECE, gap 28 */}
+                <div className="font-pretendard flex flex-wrap items-center gap-x-[28px] gap-y-[10px] text-[16px] leading-[22.4px] font-[400] tracking-[-0.03em] text-[#CECECE]">
+                  <a href="#" className="hover:text-white">
+                    개인정보처리방침
+                  </a>
+                  <a href="#" className="hover:text-white">
+                    이용약관
+                  </a>
+                  <a href="#" className="hover:text-white">
+                    멘토링&강사지원
+                  </a>
+                </div>
+  
+                {/* Right icons: 132 x 24 */}
+                <div className="flex h-[24px] w-[132px] items-center justify-start sm:justify-end">
+                  <svg
+                    className="h-[24px] w-[132px]"
+                    viewBox="0 0 132 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12.5482 4C7.83195 4 4 7.1 4 10.9C4 13.3 5.57208 15.4 7.83195 16.7L7.24242 20L10.8779 17.6C11.3691 17.7 11.9587 17.7 12.4499 17.7C17.1662 17.7 20.9981 14.6 20.9981 10.8C21.0964 7.1 17.2645 4 12.5482 4Z"
+                      fill="#BDBDBD"
+                    />
+                    <path
+                      d="M41.7679 9.89258C41.5282 9.89258 41.3152 9.98703 41.1554 10.1624C40.9822 10.3379 40.9023 10.5537 40.9023 10.8101C40.9023 11.0665 40.9822 11.2689 41.1554 11.4578C41.3285 11.6332 41.5282 11.7277 41.7679 11.7277C42.0076 11.7277 42.2207 11.6332 42.3938 11.4578C42.567 11.2824 42.6602 11.0665 42.6602 10.8101C42.6602 10.5537 42.567 10.3379 42.3938 10.1624C42.2207 9.97354 42.021 9.89258 41.7679 9.89258Z"
+                      fill="#BDBDBD"
+                    />
+                    <path
+                      d="M49.2386 9.87891C48.9989 9.87891 48.7859 9.97336 48.6261 10.1488C48.4529 10.3242 48.373 10.5401 48.373 10.7964C48.373 11.0528 48.4529 11.2552 48.6261 11.4441C48.7992 11.6195 48.9989 11.714 49.2386 11.714C49.4783 11.714 49.6914 11.6195 49.8645 11.4441C50.0377 11.2687 50.1309 11.0528 50.1309 10.7964C50.1309 10.5401 50.0377 10.3377 49.8645 10.1488C49.7047 9.95987 49.4917 9.87891 49.2386 9.87891Z"
+                      fill="#BDBDBD"
+                    />
+                    <path
+                      d="M54.2318 9.89258C53.9921 9.89258 53.779 9.98703 53.6192 10.1624C53.4461 10.3379 53.3662 10.5537 53.3662 10.8101C53.3662 11.0665 53.4461 11.2689 53.6192 11.4578C53.7924 11.6332 53.9921 11.7277 54.2318 11.7277C54.4715 11.7277 54.6846 11.6332 54.8577 11.4578C55.0308 11.2824 55.1241 11.0665 55.1241 10.8101C55.1241 10.5537 55.0308 10.3379 54.8577 10.1624C54.6846 9.97354 54.4715 9.89258 54.2318 9.89258Z"
+                      fill="#BDBDBD"
+                    />
+                    <path
+                      d="M56.4431 3.22656H39.5573C38.2655 3.22656 37.2002 4.30602 37.2002 5.61487V15.2895C37.2002 16.5984 38.2655 17.6778 39.5573 17.6778H46.1891C46.1891 17.6778 47.4675 21.2266 47.9336 21.2266C48.3997 21.2266 49.7847 17.6778 49.7847 17.6778H56.4431C57.7348 17.6778 58.8002 16.5984 58.8002 15.2895V5.61487C58.8002 4.30602 57.7348 3.22656 56.4431 3.22656Z"
+                      fill="#BDBDBD"
+                    />
+                    <path
+                      d="M84.002 4.25C84.0129 4.25 90.8797 4.25053 92.5977 4.71582C93.5446 4.96807 94.2897 5.71721 94.542 6.67188C94.9999 8.39891 94.9961 12 94.9961 12C94.9961 12.0252 94.9944 15.6073 94.5381 17.3281C94.2858 18.2789 93.5407 19.0281 92.5938 19.2842C90.8781 19.7459 83.998 19.7461 83.998 19.7461C83.9875 19.7461 77.1166 19.7456 75.4023 19.2842C74.4554 19.0319 73.7103 18.2828 73.458 17.3281C73.0017 15.6073 73 12.0252 73 12C73 12 73.0002 8.39887 73.4619 6.66797C73.7142 5.71718 74.4593 4.96804 75.4062 4.71191C77.1218 4.25014 84.002 4.25 84.002 4.25ZM81.751 15.2715L87.502 12L81.751 8.72852V15.2715Z"
+                      fill="#BDBDBD"
+                    />
+                    <path
+                      d="M120 8.83398C118.288 8.83398 116.833 10.2889 116.833 12.0007C116.833 13.7124 118.288 15.1673 120 15.1673C121.711 15.1673 123.166 13.7124 123.166 12.0007C123.166 10.2889 121.711 8.83398 120 8.83398Z"
+                      fill="#BDBDBD"
+                    />
+                    <path
+                      d="M124.059 2.5H116.027C112.918 2.5 110.5 4.91818 110.5 7.94091V15.9727C110.5 19.0818 112.918 21.5 116.027 21.5H124.059C127.082 21.5 129.5 19.0818 129.5 15.9727V7.94091C129.5 4.91818 127.082 2.5 124.059 2.5Z"
+                      fill="#BDBDBD"
+                    />
+                  </svg>
+                </div>
+              </div>
+  
+              {/* Company info: 16px / 140% / -3% / #9D9D9D, width 640 (작은 화면에선 자동 줄바꿈) */}
+              <div className="font-pretendard mt-[16px] w-full max-w-[640px] text-[16px] leading-[22px] font-[200] tracking-[-0.05em] text-[#9D9D9D]">
+                <p>
+                  대표자 : 이한별 | 사업자 등록번호 : 540-86-00384 | 통신판매업
+                  신고번호 : 2020-경기김포-3725호
+                </p>
+                <p className="mt-[6px]">
+                  주소 : 경기도 김포시 사우중로 87 201호 | 이메일 :
+                  kdigital@nextrunners.co.kr | 전화 : 070-4099-8219
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
+    )
+  }

--- a/src/components/common/Modal/variants/WithdrawalReasonModal.tsx
+++ b/src/components/common/Modal/variants/WithdrawalReasonModal.tsx
@@ -3,10 +3,10 @@ import { useNavigate } from 'react-router-dom'
 import { useAuthStore } from '@/store/authStore'
 import { useForm, FormProvider } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Button } from '@/components/common/Button'
-import { CommonInputField } from '@/components/common/CommonInputField'
-import Dropdown from '@/components/common/Dropdown'
-import { Modal } from '@/components/common/Modal'
+import { Modal } from '../Modal'
+import { Button } from '../../Button'
+import Dropdown from '../../Dropdown'
+import { CommonInputField } from '../../CommonInputField'
 import {
   withdrawalReasonSchema,
   type WithdrawalReasonFormData,
@@ -34,7 +34,6 @@ export function WithdrawalReasonModal({
 }: WithdrawalReasonModalProps) {
   const toastTimerRef = useRef<NodeJS.Timeout | null>(null)
   const navigate = useNavigate()
-  const logout = useAuthStore((state) => state.logout)
 
   useEffect(() => {
     return () => {
@@ -71,7 +70,7 @@ export function WithdrawalReasonModal({
   const onSubmit = async (data: WithdrawalReasonFormData) => {
     if (onSuccess) {
       await onSuccess(data)
-      logout()
+      useAuthStore.getState().logout()
       navigate('/login', { replace: true })
     }
     if (toastTimerRef.current) {

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,5 +1,6 @@
 import { Outlet } from 'react-router-dom'
 import Header from '@/components/common/Header'
+import Footer from '@/components/common/Footer'
 
 export default function MainLayout() {
   return (
@@ -8,6 +9,7 @@ export default function MainLayout() {
       <main className="flex-1 pt-[var(--header-offset)]">
         <Outlet />
       </main>
+      <Footer />
     </div>
   )
 }

--- a/src/components/myinfo/EditMyInfo.tsx
+++ b/src/components/myinfo/EditMyInfo.tsx
@@ -1,17 +1,128 @@
 import { Button, CommonInput } from '../common'
 import type { User } from '@/types/auth'
 import { unmapGender } from '@/utils/gender'
+import { useMyInfoStore } from '@/store/myInfoStore'
+import { checkNickname, sendSmsVerification, verifySmsCode } from '@/api/auth'
+import { useCountdown } from '@/hooks/useCountdown'
 
 type GenderUI = 'male' | 'female'
 
 type Props = {
   user: User
-  onChange: (v: User) => void
 }
 
-export function EditMyInfo({ user, onChange }: Props) {
-  const handleChange = <K extends keyof User>(key: K, value: User[K]) => {
-    onChange({ ...user, [key]: value })
+export function EditMyInfo({ user }: Props) {
+  const {
+    nickname,
+    nicknameStatus,
+    phone,
+    phoneStatus,
+    smsCode,
+    smsStatus,
+    phoneChanging,
+    error,
+    setField,
+  } = useMyInfoStore()
+  const { isActive, startTimer, resetTimer, formatTime, isExpired } =
+    useCountdown(5) // 5분
+
+  const handleChange = (key: 'nickname' | 'phone', value: string) => {
+    setField(key, value)
+    if (key === 'nickname') {
+      setField('nicknameStatus', 'default')
+      setField('error', null)
+    }
+    if (key === 'phone') {
+      setField('phoneStatus', 'default')
+      setField('smsToken', null)
+      setField('smsCode', '')
+      setField('error', null)
+      resetTimer()
+    }
+  }
+
+  const handleCheckNickname = async () => {
+    if (!nickname.trim()) return
+    if (nickname.length > 10) {
+      setField('nicknameStatus', 'error')
+      setField('error', '닉네임은 최대 10자까지 입력 가능합니다.')
+      return
+    }
+    if (!/^[가-힣a-zA-Z0-9]*$/.test(nickname)) {
+      setField('nicknameStatus', 'error')
+      setField('error', '닉네임은 한글, 영문, 숫자만 입력 가능합니다.')
+      return
+    }
+    if (nickname === user.nickname) {
+      setField('nicknameStatus', 'success')
+      setField('error', null)
+      return
+    }
+    try {
+      await checkNickname({ nickname })
+      setField('nicknameStatus', 'success')
+      setField('error', null)
+    } catch (error: any) {
+      if (error.response?.status === 409) {
+        setField('nicknameStatus', 'error')
+        setField('error', '이미 사용중인 닉네임 입니다.')
+      } else if (error.response?.status === 400) {
+        const errorData = error.response?.data
+        if (errorData?.error_detail?.nickname) {
+          setField('nicknameStatus', 'error')
+          setField('error', errorData.error_detail.nickname[0])
+        } else {
+          setField('nicknameStatus', 'error')
+          setField('error', '잘못된 요청입니다.')
+        }
+      } else {
+        setField('nicknameStatus', 'error')
+        setField('error', '닉네임 확인 중 오류가 발생했습니다.')
+      }
+    }
+  }
+
+  const handleSendSms = async () => {
+    if (!phone.trim()) return
+    if (!/^\d+$/.test(phone)) {
+      setField('phoneStatus', 'error')
+      setField('error', '휴대전화 번호는 숫자만 입력 가능합니다.')
+      return
+    }
+    try {
+      await sendSmsVerification({ phoneNumber: phone })
+      setField('phoneChanging', true)
+      setField('phoneStatus', 'default')
+      setField('error', null)
+      startTimer()
+    } catch (error) {
+      setField('phoneStatus', 'error')
+      setField('error', '인증 코드 발송에 실패했습니다.')
+    }
+  }
+
+  const handleVerifySms = async () => {
+    if (!smsCode.trim()) return
+    if (isExpired) {
+      setField('phoneStatus', 'error')
+      setField('error', '인증번호 전송 시간이 초과되었습니다. 재전송 해주세요.')
+      return
+    }
+    try {
+      const result = await verifySmsCode({
+        phoneNumber: phone,
+        verificationCode: smsCode,
+      })
+      setField('smsToken', result.smsToken)
+      setField('phoneStatus', 'success')
+      setField('error', null)
+      resetTimer()
+      setField('smsStatus', 'success')
+    } catch (error) {
+      setField('phoneStatus', 'error')
+      setField('error', '인증번호가 일치하지 않습니다.')
+      setField('smsStatus', 'error')
+    }
   }
 
   const currentGender = unmapGender(user.gender)
@@ -30,15 +141,34 @@ export function EditMyInfo({ user, onChange }: Props) {
         </div>
 
         <Label>닉네임</Label>
-        <div className="flex gap-[12px]">
-          <CommonInput
-            value={user.nickname}
-            onChange={(v) => handleChange('nickname', v)}
-            width={532}
-          />
-          <Button size="sm" variant="secondary">
-            중복확인
-          </Button>
+        <div className="flex flex-col gap-2">
+          <div className="flex gap-[12px]">
+            <CommonInput
+              value={nickname}
+              onChange={(v) => {
+                if (v.length <= 10) {
+                  handleChange('nickname', v)
+                }
+              }}
+              width={532}
+              placeholder={user.nickname}
+              state={nicknameStatus}
+              autoComplete="off"
+            />
+            <Button size="sm" variant="secondary" onClick={handleCheckNickname}>
+              중복확인
+            </Button>
+          </div>
+          <div className="h-[22px]">
+            {nicknameStatus === 'error' && error && (
+              <p className="text-sm text-red-500">{error}</p>
+            )}
+            {nicknameStatus === 'success' && (
+              <p className="text-sm text-green-500">
+                사용 가능한 닉네임입니다.
+              </p>
+            )}
+          </div>
         </div>
 
         <Label>이메일</Label>
@@ -53,11 +183,110 @@ export function EditMyInfo({ user, onChange }: Props) {
 
       <Section title="개인 정보 수정">
         <Label>휴대전화</Label>
-        <CommonInput
-          value={user.phone_number}
-          onChange={(v) => handleChange('phone_number', v)}
-          width={656}
-        />
+        {!phoneChanging ? (
+          <div className="flex gap-[12px]">
+            <CommonInput
+              value={phone || user.phone_number}
+              locked
+              width={532}
+              disabled
+              onChange={() => {}}
+            />
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => {
+                setField('phoneChanging', true)
+                setField('smsCode', '') // 인증번호 입력값 초기화
+                setField('smsStatus', 'default') // 인증번호 입력 상태 초기화
+                setField('phoneStatus', 'default') // 인증 상태 초기화
+                setField('smsToken', null)
+                setField('error', null)
+              }}
+            >
+              변경
+            </Button>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <div className="flex gap-[12px]">
+              <CommonInput
+                value={phone}
+                onChange={(v) => {
+                  if (/^\d*$/.test(v)) {
+                    handleChange('phone', v)
+                  }
+                }}
+                width={502}
+                placeholder="휴대전화 번호를 입력하세요"
+                autoComplete="off"
+              />
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => {
+                  handleSendSms()
+                  setField('smsCode', '') // 인증번호 입력값 초기화
+                  setField('smsStatus', 'default') // 인증번호 입력 상태 초기화
+                  setField('phoneStatus', 'default') // 인증 상태 초기화
+                  setField('smsToken', null)
+                  setField('error', null)
+                }}
+                disabled={!phone.trim()}
+                className="w-[142px]"
+              >
+                {isActive ? '재전송' : '인증번호 받기'}
+              </Button>
+            </div>
+            {(isActive || phoneStatus === 'success') && (
+              <div className="flex items-center gap-[12px]">
+                <div className="relative">
+                  <CommonInput
+                    value={smsCode}
+                    onChange={(v) => {
+                      if (/^\d{0,6}$/.test(v)) {
+                        setField('smsCode', v)
+                        setField('smsStatus', 'default')
+                      }
+                    }}
+                    width={502}
+                    placeholder="6자리 인증번호를 입력하세요"
+                    disabled={phoneStatus === 'success'}
+                    state={
+                      phoneStatus === 'success'
+                        ? 'success'
+                        : smsStatus === 'error'
+                          ? 'error'
+                          : 'default'
+                    }
+                    autoComplete="off"
+                  />
+                  {phoneStatus === 'success' ? (
+                    <span className="absolute top-1/2 right-3 -translate-y-1/2 transform text-green-500">
+                      ✓
+                    </span>
+                  ) : (
+                    <span className="absolute top-1/2 right-3 -translate-y-1/2 transform text-sm text-red-500">
+                      {formatTime}
+                    </span>
+                  )}
+                </div>
+                <Button
+                  size="sm"
+                  variant={phoneStatus === 'success' ? 'disabled' : 'secondary'}
+                  onClick={handleVerifySms}
+                  disabled={phoneStatus === 'success'}
+                  className="w-[142px]"
+                >
+                  인증번호 확인
+                </Button>
+              </div>
+            )}
+            {phoneStatus === 'error' && error && (
+              <p className="text-sm text-red-500">{error}</p>
+            )}
+          </div>
+        )}
 
         <Label>성별</Label>
         <div className="flex gap-[20px]">
@@ -81,6 +310,7 @@ export function EditMyInfo({ user, onChange }: Props) {
           width={656}
           onChange={() => {}}
           disabled
+          autoComplete="off"
         />
       </Section>
     </div>

--- a/src/components/myinfo/ViewMyInfo.tsx
+++ b/src/components/myinfo/ViewMyInfo.tsx
@@ -1,18 +1,100 @@
-import type { User } from '@/types/auth'
 import { unmapGender } from '@/utils/gender'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { refreshToken } from '@/api/refresh'
+import { useAuthStore } from '@/store/authStore'
 import { WithdrawalReasonModal } from '../common'
-import { withdraw } from '@/api/info'
-import type { CourseEnrollment } from '@/types/info'
+import { withdraw, getMyCourses } from '@/api/info'
+import { useCoursesStore } from '@/store/coursesStore'
 import { WITHDRAW_REASON_MAP } from '@/constants/withdrawReason'
 import type { WithdrawalReasonFormData } from '@/schemas/modalSchemas'
-type Props = {
-  user: User
-  courses: CourseEnrollment[]
-}
 
-export function ViewMyInfo({ user, courses }: Props) {
-  const gender = unmapGender(user.gender)
+export function ViewMyInfo() {
+  const {
+    accessToken,
+    user: currentUser,
+    setAuth,
+    refreshToken: zRefreshToken,
+  } = useAuthStore()
+  // 프로필 상태
+  const [profileLoading, setProfileLoading] = useState(false)
+  const [profileError, setProfileError] = useState<string | null>(null)
+  const {
+    courses,
+    loading: coursesLoading,
+    error: coursesError,
+    setCourses,
+    setLoading: setCoursesLoading,
+    setError: setCoursesError,
+  } = useCoursesStore()
+  useEffect(() => {
+    const fetchAndUpdateUser = async () => {
+      setProfileLoading(true)
+      setProfileError(null)
+      try {
+        const res = await import('@/api/auth')
+        try {
+          if (!accessToken) throw new Error('토큰 없음')
+          const info = await res.me(accessToken)
+          setAuth({ accessToken: accessToken as string, user: info })
+        } catch (err: any) {
+          if (err?.response?.status === 401) {
+            try {
+              if (!zRefreshToken) throw new Error('리프레시 토큰 없음')
+              const newToken = await refreshToken(zRefreshToken)
+              const info = await res.me(newToken)
+              setAuth({ accessToken: newToken, user: info })
+            } catch (refreshErr) {
+              setProfileError('세션이 만료되었습니다. 다시 로그인 해주세요.')
+            }
+          } else {
+            setProfileError('내 정보 조회에 실패했습니다.')
+          }
+        }
+      } finally {
+        setProfileLoading(false)
+      }
+    }
+    if (!currentUser) {
+      fetchAndUpdateUser()
+    }
+  }, [accessToken, currentUser, setAuth])
+
+  // 수강 과정 별도 로딩/에러 관리 (zustand)
+  useEffect(() => {
+    const fetchCoursesData = async () => {
+      setCoursesLoading(true)
+      setCoursesError(null)
+      try {
+        const data = await getMyCourses()
+        setCourses(data)
+      } catch (err) {
+        setCoursesError('')
+      } finally {
+        setCoursesLoading(false)
+      }
+    }
+    fetchCoursesData()
+  }, [setCourses, setCoursesLoading, setCoursesError])
+
+  // 5분마다 토큰 자동 갱신
+  useEffect(() => {
+    const interval = setInterval(
+      async () => {
+        try {
+          if (!zRefreshToken) return
+          const newToken = await refreshToken(zRefreshToken)
+          if (currentUser && newToken) {
+            setAuth({ accessToken: newToken, user: currentUser })
+          }
+        } catch (e) {
+          console.error('토큰 갱신 실패', e)
+        }
+      },
+      5 * 60 * 1000
+    ) // 5분
+    return () => clearInterval(interval)
+  }, [setAuth, currentUser, zRefreshToken])
+  // (불필요한 gender 변수 제거)
   const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false)
 
   /* ================= 회원 탈퇴 ================= */
@@ -42,38 +124,56 @@ export function ViewMyInfo({ user, courses }: Props) {
     <>
       {/* ================= 프로필 / 개인 정보 ================= */}
       <div className="info-border mt-[20px] w-[747px]">
-        <InfoSection title="프로필">
-          <div className="flex justify-center">
-            <img
-              src={
-                user.profile_img_url ? user.profile_img_url : '/프로필 사진.svg'
-              }
-              alt="프로필 사진"
-              className="mb-[52px] h-[184px] rounded-full"
-            />
-          </div>
+        {profileLoading ? (
+          <p className="text-mono-400">내 정보 불러오는 중...</p>
+        ) : profileError ? (
+          <p className="text-red-500">{profileError}</p>
+        ) : currentUser ? (
+          <>
+            <InfoSection title="프로필">
+              <div className="flex justify-center">
+                <img
+                  src={
+                    currentUser.profile_img_url
+                      ? currentUser.profile_img_url
+                      : '/프로필 사진.svg'
+                  }
+                  alt="프로필 사진"
+                  className="mb-[52px] h-[184px] rounded-full"
+                />
+              </div>
 
-          <div className="mb-[90px] flex flex-col gap-[20px]">
-            <InfoRow label="닉네임" value={user.nickname} />
-            <InfoRow label="이메일" value={user.email} />
-          </div>
-        </InfoSection>
+              <div className="mb-[90px] flex flex-col gap-[20px]">
+                <InfoRow label="닉네임" value={currentUser.nickname} />
+                <InfoRow label="이메일" value={currentUser.email} />
+              </div>
+            </InfoSection>
 
-        <InfoSection title="개인 정보">
-          <div className="flex flex-col gap-[20px]">
-            <InfoRow label="이름" value={user.name} />
-            <InfoRow label="휴대전화" value={user.phone_number} />
-            <InfoRow label="성별" value={gender === 'male' ? '남자' : '여자'} />
-            <InfoRow label="생년월일" value={user.birthday} />
-          </div>
-        </InfoSection>
+            <InfoSection title="개인 정보">
+              <div className="flex flex-col gap-[20px]">
+                <InfoRow label="이름" value={currentUser.name} />
+                <InfoRow label="휴대전화" value={currentUser.phone_number} />
+                <InfoRow
+                  label="성별"
+                  value={
+                    unmapGender(currentUser.gender) === 'male' ? '남자' : '여자'
+                  }
+                />
+                <InfoRow label="생년월일" value={currentUser.birthday} />
+              </div>
+            </InfoSection>
+          </>
+        ) : null}
       </div>
       {/* ================= 수강중 / 수강완료 과정 ================= */}
       <div className="info-border mt-[20px] w-[747px]">
         <p className="text-primary title-l-b">수강중인 과정</p>
         <hr className="border-mono-400 mt-[16px] mb-[40px]" />
-
-        {courses.length === 0 ? (
+        {coursesLoading ? (
+          <p className="text-mono-400">수강 과정 불러오는 중...</p>
+        ) : coursesError ? (
+          <p className="text-red-500">{coursesError}</p>
+        ) : courses.length === 0 ? (
           <p className="text-mono-400">현재 수강 중인 과정이 없습니다.</p>
         ) : (
           <div className="flex flex-col gap-[24px]">

--- a/src/components/quiz/QuizHeader.tsx
+++ b/src/components/quiz/QuizHeader.tsx
@@ -19,6 +19,8 @@ interface QuizHeaderProps {
   timeRemaining?: string
   timeRemainingSuffix?: string
   cheatingCount?: number
+  /** 우측 타이머/부정행위 영역 노출 여부 (기본값: true) */
+  showExamStatus?: boolean
 }
 
 function QuizHeader({
@@ -27,6 +29,7 @@ function QuizHeader({
   timeRemaining = '29 : 17',
   timeRemainingSuffix = '뒤에 끝나요',
   cheatingCount: _cheatingCount = 0,
+  showExamStatus = true,
 }: QuizHeaderProps) {
   const maxCheatingCount = 3
   const cheatingCount = Math.min(Math.max(_cheatingCount, 0), maxCheatingCount)
@@ -60,25 +63,27 @@ function QuizHeader({
           <p className={contentStyle}>{message}</p>
         </div>
 
-        {/* 우측 영역 */}
-        <div className="flex items-center gap-4">
-          {/* 타이머 박스 */}
-          <div className={infoBoxStyle}>
-            <span className={timerNumberStyle}>{timeRemaining}</span>
-            <span className={timerTextStyle}> {timeRemainingSuffix}</span>
-          </div>
-          {/* 부정행위 카운트 */}
-          <div className={infoBoxStyle}>
-            <span className={warningLabelStyle}>부정행위</span>
-            <div className="flex gap-1">
-              {Array.from({ length: maxCheatingCount }).map((_, index) => (
-                <div key={index} className={getWarningBoxClass(index)}>
-                  <span className={getWarningTextClass(index)}>!</span>
-                </div>
-              ))}
+        {/* 우측 영역 (타이머 + 부정행위). 결과 페이지 등에서는 숨길 수 있도록 옵션 제공 */}
+        {showExamStatus && (
+          <div className="flex items-center gap-4">
+            {/* 타이머 박스 */}
+            <div className={infoBoxStyle}>
+              <span className={timerNumberStyle}>{timeRemaining}</span>
+              <span className={timerTextStyle}> {timeRemainingSuffix}</span>
+            </div>
+            {/* 부정행위 카운트 */}
+            <div className={infoBoxStyle}>
+              <span className={warningLabelStyle}>부정행위</span>
+              <div className="flex gap-1">
+                {Array.from({ length: maxCheatingCount }).map((_, index) => (
+                  <div key={index} className={getWarningBoxClass(index)}>
+                    <span className={getWarningTextClass(index)}>!</span>
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-        </div>
+        )}
       </div>
     </header>
   )

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -293,6 +293,7 @@ function QuizPage() {
   const showTimeEndModal = isEnded && endReason === 'time'
   const showQuizEndModal = isEnded && endReason === 'status'
 
+  // 시험 종료 시 전체화면 해제 후 쪽지시험 리스트로 이동
   const handleEndConfirm = () => {
     exitFullscreenIfActive().then(() => navigate('/mypage/quiz'))
   }

--- a/src/pages/QuizResultPage.tsx
+++ b/src/pages/QuizResultPage.tsx
@@ -37,6 +37,23 @@ function QuizResultPage() {
     )
   }
 
+  const questionCount = data?.questions.length ?? 0
+  const cheatingCount = data?.cheatingCount ?? 0
+
+  // startedAt / submittedAt 기준 실제 응시 시간 (분 단위, 초는 버림)
+  let elapsedMinutes = data?.elapsedTime ?? 0
+  if (data?.startedAt && data?.submittedAt) {
+    const started = new Date(data.startedAt)
+    const submitted = new Date(data.submittedAt)
+    const diffMs = submitted.getTime() - started.getTime()
+    elapsedMinutes = Math.max(0, Math.floor(diffMs / 60000))
+  }
+
+  const maxScore =
+    data?.questions.reduce((sum, question) => sum + (question.point ?? 0), 0) ??
+    0
+  const totalScore = data?.totalScore ?? 0
+
   const renderQuestion = (
     question: NonNullable<typeof data>['questions'][0],
     index: number
@@ -136,13 +153,14 @@ function QuizResultPage() {
     <div>
       <QuizHeader
         subjectName={data?.exam.title}
-        message={`총 문항 수: ${data?.questions.length ?? 0} ㆍ 부정행위: ${data?.cheatingCount ?? 0} ㆍ 응시시간: ${data?.elapsedTime ?? 0}분 ㆍ 응시 결과 점수: ${data?.totalScore ?? 0}점/100점`}
+        message={`총 문항 수: ${questionCount} ㆍ 부정행위: ${cheatingCount}회 ㆍ 응시시간: ${elapsedMinutes}분 ㆍ 응시 결과 점수: ${totalScore}점/${maxScore}점`}
+        showExamStatus={false}
       />
 
       <main>
         <QuizResultTop />
         <div className="flex justify-center">
-          <div className="w-[1290px] space-y-6 py-10">
+          <div className="w-[1290px] space-y-6 py-10 pt-16">
             {data?.questions?.map((question, index) => (
               <div key={question.id} className="space-y-4">
                 {renderQuestion(question, index)}

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -6,10 +6,15 @@ import * as authApi from '@/api/auth'
 
 type AuthState = {
   accessToken: string | null
+  refreshToken: string | null
   user: User | null
   isAuthenticated: boolean
 
-  setAuth: (payload: { accessToken: string | null; user: User }) => void
+  setAuth: (payload: {
+    accessToken: string | null
+    refreshToken?: string
+    user: User
+  }) => void
   clearAuth: () => void
 
   login: (payload: LoginPayload) => Promise<void>
@@ -21,25 +26,39 @@ export const useAuthStore = create<AuthState>()(
   persist(
     (set, get) => ({
       accessToken: null,
+      refreshToken: null,
       user: null,
       isAuthenticated: false,
 
-      setAuth: ({ accessToken, user }) => {
-        set({ accessToken, user, isAuthenticated: true })
+      setAuth: ({ accessToken, refreshToken, user }) => {
+        set((prev) => ({
+          accessToken,
+          refreshToken: refreshToken ?? prev.refreshToken,
+          user,
+          isAuthenticated: true,
+        }))
       },
 
       clearAuth: () => {
-        set({ accessToken: null, user: null, isAuthenticated: false })
+        set({
+          accessToken: null,
+          refreshToken: null,
+          user: null,
+          isAuthenticated: false,
+        })
       },
 
       login: async (payload) => {
         try {
           const response = await authApi.login(payload)
           const accessToken = response?.access_token
-          if (!accessToken) throw new Error('LOGIN_FAILED')
-
+          let refreshToken = response?.refresh_token // undefined일 수 있음
+          if (!accessToken) {
+            throw new Error('LOGIN_FAILED')
+          }
           const user = await authApi.me(accessToken)
-          get().setAuth({ accessToken, user })
+          // refreshToken이 없으면 setAuth에 undefined로 저장 (별도 API에서 추후 갱신)
+          get().setAuth({ accessToken, refreshToken, user })
         } catch (error) {
           get().clearAuth()
           throw error
@@ -72,6 +91,7 @@ export const useAuthStore = create<AuthState>()(
       name: 'auth-storage',
       partialize: (s) => ({
         accessToken: s.accessToken,
+        refreshToken: s.refreshToken,
         user: s.user,
         isAuthenticated: s.isAuthenticated,
       }),

--- a/src/store/coursesStore.ts
+++ b/src/store/coursesStore.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand'
+import type { CourseEnrollment } from '@/types/info'
+
+interface CoursesState {
+  courses: CourseEnrollment[]
+  loading: boolean
+  error: string | null
+  setCourses: (courses: CourseEnrollment[]) => void
+  setLoading: (loading: boolean) => void
+  setError: (error: string | null) => void
+}
+
+export const useCoursesStore = create<CoursesState>((set) => ({
+  courses: [],
+  loading: false,
+  error: null,
+  setCourses: (courses) => set({ courses }),
+  setLoading: (loading) => set({ loading }),
+  setError: (error) => set({ error }),
+}))

--- a/src/store/myInfoStore.ts
+++ b/src/store/myInfoStore.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand'
+
+export type MyInfoState = {
+  nickname: string
+  nicknameStatus: 'default' | 'success' | 'error'
+  phone: string
+  phoneStatus: 'default' | 'success' | 'error'
+  smsCode: string
+  smsStatus: 'default' | 'success' | 'error'
+  phoneChanging: boolean
+  smsToken: string | null
+  error: string | null
+  setField: (key: keyof MyInfoState, value: any) => void
+  reset: () => void
+}
+
+const initialState: Omit<MyInfoState, 'setField' | 'reset'> = {
+  nickname: '',
+  nicknameStatus: 'default',
+  phone: '',
+  phoneStatus: 'default',
+  smsCode: '',
+  smsStatus: 'default',
+  phoneChanging: false,
+  smsToken: null,
+  error: null,
+}
+
+export const useMyInfoStore = create<MyInfoState>((set) => ({
+  ...initialState,
+  setField: (key, value) => set({ [key]: value }),
+  reset: () => set(initialState),
+}))

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -6,6 +6,7 @@ export type LoginPayload = {
 
 export type LoginResult = {
   access_token: string
+  refresh_token: string
 }
 
 export type User = {


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #134 

- **쪽지시험 결과 상세 페이지 헤더 개선 (`QuizResultPage.tsx`, `QuizHeader.tsx`)**
  - 결과 페이지 헤더에서는 **타이머/부정행위 박스 비노출**
    - `QuizHeader`에 `showExamStatus` prop 추가 (기본값 `true`)
    - 결과 페이지에서는 `<QuizHeader ... showExamStatus={false} />`로 사용
  - 헤더 메시지 포맷을 요구사항에 맞게 구성
    - `총 문항 수: {문항수} ㆍ 부정행위: {부정행위 횟수}회 ㆍ 응시시간: {응시시간(분)}분 ㆍ 응시 결과 점수: {응시결과점수}점/{응시총점수}점`
    - `startedAt`, `submittedAt` 차이로 실제 응시 시간(분)을 계산(초는 버림)
    - 각 문항의 `point` 합으로 응시 총점수 계산

- **쪽지시험 제출 API Authorization 헤더 연동 (`api/quiz.ts`)**
  - `submitExam` 호출 시 `Authorization: Bearer {accessToken}` 헤더를 포함하도록 수정
    - `useAuthStore.getState().accessToken`에서 토큰을 읽어와 헤더 구성
    - 비로그인 상태에서는 헤더 없이 호출

- **레이아웃 공통 푸터 추가 (`MainLayout.tsx`, `Footer.tsx`)**
  - `MainLayout`에 `Footer`를 추가하여 **헤더가 있는 페이지 하단에 공통 푸터 노출**
  - 푸터는 Figma 디자인 기반으로 OZ 로고, 캠프 링크, 정책 링크, 회사 정보, SNS 아이콘 영역 포함

## 🌀 어려웠던 점 / 고민했던 부분

- 결과 페이지에서 **“헤더 타이머/부정행위 UI는 숨기되, 텍스트 정보는 유지”**해야 해서
  - `QuizHeader`의 props만 최소 변경(`showExamStatus`)으로 해결하고,
  - 결과 페이지는 텍스트 메시지로 필요한 정보만 노출하는 방향으로 정리했습니다.
- 시험 제출 API에 Authorization을 붙이면서, 기존 `apiClient` 설정과 `authStore` 흐름을 해치지 않도록
  - `submitExam` 내부에서만 `useAuthStore.getState()`를 사용해 헤더를 구성하도록 한정했습니다.
 
## 📸 구현 이미지

-
<img width="1216" height="130" alt="스크린샷 2026-02-04 오후 7 14 47" src="https://github.com/user-attachments/assets/eff744eb-3832-4d34-82f4-5d9963086a4f" />


## ❇️ 코드 설명

-

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.