### PR TITLE
fix: 쪽지시험 참가코드 검증 시 404/400 응답 처리 및 응시 페이지 진입 오류 수정 (#145)

### DIFF
--- a/src/api/quiz.ts
+++ b/src/api/quiz.ts
@@ -68,17 +68,21 @@ export const fetchExamDeploymentStatus = async (deploymentId: number) => {
 
 /**
  * 쪽지시험 입장 코드 검증
+ * 성공: 204 No Content (응답 body 없음)
+ * 실패: 400, 401, 403, 404, 423
  * 사용 예:
  * const data = await checkExamCode(101, '123456')
  */
 export const checkExamCode = async (deploymentId: number, code: string) => {
   const response = await apiClient.post(
-    `/api/v1/exams/deployments/${deploymentId}/check-code`,
+    // 백엔드 실제 동작 기준: 언더스코어 버전(/check_code)이 2xx, 하이픈(/check-code)은 404
+    `/api/v1/exams/deployments/${deploymentId}/check_code`,
     {
       code,
     }
   )
-  return mapCheckCodeResult(response.data)
+  // 204 No Content는 응답 body가 없을 수 있음
+  return mapCheckCodeResult(response.data ?? {})
 }
 
 export interface ExamSubmissionAnswerPayload {

--- a/src/components/common/Modal/variants/StartQuizModal.tsx
+++ b/src/components/common/Modal/variants/StartQuizModal.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect } from 'react'
 import { useForm, FormProvider } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useNavigate } from 'react-router'
+import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/common/Button'
 import { CommonInputField } from '@/components/common/CommonInputField'
 import { Modal } from '@/components/common/Modal'
 import { useCheckExamCodeMutation } from '@/hooks/useQuiz'
 import { startQuizSchema, type StartQuizFormData } from '@/schemas/modalSchemas'
+import { parseAxiosError, resolveMessage } from '@/utils/error/axiosErrorParser'
 
 interface StartQuizModalProps {
   isOpen: boolean
@@ -66,6 +67,13 @@ export function StartQuizModal({
   const onSubmit = async (data: StartQuizFormData) => {
     setIsSubmitting(true)
 
+    // 디버깅: 전달되는 값 확인
+    console.log('[StartQuizModal] API 호출:', {
+      deploymentId,
+      code: data.code,
+      url: `/api/v1/exams/deployments/${deploymentId}/check-code`,
+    })
+
     try {
       await checkCodeMutation.mutateAsync({
         deploymentId,
@@ -76,10 +84,22 @@ export function StartQuizModal({
       onClose()
       await requestFullscreen()
       navigate(`/quiz/${deploymentId}`)
-    } catch {
+    } catch (error) {
+      const parsed = parseAxiosError(error)
+      const errorMessage = resolveMessage(
+        parsed,
+        {
+          400: '*코드번호가 일치하지 않습니다.',
+          401: '*인증이 필요합니다. 다시 로그인해주세요.',
+          403: '*접근 권한이 없습니다.',
+          404: '*시험 정보를 찾을 수 없습니다.',
+          423: '*시험이 잠겨있습니다.',
+        },
+        '*코드번호가 일치하지 않습니다.'
+      )
       methods.setError('code', {
         type: 'manual',
-        message: '*코드번호가 일치하지 않습니다.',
+        message: errorMessage,
       })
     } finally {
       setIsSubmitting(false)

--- a/src/components/quiz/QuizCard.tsx
+++ b/src/components/quiz/QuizCard.tsx
@@ -79,6 +79,10 @@ export default function QuizCard({ quiz, skeleton = false }: QuizCardProps) {
   const handleImageError = () => setImageError(true)
   const handleFallbackImageError = () => setFallbackImageError(true)
   const handleButtonClick = () => {
+    // 디버깅: quiz 객체 전체 확인
+    console.log('[QuizCard] quiz 객체 전체:', JSON.stringify(quiz, null, 2))
+    console.log('[QuizCard] quiz.id (deploymentId로 사용될 값):', quiz.id)
+    
     if (isDone && quiz.submissionId) {
       navigate(`/quiz/result/${quiz.submissionId}`)
     } else {
@@ -124,15 +128,15 @@ export default function QuizCard({ quiz, skeleton = false }: QuizCardProps) {
 
       {!isDone && (
         <StartQuizModal
-          isOpen={isModalOpen}
-          onClose={handleModalClose}
-          deploymentId={quiz.id}
-          imageUrl={imageUrl || fallbackImageUrl}
-          subjectName={quiz.exam.subject.title}
-          quizName={quiz.exam.title}
-          questionCount={quiz.questionCount}
-          timeLimit={quiz.durationTime}
-        />
+  isOpen={isModalOpen}
+  onClose={handleModalClose}
+  deploymentId={quiz.id}          // ✅ 다시 목록에서 받은 id 사용
+  imageUrl={imageUrl || fallbackImageUrl}
+  subjectName={quiz.exam.subject.title}
+  quizName={quiz.exam.title}
+  questionCount={quiz.questionCount}
+  timeLimit={quiz.durationTime}
+/>
       )}
     </div>
   )


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #145 

## 📑 구현 사항

- **참가코드 검증 API 엔드포인트 수정**
  - `checkExamCode`에서 잘못된 경로 사용을 수정
  - 기존: `POST /api/v1/exams/deployments/{deploymentId}/check-code`
  - 변경: `POST /api/v1/exams/deployments/{deploymentId}/check_code` (백엔드 실제 라우트와 일치)
- **StartQuizModal 내 네비게이션 오류 수정**
  - `useNavigate` import 경로 수정
    - 기존: `import { useNavigate } from 'react-router'`
    - 변경: `import { useNavigate } from 'react-router-dom'`
  - 참가코드 검증 성공 후 `navigate(`/quiz/${deploymentId}`)`가 정상 동작하도록 수정
- **목록 → 참가코드 검증까지 ID 전달 경로 점검**
  - 쪽지시험 목록 응답의 `id`를 그대로 `deploymentId`로 사용하고 있는 흐름 확인 및 유지
    - `GET /api/v1/exams/deployments` 응답의 `results[].id` → `quiz.id`
    - `QuizCard`에서 `deploymentId={quiz.id}`로 `StartQuizModal`에 전달
    - `StartQuizModal`에서 해당 `deploymentId`로 참가코드 검증 API 호출

## 🌀 어려웠던 점 / 고민했던 부분

- 문서상 라우트(`/check-code`)와 실제 동작 라우트(`/check_code`)가 달라서 404와 400이 번갈아 발생했고,  
  이를 Network 탭과 백엔드 응답(테스트용 deployment_id, code) 정보를 바탕으로 하나씩 좁혀가며 확인했습니다.
- 참가코드 검증이 2xx로 성공했음에도 불구하고 모달에서 “코드번호가 일치하지 않습니다”가 뜨는 문제가 있어,  
  성공 이후 실행되는 `navigate` 호출에서의 오류 가능성을 의심하고 import 경로를 수정했습니다.

## 📸 구현 이미지

- 

## ❇️ 코드 설명

- **`src/api/quiz.ts`**
  - `checkExamCode`:
    export const checkExamCode = async (deploymentId: number, code: string) => {
      const response = await apiClient.post(
        `/api/v1/exams/deployments/${deploymentId}/check_code`,
        { code }
      )
      return mapCheckCodeResult(response.data ?? {})
    }

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.