### PR TITLE
feat: 비밀번호 변경api 연결 및 마이페이지 로딩 컴포넌트 연결 및 로딩 컴포넌트 연결

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -143,6 +143,20 @@ export async function resetPassword(
   })
 }
 
+export async function changePassword(payload: {
+  oldPassword: string
+  newPassword: string
+}): Promise<{ detail: string }> {
+  const { data } = await apiClient.post<{ detail: string }>(
+    '/api/v1/accounts/change-password/',
+    {
+      old_password: payload.oldPassword,
+      new_password: payload.newPassword,
+    }
+  )
+  return data
+}
+
 export async function updateMyInfo(payload: Partial<User>): Promise<User> {
   const { data } = await apiClient.patch<User>('/api/v1/accounts/me/', payload)
   return data

--- a/src/components/MyInfo.tsx
+++ b/src/components/MyInfo.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Button } from './common'
+import { Button, Loading } from './common'
 import { ViewMyInfo } from './myinfo/ViewMyInfo'
 import { EditMyInfo } from './myinfo/EditMyInfo'
 import type { User } from '@/types/auth'
@@ -62,7 +62,12 @@ export default function MyInfo() {
 
   // 저장 버튼 활성화 조건 계산 관련 미사용 변수 삭제
 
-  if (loading) return <div>로딩중...</div>
+  if (loading)
+    return (
+      <div className="flex-center h-[600px]">
+        <Loading />
+      </div>
+    )
   if (!user) return <div>정보를 불러올 수 없습니다.</div>
 
   return (

--- a/src/components/PasswordChange.tsx
+++ b/src/components/PasswordChange.tsx
@@ -1,6 +1,13 @@
-import { useState } from 'react'
-import { CommonInput, type FieldState } from './common/CommonInput'
+import { useState, useMemo } from 'react'
+import { PasswordInput } from './common/PasswordInput'
 import { Button } from './common'
+import { changePassword } from '@/api/auth'
+import { mapChangePasswordError } from '@/utils/error/authEndpointErrorMapper'
+import {
+  derivePasswordFieldState,
+  derivePasswordConfirmState,
+} from '@/utils/signupUtils'
+import type { FieldState } from '@/components/common/CommonInput'
 
 export default function PasswordChange() {
   const [form, setForm] = useState({
@@ -9,28 +16,81 @@ export default function PasswordChange() {
     confirmPassword: '',
   })
 
-  const [error, setError] = useState('')
-  const [confirmState, setConfirmState] = useState<FieldState>('default')
+  const [currentState, setCurrentState] = useState<FieldState>('default')
+  const [currentHelper, setCurrentHelper] = useState<string | null>(null)
+  const [newHelper, setNewHelper] = useState<string | null>(null)
+  const [confirmHelper, setConfirmHelper] = useState<string | null>(null)
+
+  const [isLoading, setIsLoading] = useState(false)
 
   const handleChange = (key: keyof typeof form) => (value: string) => {
     setForm((prev) => ({ ...prev, [key]: value }))
-    setError('')
-    setConfirmState('default')
+    // clear field-specific helpers while typing
+    if (key === 'currentPassword') {
+      setCurrentHelper(null)
+      setCurrentState('default')
+    }
+    if (key === 'newPassword') {
+      setNewHelper(null)
+      setConfirmHelper(null)
+    }
+    if (key === 'confirmPassword') {
+      setConfirmHelper(null)
+    }
   }
 
-  const handleSubmit = () => {
-    if (!form.currentPassword || !form.newPassword) {
-      setError('모든 항목을 입력해주세요.')
+  const newState = useMemo(
+    () => derivePasswordFieldState(form.newPassword),
+    [form.newPassword]
+  )
+  const confirmState = useMemo(
+    () => derivePasswordConfirmState(form.newPassword, form.confirmPassword),
+    [form.newPassword, form.confirmPassword]
+  )
+
+  const handleSubmit = async () => {
+    if (newState !== 'success') {
+      setNewHelper('비밀번호가 정책에 맞지 않습니다.')
       return
     }
 
-    if (form.newPassword !== form.confirmPassword) {
-      setError('새 비밀번호가 일치하지 않습니다.')
-      setConfirmState('error')
+    if (confirmState !== 'success') {
+      setConfirmHelper('비밀번호가 일치하지 않습니다.')
       return
     }
 
-    setConfirmState('success')
+    setIsLoading(true)
+    try {
+      await changePassword({
+        oldPassword: form.currentPassword,
+        newPassword: form.newPassword,
+      })
+
+      setNewHelper('비밀번호가 유효합니다.')
+      setConfirmHelper('비밀번호가 일치합니다.')
+      setCurrentState('default')
+      setForm({ currentPassword: '', newPassword: '', confirmPassword: '' })
+
+      window.alert('비밀번호 변경 성공.')
+    } catch (err) {
+      const mapped = mapChangePasswordError(err)
+      if (mapped.kind === 'field') {
+        if (mapped.field === 'newPassword') {
+          setNewHelper(mapped.message)
+        } else if (mapped.field === 'currentPassword') {
+          setCurrentHelper(mapped.message)
+          setCurrentState('error')
+        } else {
+          setConfirmHelper(mapped.message)
+        }
+      } else if (mapped.kind === 'form' || mapped.kind === 'tokenInvalid') {
+        setConfirmHelper(mapped.message)
+      } else {
+        setConfirmHelper('비밀번호 변경에 실패했습니다. 다시 시도해주세요.')
+      }
+    } finally {
+      setIsLoading(false)
+    }
   }
 
   return (
@@ -41,43 +101,68 @@ export default function PasswordChange() {
           {/* 기존 비밀번호 */}
           <div className="flex items-center justify-between">
             <p className="w-[105px]">기존 비밀번호</p>
-            <CommonInput
-              type="password"
-              placeholder="새 비밀번호를 입력해주세요."
+            <PasswordInput
+              placeholder={'새 비밀번호를 입력해주세요.'}
               value={form.currentPassword}
               width={533}
+              state={currentState}
+              helperTextByState={{ error: currentHelper ?? undefined }}
+              helperVisibility={currentHelper ? 'always' : 'never'}
               onChange={handleChange('currentPassword')}
+              autoComplete="off"
             />
           </div>
+
           {/* 새 비밀번호 */}
           <div className="flex items-center justify-between">
             <p className="w-[105px]">새 비밀번호</p>
-            <CommonInput
-              type="password"
-              placeholder="새 비밀번호를 한 번 더 입력해주세요."
+            <PasswordInput
+              placeholder={'새 비밀번호를 입력해주세요.'}
               value={form.newPassword}
               width={533}
+              state={newState}
+              helperTextByState={{
+                error: newHelper ?? '비밀번호가 정책에 맞지 않습니다.',
+                success: newHelper ?? '비밀번호가 유효합니다.',
+              }}
+              helperVisibility={'always'}
               onChange={handleChange('newPassword')}
+              autoComplete="off"
             />
           </div>
+
           {/* 새 비밀번호 확인 */}
           <div className="flex items-center justify-between">
             <p className="w-[105px]">새 비밀번호 확인</p>
-            <CommonInput
-              type="password"
-              placeholder="새 비밀번호를 한 번 더 입력해주세요."
+            <PasswordInput
+              placeholder={'새 비밀번호를 한 번 더 입력해주세요.'}
               value={form.confirmPassword}
               width={533}
               state={confirmState}
-              helperText={error}
-              helperVisibility={error ? 'always' : 'never'}
+              helperTextByState={{
+                error: confirmHelper ?? '비밀번호가 일치하지 않습니다.',
+                success: confirmHelper ?? '비밀번호가 일치합니다.',
+              }}
+              helperVisibility={'always'}
               onChange={handleChange('confirmPassword')}
+              autoComplete="off"
             />
           </div>
         </div>
+
         <div className="mt-[40px] flex justify-end">
-          <Button size="md" onClick={handleSubmit}>
-            변경하기
+          <Button
+            size="md"
+            onClick={handleSubmit}
+            variant={
+              !form.currentPassword ||
+              !form.newPassword ||
+              !form.confirmPassword
+                ? 'disabled'
+                : 'primary'
+            }
+          >
+            {isLoading ? '처리 중...' : '변경하기'}
           </Button>
         </div>
       </div>

--- a/src/components/myinfo/ViewMyInfo.tsx
+++ b/src/components/myinfo/ViewMyInfo.tsx
@@ -1,6 +1,5 @@
 import { unmapGender } from '@/utils/gender'
 import { useState, useEffect } from 'react'
-import { refreshToken } from '@/api/refresh'
 import { useAuthStore } from '@/store/authStore'
 import { WithdrawalReasonModal } from '../common'
 import { withdraw, getMyCourses } from '@/api/info'
@@ -9,12 +8,7 @@ import { WITHDRAW_REASON_MAP } from '@/constants/withdrawReason'
 import type { WithdrawalReasonFormData } from '@/schemas/modalSchemas'
 
 export function ViewMyInfo() {
-  const {
-    accessToken,
-    user: currentUser,
-    setAuth,
-    refreshToken: zRefreshToken,
-  } = useAuthStore()
+  const { accessToken, user: currentUser, setAuth } = useAuthStore()
   // 프로필 상태
   const [profileLoading, setProfileLoading] = useState(false)
   const [profileError, setProfileError] = useState<string | null>(null)
@@ -32,24 +26,11 @@ export function ViewMyInfo() {
       setProfileError(null)
       try {
         const res = await import('@/api/auth')
-        try {
-          if (!accessToken) throw new Error('토큰 없음')
-          const info = await res.me(accessToken)
-          setAuth({ accessToken: accessToken as string, user: info })
-        } catch (err: any) {
-          if (err?.response?.status === 401) {
-            try {
-              if (!zRefreshToken) throw new Error('리프레시 토큰 없음')
-              const newToken = await refreshToken(zRefreshToken)
-              const info = await res.me(newToken)
-              setAuth({ accessToken: newToken, user: info })
-            } catch (refreshErr) {
-              setProfileError('세션이 만료되었습니다. 다시 로그인 해주세요.')
-            }
-          } else {
-            setProfileError('내 정보 조회에 실패했습니다.')
-          }
-        }
+        if (!accessToken) throw new Error('토큰 없음')
+        const info = await res.me(accessToken)
+        setAuth({ accessToken: accessToken as string, user: info })
+      } catch (err: any) {
+        setProfileError('내 정보 조회에 실패했습니다.')
       } finally {
         setProfileLoading(false)
       }
@@ -76,25 +57,6 @@ export function ViewMyInfo() {
     fetchCoursesData()
   }, [setCourses, setCoursesLoading, setCoursesError])
 
-  // 5분마다 토큰 자동 갱신
-  useEffect(() => {
-    const interval = setInterval(
-      async () => {
-        try {
-          if (!zRefreshToken) return
-          const newToken = await refreshToken(zRefreshToken)
-          if (currentUser && newToken) {
-            setAuth({ accessToken: newToken, user: currentUser })
-          }
-        } catch (e) {
-          console.error('토큰 갱신 실패', e)
-        }
-      },
-      5 * 60 * 1000
-    ) // 5분
-    return () => clearInterval(interval)
-  }, [setAuth, currentUser, zRefreshToken])
-  // (불필요한 gender 변수 제거)
   const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false)
 
   /* ================= 회원 탈퇴 ================= */
@@ -191,7 +153,6 @@ export function ViewMyInfo() {
                   </p>
                 </div>
 
-                {/* 썸네일 */}
                 {item.course.thumbnail_img_url ? (
                   <img
                     src={item.course.thumbnail_img_url}
@@ -233,8 +194,6 @@ export function ViewMyInfo() {
     </>
   )
 }
-
-/* ===== sub ===== */
 
 function InfoSection({
   title,

--- a/src/constants/authMessages.ts
+++ b/src/constants/authMessages.ts
@@ -105,6 +105,12 @@ export const AUTH_MESSAGES = {
     failed: '* 비밀번호 재설정에 실패했습니다. 다시 시도해주세요.',
     tokenInvalid: '* 이메일 인증을 다시 진행해주세요.',
   },
+  // 비밀번호 변경 (내 정보)
+  changePassword: {
+    success: '비밀번호 변경 성공.',
+    failed: '* 비밀번호 변경에 실패했습니다. 다시 시도해주세요.',
+    unauthorized: '* 로그인 정보가 필요합니다.',
+  },
   // 아이디 찾기
   findId: {
     defaultGuide: '이름과 휴대전화를 입력하고 인증번호를 요청해주세요.',

--- a/src/utils/error/authEndpointErrorMapper.ts
+++ b/src/utils/error/authEndpointErrorMapper.ts
@@ -108,6 +108,30 @@ export function mapResetPasswordError(err: unknown): MappedError {
   return toForm(message)
 }
 
+export function mapChangePasswordError(err: unknown): MappedError {
+  const parsed = parseAxiosError(err)
+  const newPasswordError = parsed.fieldErrors?.new_password
+  const oldPasswordError = parsed.fieldErrors?.old_password
+
+  if (newPasswordError) {
+    return toField('newPassword', newPasswordError)
+  }
+  if (oldPasswordError) {
+    return toField('currentPassword', oldPasswordError)
+  }
+
+  if (parsed.status === 401) {
+    return toForm(parsed.detail ?? AUTH_MESSAGES.changePassword.unauthorized)
+  }
+
+  const message = resolveMessage(
+    parsed,
+    { 400: AUTH_MESSAGES.changePassword.failed },
+    getFallbackMessage(parsed, AUTH_MESSAGES.changePassword.failed)
+  )
+  return toForm(message)
+}
+
 export function mapCheckNicknameError(err: unknown): MappedError {
   const parsed = parseAxiosError(err)
   const message = resolveMessage(


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #137 

## 📑 구현 사항

-비밀번호 변경 api 연결 및 마이페이지 로딩 컴포넌트 연결

## 🌀 어려웠던 점 / 고민했던 부분

-

## 📸 구현 이미지

-
<img width="744" height="620" alt="image" src="https://github.com/user-attachments/assets/d231636d-1b8b-43ce-977f-0e0ed91590d7" />


## ❇️ 코드 설명

-

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.