### PR TITLE
feat: 401 시 리프레시 토큰 자동 갱신 및 요청 재시도 (#140)

### DIFF
--- a/src/api/refresh.ts
+++ b/src/api/refresh.ts
@@ -1,9 +1,17 @@
 import { apiClient } from '@/api/client'
 
-export async function refreshToken(refreshToken: string) {
-  const { data } = await apiClient.post<{ access_token: string }>(
+/** 401 응답 인터셉터에서 리프레시 재시도 무한 루프 방지용 플래그 */
+export const REFRESH_REQUEST_CONFIG = { __isRefreshRequest: true } as const
+
+export async function refreshToken(token: string): Promise<string> {
+  const { data } = await apiClient.post<{ access_token?: string }>(
     '/api/v1/accounts/me/refresh/',
-    { refresh_token: refreshToken }
+    { refresh_token: token },
+    REFRESH_REQUEST_CONFIG as object
   )
-  return data.access_token
+  const accessToken = data?.access_token
+  if (!accessToken) {
+    throw new Error('Refresh response missing access_token')
+  }
+  return accessToken
 }

--- a/src/api/setupRefreshInterceptor.ts
+++ b/src/api/setupRefreshInterceptor.ts
@@ -1,0 +1,91 @@
+import type { AxiosInstance, InternalAxiosRequestConfig } from 'axios'
+import { refreshToken as callRefreshToken } from '@/api/refresh'
+import type { User } from '@/types/auth'
+
+const LOGIN_PATH = '/login'
+
+type AuthState = {
+  refreshToken: string | null
+  user: User | null
+  setAuth: (payload: {
+    accessToken: string | null
+    refreshToken?: string
+    user: User
+  }) => void
+  clearAuth: () => void
+}
+
+/** 인증 초기화 후 로그인 페이지로 이동 */
+function clearAuthAndRedirectToLogin(getAuthState: () => AuthState) {
+  getAuthState().clearAuth()
+  window.location.replace(LOGIN_PATH)
+}
+
+/** 재시도 요청 플래그: 재시도된 요청이 또 401이면 refresh 재시도 무한 루프 방지 */
+const RETRY_REQUEST_FLAG = '__isRetryRequest' as const
+
+/** 401 시 리프레시 토큰으로 accessToken 갱신 후 실패한 요청 재시도 */
+export function setupRefreshInterceptor(
+  client: AxiosInstance,
+  getAuthState: () => AuthState
+) {
+  let refreshPromise: Promise<string | null> | null = null
+
+  const id = client.interceptors.response.use(
+    (response) => response,
+    async (error: {
+      config?: InternalAxiosRequestConfig & {
+        __isRefreshRequest?: boolean
+        __isRetryRequest?: boolean
+      }
+      response?: { status: number }
+    }) => {
+      const config = error.config
+      if (error.response?.status !== 401 || !config) {
+        return Promise.reject(error)
+      }
+
+      const state = getAuthState()
+
+      // 리프레시 API 또는 이미 재시도한 요청이 401이면 갱신 시도 없이 로그인으로
+      if (config.__isRefreshRequest || config.__isRetryRequest) {
+        clearAuthAndRedirectToLogin(getAuthState)
+        return Promise.reject(error)
+      }
+
+      const { refreshToken, user, setAuth } = state
+      if (!refreshToken || !user) {
+        clearAuthAndRedirectToLogin(getAuthState)
+        return Promise.reject(error)
+      }
+
+      try {
+        if (!refreshPromise) {
+          refreshPromise = callRefreshToken(refreshToken)
+            .then((newToken) => {
+              setAuth({ accessToken: newToken, user })
+              return newToken
+            })
+            .finally(() => {
+              refreshPromise = null
+            })
+        }
+        const newToken = await refreshPromise
+        if (!newToken) {
+          clearAuthAndRedirectToLogin(getAuthState)
+          return Promise.reject(error)
+        }
+
+        config.headers = config.headers ?? {}
+        config.headers.Authorization = `Bearer ${newToken}`
+        ;(config as unknown as Record<string, unknown>)[RETRY_REQUEST_FLAG] = true
+        return client.request(config)
+      } catch {
+        clearAuthAndRedirectToLogin(getAuthState)
+        return Promise.reject(error)
+      }
+    }
+  )
+
+  return () => client.interceptors.response.eject(id)
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import App from '@/App'
 
 import { apiClient } from '@/api/client'
 import { setupAuthInterceptor } from '@/api/setupInterceptors'
+import { setupRefreshInterceptor } from '@/api/setupRefreshInterceptor'
 import { useAuthStore } from '@/store/authStore'
 
 const queryClient = new QueryClient()
@@ -24,6 +25,7 @@ async function enableMocking() {
 
 async function bootstrap() {
   setupAuthInterceptor(apiClient, () => useAuthStore.getState().accessToken)
+  setupRefreshInterceptor(apiClient, () => useAuthStore.getState())
 
   await enableMocking()
 


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #140 

## 📑 구현 사항

- **apiClient 401 응답 인터셉터 추가**
  - `src/api/setupRefreshInterceptor.ts` 신규 추가 (다른 팀원 파일 `setupInterceptors.ts` 수정 없음)
  - 401 응답 시 리프레시 토큰으로 새 accessToken 발급 → store 갱신 → 실패한 요청을 새 토큰으로 한 번 재시도
  - 리프레시 API 실패 또는 refreshToken/user 없음 시 `clearAuth()` 후 **로그인 페이지(`/login`)로 이동** (`window.location.replace`)
- **재시도 무한 루프 방지**
  - 리프레시 API 요청에 `__isRefreshRequest` 플래그 부여 → 해당 요청이 401이면 refresh 재시도 없이 로그인으로 이동
  - 재시도한 요청에 `__isRetryRequest` 플래그 부여 → 재시도 요청이 또 401이면 refresh 재시도 없이 로그인으로 이동
- **동시 401 처리**
  - `refreshPromise`로 동시에 여러 요청이 401이어도 refresh API는 한 번만 호출 후, 모두 새 토큰으로 재시도
- **refresh.ts 보완**
  - 파라미터 이름 `refreshToken` → `token` (함수명과 구분)
  - 응답에 `access_token` 없으면 `throw new Error(...)` 로 명시적 실패 처리
- **main.tsx**
  - `setupRefreshInterceptor(apiClient, () => useAuthStore.getState())` 등록

## 🌀 어려웠던 점 / 고민했던 부분

- 다른 팀원이 만든 `setupInterceptors.ts`를 수정하지 않고, 리프레시 인터셉터만 **별도 파일(`setupRefreshInterceptor.ts`)** 로 분리해 담당 영역만 수정하도록 함.
- 재시도된 요청이 또 401일 때 refresh를 다시 시도하면 무한 루프가 될 수 있어, `__isRetryRequest` 플래그로 재시도 요청은 갱신 시도 없이 로그인으로만 보내도록 처리함.

## 📸 구현 이미지

- (스크린샷 없음 – API 인터셉터 동작)

## ❇️ 코드 설명

- **동작 흐름**
  1. 인증 필요 API 호출 → accessToken 만료로 401
  2. 인터셉터에서 401 감지 → `__isRefreshRequest`/`__isRetryRequest` 아니면 refresh 시도
  3. `refreshToken(token)` 호출 → store의 accessToken 갱신 → 실패했던 요청을 새 토큰으로 `client.request(config)` 재시도
  4. 리프레시 실패 또는 refreshToken/user 없음 → `clearAuthAndRedirectToLogin` → 로그인 페이지로 이동
- **적용 범위**: `apiClient`를 쓰는 모든 요청(과정 리스트, 기수 조회, 수강생 등록, 쪽지시험 등)에서 토큰 만료 시 자동 갱신·재시도.

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.