### PR TITLE
fix: 쪽지시험 잘못된 접근 처리 및 참가코드 검증 (#148)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import '@/App.css'
 import LandingPage from '@/pages/LandingPage'
 import TestPage from '@/pages/TestPage'
+import QuizInvalidAccessPage from '@/pages/QuizInvalidAccessPage'
 import LoginPage from '@/pages/LoginPage'
 import SignupPage from '@/pages/SignupPage'
 import SignupEmailPage from '@/pages/SignupEmailPage'
@@ -39,6 +40,7 @@ function App() {
           <Route element={<RequireAuth />}>
             <Route path="/mypage" element={<MyPage />}>
               <Route path="quiz" element={<MyPageQuiz />} />
+              <Route path="quiz/:deploymentId" element={<QuizInvalidAccessPage />} />
               <Route path="profile" element={<MyInfo />} />
               <Route path="password" element={<PasswordChange />} />
             </Route>

--- a/src/api/quiz.ts
+++ b/src/api/quiz.ts
@@ -46,12 +46,28 @@ export const fetchExamDeployments = async (params: FetchExamDeploymentsParams = 
  * 쪽지시험 상세/문항 조회
  * 사용 예:
  * const data = await fetchExamDeploymentDetail(101)
+ * 실 API가 { data: ... } 또는 { result: ... } 로 감싸서 보낼 수 있음.
  */
 export const fetchExamDeploymentDetail = async (deploymentId: number) => {
-  const response = await apiClient.get<ExamDeploymentDetailResponse>(
-    `/api/v1/exams/deployments/${deploymentId}`
-  )
-  return mapExamDeploymentDetail(response.data)
+  const response = await apiClient.get<
+    ExamDeploymentDetailResponse | { data: ExamDeploymentDetailResponse } | { result: ExamDeploymentDetailResponse }
+  >(`/api/v1/exams/deployments/${deploymentId}`)
+  const raw = response.data as Record<string, unknown>
+  let payload: ExamDeploymentDetailResponse = raw?.data && typeof raw.data === 'object'
+    ? (raw.data as ExamDeploymentDetailResponse)
+    : raw?.result && typeof raw.result === 'object'
+      ? (raw.result as ExamDeploymentDetailResponse)
+      : (response.data as ExamDeploymentDetailResponse)
+  // 실 API가 { exam: { exam_id, duration_time, ... }, questions: [] } 형태일 수 있음
+  const payloadRaw = payload as unknown as Record<string, unknown>
+  if (payload && payloadRaw.exam != null && Array.isArray(payloadRaw.questions)) {
+    const exam = payloadRaw.exam as Record<string, unknown>
+    payload = {
+      ...(exam as unknown as ExamDeploymentDetailResponse),
+      questions: payloadRaw.questions as ExamDeploymentDetailResponse['questions'],
+    }
+  }
+  return mapExamDeploymentDetail(payload)
 }
 
 /**

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -66,8 +66,13 @@ export function Modal({
 }: ModalProps) {
   const modalRoot = useRef<HTMLElement | null>(null)
   const modalIdRef = useRef<string>(generateModalId())
+  const [rootReady, setRootReady] = useState(false)
   useEffect(() => {
-    modalRoot.current = document.getElementById('modal-root')
+    const root = document.getElementById('modal-root')
+    if (root) {
+      modalRoot.current = root
+      setRootReady(true)
+    }
   }, [])
 
   const [isTopModal, setIsTopModal] = useState(isOpen)
@@ -178,7 +183,7 @@ export function Modal({
       </motion.div>
     )
 
-  if (!modalRoot.current) return null
+  if (!rootReady || !modalRoot.current) return null
 
   // 맨 위 모달이 아니면 backdrop처럼 처리
   if (isOpen && !isTopModal) {

--- a/src/components/common/Modal/variants/InvalidAccessModal.tsx
+++ b/src/components/common/Modal/variants/InvalidAccessModal.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react'
+import { Modal } from '../Modal'
+import { Button } from '../../Button'
+import { INVALID_ACCESS_AUTO_REDIRECT_MS } from '@/constants/quiz'
+
+export interface InvalidAccessModalProps {
+  isOpen: boolean
+  onConfirm: () => void
+  /** 자동으로 onConfirm 호출까지의 시간(ms). 0이면 비활성화 */
+  autoRedirectMs?: number
+}
+
+export function InvalidAccessModal({
+  isOpen,
+  onConfirm,
+  autoRedirectMs = INVALID_ACCESS_AUTO_REDIRECT_MS,
+}: InvalidAccessModalProps) {
+  useEffect(() => {
+    if (!isOpen || autoRedirectMs <= 0) return
+    const timer = window.setTimeout(onConfirm, autoRedirectMs)
+    return () => window.clearTimeout(timer)
+  }, [isOpen, autoRedirectMs, onConfirm])
+
+  return (
+    <Modal isOpen={isOpen} onClose={onConfirm}>
+      <Modal.Body>
+        <div className="flex min-w-[280px] flex-col items-center gap-6 py-6">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-[#FEE2E2]">
+            <span className="text-[28px] text-[#DC2626]" aria-hidden>
+              !
+            </span>
+          </div>
+          <div className="flex flex-col items-center gap-2">
+            <p className="text-center text-[18px] font-semibold text-foreground">
+              잘못된 접근입니다
+            </p>
+            <p className="text-center text-[14px] text-foreground-secondary">
+              쪽지시험 목록에서 참가코드를 입력한 후 응시해 주세요.
+            </p>
+          </div>
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button
+          variant="primary"
+          size="md"
+          rounded="default"
+          className="w-full"
+          onClick={onConfirm}
+        >
+          목록으로 이동
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/src/components/common/Modal/variants/StartQuizModal.tsx
+++ b/src/components/common/Modal/variants/StartQuizModal.tsx
@@ -7,6 +7,7 @@ import { CommonInputField } from '@/components/common/CommonInputField'
 import { Modal } from '@/components/common/Modal'
 import { useCheckExamCodeMutation } from '@/hooks/useQuiz'
 import { startQuizSchema, type StartQuizFormData } from '@/schemas/modalSchemas'
+import { getQuizVerifiedKey } from '@/constants/quiz'
 import { parseAxiosError, resolveMessage } from '@/utils/error/axiosErrorParser'
 
 interface StartQuizModalProps {
@@ -66,20 +67,13 @@ export function StartQuizModal({
 
   const onSubmit = async (data: StartQuizFormData) => {
     setIsSubmitting(true)
-
-    // 디버깅: 전달되는 값 확인
-    console.log('[StartQuizModal] API 호출:', {
-      deploymentId,
-      code: data.code,
-      url: `/api/v1/exams/deployments/${deploymentId}/check-code`,
-    })
-
     try {
       await checkCodeMutation.mutateAsync({
         deploymentId,
         code: data.code,
       })
 
+      sessionStorage.setItem(getQuizVerifiedKey(deploymentId), '1')
       onSuccess?.(data)
       onClose()
       await requestFullscreen()

--- a/src/components/common/Modal/variants/index.ts
+++ b/src/components/common/Modal/variants/index.ts
@@ -11,3 +11,4 @@ export { StartQuizModal } from './StartQuizModal' // 시험 시작 모달
 export { CheatingWarningModal } from './CheatingWarningModal' // 부정행위 경고 모달
 export { QuizEndModal } from './QuizEndModal' // 관리자에 의한 시험 종료 모달
 export { QuizSubmitCompleteModal } from './QuizSubmitCompleteModal' // 시험 제출 완료 모달
+export { InvalidAccessModal } from './InvalidAccessModal' // 잘못된 접근 안내 모달

--- a/src/constants/quiz.ts
+++ b/src/constants/quiz.ts
@@ -1,0 +1,12 @@
+/** 쪽지시험 목록 페이지 경로 */
+export const QUIZ_LIST_PATH = '/mypage/quiz'
+
+const QUIZ_VERIFIED_KEY_PREFIX = 'quiz_verified_'
+
+/** 참가코드 검증 완료 여부를 sessionStorage에 저장할 때 사용하는 키 */
+export function getQuizVerifiedKey(deploymentId: number): string {
+  return `${QUIZ_VERIFIED_KEY_PREFIX}${deploymentId}`
+}
+
+/** 잘못된 접근 모달에서 목록으로 자동 이동까지의 시간(ms) */
+export const INVALID_ACCESS_AUTO_REDIRECT_MS = 3000

--- a/src/mappers/examDeploymentDetail.ts
+++ b/src/mappers/examDeploymentDetail.ts
@@ -48,16 +48,44 @@ export interface ExamDeploymentDetailResult {
   }>
 }
 
+type ExamDeploymentDetailRaw = ExamDeploymentDetailResponse & {
+  exam?: { duration_time?: number; elapsed_time?: number }
+  deployment?: { duration_time?: number; elapsed_time?: number }
+  durationTime?: number
+  elapsedTime?: number
+}
+
+const toMinutes = (v: unknown): number => {
+  if (v === undefined || v === null) return 30
+  const n = typeof v === 'number' ? v : Number(v)
+  return Number.isFinite(n) ? n : 30
+}
+
 export const mapExamDeploymentDetail = (
-  response: ExamDeploymentDetailResponse
+  response: ExamDeploymentDetailRaw
 ): ExamDeploymentDetailResult => {
+  const rawDuration =
+    response.duration_time ??
+    response.durationTime ??
+    response.exam?.duration_time ??
+    response.deployment?.duration_time ??
+    30
+  const durationTime = toMinutes(rawDuration)
+  const rawElapsed =
+    response.elapsed_time ??
+    response.elapsedTime ??
+    response.exam?.elapsed_time ??
+    response.deployment?.elapsed_time ??
+    0
+  const elapsedTime = Math.max(0, Number(rawElapsed) || 0)
+  const questions = response.questions ?? []
   return {
     examId: response.exam_id,                             // 시험 배포 ID
     examName: response.exam_name,                         // 시험 이름
-    durationTime: response.duration_time,                 // 시험 시간(분)
-    elapsedTime: response.elapsed_time,                   // 경과 시간(분)
+    durationTime,                                         // 시험 시간(분), 실 API에서 오는 값 사용
+    elapsedTime,                                          // 경과 시간(분)
     cheatingCount: response.cheating_count,               // 부정행위 카운트
-    questions: response.questions.map((question) => ({    // 문제 목록
+    questions: questions.map((question) => ({    // 문제 목록
       questionId: question.question_id,                     // 문제 ID
       number: question.number,                              // 문제 번호
       type: question.type,                                  // 문제 유형(문제 타입)

--- a/src/pages/QuizInvalidAccessPage.tsx
+++ b/src/pages/QuizInvalidAccessPage.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { InvalidAccessModal } from '@/components/common'
+import {
+  INVALID_ACCESS_AUTO_REDIRECT_MS,
+  QUIZ_LIST_PATH,
+} from '@/constants/quiz'
+
+export default function QuizInvalidAccessPage() {
+  const navigate = useNavigate()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  const handleConfirm = () => {
+    navigate(QUIZ_LIST_PATH, { replace: true })
+  }
+
+  if (!mounted) return null
+
+  return (
+    <InvalidAccessModal
+      isOpen
+      onConfirm={handleConfirm}
+      autoRedirectMs={INVALID_ACCESS_AUTO_REDIRECT_MS}
+    />
+  )
+}

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -25,6 +25,7 @@ import {
   Ordering,
   ShortAnswer,
 } from '@/components/quiz'
+import { QUIZ_LIST_PATH, getQuizVerifiedKey } from '@/constants/quiz'
 import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
 
 type Question = ExamDeploymentDetailResult['questions'][0]
@@ -50,6 +51,7 @@ function QuizPage() {
   const queryClient = useQueryClient()
   const { deploymentId } = useParams<{ deploymentId: string }>()
   const deploymentIdNumber = deploymentId ? Number(deploymentId) : 0
+  const [isAccessAllowed, setIsAccessAllowed] = useState<boolean | null>(null)
   const [isEnded, setIsEnded] = useState(false)
   const [endReason, setEndReason] = useState<
     'time' | 'status' | 'cheating' | null
@@ -137,8 +139,15 @@ function QuizPage() {
 
   const navigateToResultOrList = (submissionId: number | null) => {
     exitFullscreenIfActive().then(() =>
-      navigate(submissionId != null ? `/quiz/result/${submissionId}` : '/mypage/quiz')
+      navigate(
+        submissionId != null ? `/quiz/result/${submissionId}` : QUIZ_LIST_PATH
+      )
     )
+  }
+
+  const clearVerificationAndNavigate = (submissionId: number | null) => {
+    sessionStorage.removeItem(getQuizVerifiedKey(deploymentIdNumber))
+    navigateToResultOrList(submissionId)
   }
 
   // 푼 문항은 제출값, 미응답은 '' 또는 []로 제출(서버에서 0점 처리)
@@ -158,24 +167,24 @@ function QuizPage() {
     }
   }
 
-  // 3회 부정행위 감지 시: 시험 종료 처리 후 현재 답안 자동 제출 → 결과 페이지 이동, 목록 응시완료 반영
+  // 3회 부정행위 감지 시: 시험 종료 처리 후 현재 답안 자동 제출 → 결과 페이지 이동
   const handleCheatingTerminate = () => {
     setOpenModal(null)
     setIsEnded(true)
     setEndReason('cheating')
     const payload = buildSubmitPayload()
     if (!payload) {
-      navigateToResultOrList(null)
+      clearVerificationAndNavigate(null)
       return
     }
     submissionMutation.mutate(payload, {
       onSuccess: (result) => {
         applySubmitSuccess(result)
-        navigateToResultOrList(result.submissionId)
+        clearVerificationAndNavigate(result.submissionId)
       },
       onError: () => {
         queryClient.invalidateQueries({ queryKey: ['examDeployments'] })
-        navigateToResultOrList(null)
+        clearVerificationAndNavigate(null)
       },
     })
   }
@@ -196,14 +205,14 @@ function QuizPage() {
     setOpenModal(null)
     setSubmittedSubmissionId(null)
     submittedSubmissionIdRef.current = null
-    navigateToResultOrList(sid)
+    clearVerificationAndNavigate(sid)
   }
 
   const handleEndConfirm = () => {
     const sid = submittedSubmissionIdRef.current ?? submittedSubmissionId
     setSubmittedSubmissionId(null)
     submittedSubmissionIdRef.current = null
-    navigateToResultOrList(sid)
+    clearVerificationAndNavigate(sid)
   }
 
   // —— 시간 종료 (버튼/실제 만료 공통) ——
@@ -247,6 +256,24 @@ function QuizPage() {
   }
 
   const handleCloseSubmitCompleteModal = () => setOpenModal(null)
+
+  // 참가코드 검증 없이 URL로 직접 접근 시 경고 팝업 후 목록으로 리다이렉트
+  useEffect(() => {
+    const hasValidDeployment =
+      deploymentId && deploymentIdNumber > 0
+    const isVerified =
+      hasValidDeployment &&
+      sessionStorage.getItem(getQuizVerifiedKey(deploymentIdNumber))
+
+    if (!isVerified) {
+      window.alert(
+        '접근할 수 없습니다. 쪽지시험 목록에서 참가코드를 입력한 후 응시해 주세요.'
+      )
+      navigate(QUIZ_LIST_PATH, { replace: true })
+      return
+    }
+    setIsAccessAllowed(true)
+  }, [deploymentId, deploymentIdNumber, navigate])
 
   // —— 부수효과: 이벤트 리스너 & 타이머 ——
   useEffect(() => {
@@ -343,17 +370,17 @@ function QuizPage() {
   useEffect(() => {
     if (!showQuizEndModal) return
     const timer = window.setTimeout(() => {
-      navigateToResultOrList(submittedSubmissionIdRef.current)
+      clearVerificationAndNavigate(submittedSubmissionIdRef.current)
     }, STATUS_END_AUTO_NAVIGATE_MS)
     return () => window.clearTimeout(timer)
-  }, [showQuizEndModal, navigateToResultOrList])
+  }, [showQuizEndModal])
 
   const warningLevel = Math.min(
     Math.max(cheatingCount, 1),
     3
   ) as 1 | 2 | 3
 
-  if (isLoading) {
+  if (isAccessAllowed !== true || isLoading) {
     return <Loading />
   }
 

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { useNavigate, useParams } from 'react-router-dom'
 import {
   Button,
@@ -37,16 +38,23 @@ const ARRAY_ANSWER_TYPES = new Set<Question['type']>([
   'ordering',
 ])
 
+const CHEATING_DEBOUNCE_MS = 800
+const INITIAL_REMAINING_SECONDS = 30 * 60
+const STATUS_END_AUTO_NAVIGATE_MS = 5000
+
+// 문제풀이 후 "제출하기"로 답안 제출 → 자동 채점 → 결과 페이지 이동
+// 시간 초과 시: 푼 문항 제출, 미응답 0점 처리, 목록 응시완료 반영
+
 function QuizPage() {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const { deploymentId } = useParams<{ deploymentId: string }>()
   const deploymentIdNumber = deploymentId ? Number(deploymentId) : 0
   const [isEnded, setIsEnded] = useState(false)
   const [endReason, setEndReason] = useState<
     'time' | 'status' | 'cheating' | null
   >(null)
-  // 타이머: 실 API duration_time(분)으로 초기화됨. 로딩 전까지 30분 표시
-  const [remainingSeconds, setRemainingSeconds] = useState(30 * 60)
+  const [remainingSeconds, setRemainingSeconds] = useState(INITIAL_REMAINING_SECONDS)
   const [cheatingCount, setCheatingCount] = useState(0)
   const [openModal, setOpenModal] = useState<OpenModal | null>(null)
   const [submittedSubmissionId, setSubmittedSubmissionId] = useState<
@@ -54,6 +62,9 @@ function QuizPage() {
   >(null)
   const lastCheatingAtRef = useRef(0)
   const hasInitializedTimerFromApi = useRef(false)
+  const hasAutoSubmittedRef = useRef(false)
+  const submittedSubmissionIdRef = useRef<number | null>(null)
+  const submitAndEndByTimeRef = useRef<() => void>(() => {})
 
   const submissionMutation = useExamSubmissionMutation()
   const { data, isLoading } = useExamDeploymentDetailQuery(
@@ -68,20 +79,14 @@ function QuizPage() {
     Record<number, string | string[] | null>
   >({})
 
-  // 답변 변경 핸들러
+  // —— 답안 & 문제 렌더링 ——
   const handleAnswerChange = (questionId: number, answer: string | string[]) => {
     setAnswers((prev) => ({ ...prev, [questionId]: answer }))
   }
 
   const renderQuestion = (question: Question) => {
-
-    // 문제에 대한 답변 처리
     const answer = answers[question.questionId] ?? null
-    // 문제에 대한 공통 속성 처리
-    const commonProps = {
-      question, // 문제 정보
-      onAnswerChange: handleAnswerChange, // 답변 변경 핸들러
-    }
+    const commonProps = { question, onAnswerChange: handleAnswerChange }
     switch (question.type) {
       case 'single_choice':
         return <SingleChoice {...commonProps} answer={answer as string | null} />
@@ -102,34 +107,41 @@ function QuizPage() {
     }
   }
 
+  // —— 부정행위 감지 ——
   const handleCheatingDetected = () => {
     if (isEnded) return
     const now = Date.now()
-    if (now - lastCheatingAtRef.current < 800) return
+    if (now - lastCheatingAtRef.current < CHEATING_DEBOUNCE_MS) return
     lastCheatingAtRef.current = now
-    setCheatingCount((prev) => {
-      const next = Math.min(prev + 1, 3)
-      setOpenModal('cheating')
-      return next
-    })
+    setCheatingCount((prev) => Math.min(prev + 1, 3))
+    setOpenModal('cheating')
   }
 
   const handleCheatingClose = () => setOpenModal(null)
-  const handleCheatingTerminate = () => {
-    setOpenModal(null)
-    // TODO: 3회 부정행위 감지 시 자동 제출 및 결과 페이지 이동 처리 필요
-  }
 
+  // —— 공통: 전체화면 해제, 제출 성공 반영, 결과/목록 이동 ——
   const exitFullscreenIfActive = async () => {
-    if (document.fullscreenElement) {
-      try {
-        await document.exitFullscreen()
-      } catch {
-        // ignore
-      }
+    if (!document.fullscreenElement) return
+    try {
+      await document.exitFullscreen()
+    } catch {
+      // ignore
     }
   }
 
+  const applySubmitSuccess = (result: { submissionId: number }) => {
+    setSubmittedSubmissionId(result.submissionId)
+    submittedSubmissionIdRef.current = result.submissionId
+    queryClient.invalidateQueries({ queryKey: ['examDeployments'] })
+  }
+
+  const navigateToResultOrList = (submissionId: number | null) => {
+    exitFullscreenIfActive().then(() =>
+      navigate(submissionId != null ? `/quiz/result/${submissionId}` : '/mypage/quiz')
+    )
+  }
+
+  // 푼 문항은 제출값, 미응답은 '' 또는 []로 제출(서버에서 0점 처리)
   const buildSubmitPayload = () => {
     if (!data?.questions) return null
     const answerList = data.questions.map((q) => {
@@ -146,36 +158,80 @@ function QuizPage() {
     }
   }
 
+  // 3회 부정행위 감지 시: 시험 종료 처리 후 현재 답안 자동 제출 → 결과 페이지 이동, 목록 응시완료 반영
+  const handleCheatingTerminate = () => {
+    setOpenModal(null)
+    setIsEnded(true)
+    setEndReason('cheating')
+    const payload = buildSubmitPayload()
+    if (!payload) {
+      navigateToResultOrList(null)
+      return
+    }
+    submissionMutation.mutate(payload, {
+      onSuccess: (result) => {
+        applySubmitSuccess(result)
+        navigateToResultOrList(result.submissionId)
+      },
+      onError: () => {
+        queryClient.invalidateQueries({ queryKey: ['examDeployments'] })
+        navigateToResultOrList(null)
+      },
+    })
+  }
+
   const handleSubmit = () => {
     const payload = buildSubmitPayload()
     if (!payload) return
     submissionMutation.mutate(payload, {
       onSuccess: (result) => {
-        setSubmittedSubmissionId(result.submissionId)
+        applySubmitSuccess(result)
         setOpenModal('submitComplete')
       },
     })
   }
 
   const handleSubmitCompleteConfirm = () => {
-    setOpenModal(null)
     const sid = submittedSubmissionId
+    setOpenModal(null)
     setSubmittedSubmissionId(null)
-    exitFullscreenIfActive().then(() => {
-      navigate(sid !== null ? `/quiz/result/${sid}` : '/mypage/quiz')
-    })
+    submittedSubmissionIdRef.current = null
+    navigateToResultOrList(sid)
   }
 
   const handleEndConfirm = () => {
-    exitFullscreenIfActive().then(() => navigate('/mypage/quiz'))
+    const sid = submittedSubmissionIdRef.current ?? submittedSubmissionId
+    setSubmittedSubmissionId(null)
+    submittedSubmissionIdRef.current = null
+    navigateToResultOrList(sid)
   }
 
-  const handleTimeEndTest = () => {
+  // —— 시간 종료 (버튼/실제 만료 공통) ——
+  const endQuizByTime = () => {
     setRemainingSeconds(0)
     setIsEnded(true)
     setEndReason('time')
   }
 
+  const submitAndEndByTime = () => {
+    if (hasAutoSubmittedRef.current) return
+    hasAutoSubmittedRef.current = true
+    const payload = buildSubmitPayload()
+    if (!payload) {
+      endQuizByTime()
+      return
+    }
+    submissionMutation.mutate(payload, {
+      onSuccess: applySubmitSuccess,
+      onError: () => {
+        queryClient.invalidateQueries({ queryKey: ['examDeployments'] })
+      },
+    })
+    endQuizByTime()
+  }
+  submitAndEndByTimeRef.current = submitAndEndByTime
+
+  const handleTimeEndTest = () => submitAndEndByTime()
   const handleStatusEndTest = () => {
     setIsEnded(true)
     setEndReason('status')
@@ -192,6 +248,7 @@ function QuizPage() {
 
   const handleCloseSubmitCompleteModal = () => setOpenModal(null)
 
+  // —— 부수효과: 이벤트 리스너 & 타이머 ——
   useEffect(() => {
     if (isEnded) return
     const handleVisibilityChange = () => {
@@ -241,7 +298,6 @@ function QuizPage() {
     }
   }, [handleCheatingDetected, cheatingCount])
 
-  // 실 API duration_time(분), elapsed_time(분)으로 남은 시간 계산 후 타이머에 적용 (최초 1회)
   useEffect(() => {
     if (!data || hasInitializedTimerFromApi.current || isEnded) return
     hasInitializedTimerFromApi.current = true
@@ -257,14 +313,12 @@ function QuizPage() {
     const timer = setInterval(() => {
       setRemainingSeconds((prev) => {
         if (prev <= 1) {
-          setIsEnded(true)
-          setEndReason('time')
+          submitAndEndByTimeRef.current()
           return 0
         }
         return prev - 1
       })
     }, 1000)
-
     return () => clearInterval(timer)
   }, [isEnded])
 
@@ -289,10 +343,10 @@ function QuizPage() {
   useEffect(() => {
     if (!showQuizEndModal) return
     const timer = window.setTimeout(() => {
-      exitFullscreenIfActive().then(() => navigate('/mypage/quiz'))
-    }, 5000)
+      navigateToResultOrList(submittedSubmissionIdRef.current)
+    }, STATUS_END_AUTO_NAVIGATE_MS)
     return () => window.clearTimeout(timer)
-  }, [showQuizEndModal])
+  }, [showQuizEndModal, navigateToResultOrList])
 
   const warningLevel = Math.min(
     Math.max(cheatingCount, 1),
@@ -320,6 +374,7 @@ function QuizPage() {
             size="sm"
             rounded="default"
             onClick={handleTimeEndTest}
+            aria-label="시험 완료 처리, 작성한 문항 제출·미작성 0점 제출 후 결과 페이지 이동·목록 응시완료"
           >
             타이머 종료 테스트
           </Button>
@@ -342,7 +397,7 @@ function QuizPage() {
             </div>
           ) : (
             <div className="flex items-center justify-center py-20">
-              <NotFound detail="표시할 문제가 없습니다.." />
+              <NotFound detail="표시할 문제가 없습니다." />
             </div>
           )}
         </div>
@@ -356,6 +411,7 @@ function QuizPage() {
             rounded="default"
             onClick={handleSubmit}
             disabled={submissionMutation.isPending}
+            aria-label="문제풀이 답안 제출 후 채점 결과 확인 페이지로 이동"
           >
             {submissionMutation.isPending ? '제출 중...' : '제출하기'}
           </Button>
@@ -392,7 +448,7 @@ function QuizPage() {
         </Modal.Footer>
       </Modal>
 
-      {/* 시간 종료 모달 */}
+      {/* 시간 종료 모달: 자동 제출 후 확인 시 결과 페이지 또는 목록으로 */}
       <Modal isOpen={showTimeEndModal} onClose={handleEndConfirm}>
         <Modal.Body>
           <div className="flex min-w-[250px] flex-col items-center gap-6 py-4">
@@ -403,6 +459,8 @@ function QuizPage() {
             />
             <p className="text-center text-[16px] text-foreground-secondary">
               시험 시간이 종료되었습니다.
+              {submittedSubmissionId != null &&
+                ' 답안이 제출되었습니다. (풀지 못한 문항은 0점 처리됩니다)'}
             </p>
           </div>
         </Modal.Body>
@@ -413,8 +471,9 @@ function QuizPage() {
             rounded="default"
             className="w-full"
             onClick={handleEndConfirm}
+            disabled={submissionMutation.isPending}
           >
-            확인
+            {submissionMutation.isPending ? '제출 중...' : '확인'}
           </Button>
         </Modal.Footer>
       </Modal>

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -52,6 +52,7 @@ function QuizPage() {
     number | null
   >(null)
   const lastCheatingAtRef = useRef(0)
+  const hasInitializedTimerFromApi = useRef(false)
 
   const submissionMutation = useExamSubmissionMutation()
   const { data, isLoading } = useExamDeploymentDetailQuery(
@@ -238,6 +239,20 @@ function QuizPage() {
       window.removeEventListener('keydown', handleKeyDown)
     }
   }, [handleCheatingDetected, cheatingCount])
+
+  // 문제 불러온 뒤 API의 duration_time, elapsed_time으로 타이머 초기화 (한 번만)
+  useEffect(() => {
+    if (!data || hasInitializedTimerFromApi.current || isEnded) return
+    hasInitializedTimerFromApi.current = true
+    const totalSeconds = data.durationTime * 60
+    const elapsedSeconds = (data.elapsedTime ?? 0) * 60
+    const remaining = Math.max(0, totalSeconds - elapsedSeconds)
+    setRemainingSeconds(remaining)
+    if (remaining <= 0) {
+      setIsEnded(true)
+      setEndReason('time')
+    }
+  }, [data, isEnded])
 
   useEffect(() => {
     if (isEnded) return

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import {
   Button,
@@ -28,6 +28,15 @@ import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
 
 type Question = ExamDeploymentDetailResult['questions'][0]
 
+/** 열린 모달: cheating=부정행위 안내(1차·2차 경고 → 3차 시 종료), fullscreen=전체화면 해제 안내, submitComplete=제출 완료 */
+type OpenModal = 'cheating' | 'fullscreen' | 'submitComplete'
+
+const ARRAY_ANSWER_TYPES = new Set<Question['type']>([
+  'multiple_choice',
+  'fill_blank',
+  'ordering',
+])
+
 function QuizPage() {
   const navigate = useNavigate()
   const { deploymentId } = useParams<{ deploymentId: string }>()
@@ -38,14 +47,13 @@ function QuizPage() {
   >(null)
   const [remainingSeconds, setRemainingSeconds] = useState(30 * 60)
   const [cheatingCount, setCheatingCount] = useState(0)
-  const [isCheatingModalOpen, setIsCheatingModalOpen] = useState(false)
-  const [isFullscreenModalOpen, setIsFullscreenModalOpen] = useState(false)
-  const [isSubmitCompleteModalOpen, setIsSubmitCompleteModalOpen] = useState(false)
-  const [submittedSubmissionId, setSubmittedSubmissionId] = useState<number | null>(null)
+  const [openModal, setOpenModal] = useState<OpenModal | null>(null)
+  const [submittedSubmissionId, setSubmittedSubmissionId] = useState<
+    number | null
+  >(null)
   const lastCheatingAtRef = useRef(0)
 
   const submissionMutation = useExamSubmissionMutation()
-
   const { data, isLoading } = useExamDeploymentDetailQuery(
     deploymentIdNumber,
     !!deploymentId
@@ -54,112 +62,63 @@ function QuizPage() {
     deploymentIdNumber,
     !!deploymentId && !isEnded
   )
-
-  // 답변 상태 관리
   const [answers, setAnswers] = useState<
     Record<number, string | string[] | null>
   >({})
 
   // 답변 변경 핸들러
-  const handleAnswerChange = (
-    questionId: number,
-    answer: string | string[]
-  ) => {
-    setAnswers((prev) => ({
-      ...prev,
-      [questionId]: answer,
-    }))
+  const handleAnswerChange = (questionId: number, answer: string | string[]) => {
+    setAnswers((prev) => ({ ...prev, [questionId]: answer }))
   }
 
-  // 문제 유형별 컴포넌트 렌더링
-  // 남은 문제 유형 2가지 추가 예정 :  ⭐️ 다중선택(체크박스), 단답형(텍스트 입력) ⭐️
   const renderQuestion = (question: Question) => {
-    const answer = answers[question.questionId] || null
 
+    // 문제에 대한 답변 처리
+    const answer = answers[question.questionId] ?? null
+    // 문제에 대한 공통 속성 처리
+    const commonProps = {
+      question, // 문제 정보
+      onAnswerChange: handleAnswerChange, // 답변 변경 핸들러
+    }
     switch (question.type) {
-      case 'single_choice': // 단일선택 (라디오 버튼)
+      case 'single_choice':
+        return <SingleChoice {...commonProps} answer={answer as string | null} />
+      case 'multiple_choice':
         return (
-          <SingleChoice
-            question={question}
-            answer={answer as string | null}
-            onAnswerChange={handleAnswerChange}
-          />
+          <MultipleChoice {...commonProps} answer={answer as string[] | null} />
         )
-      case 'multiple_choice': // 다중선택
-        return (
-          <MultipleChoice
-            question={question}
-            answer={answer as string[] | null}
-            onAnswerChange={handleAnswerChange}
-          />
-        )
-      case 'short_answer': // 단답형
-        return (
-          <ShortAnswer
-            question={question}
-            answer={answer as string | null}
-            onAnswerChange={handleAnswerChange}
-          />
-        )
-      case 'ox': // O/X 선택
-        return (
-          <OX
-            question={question}
-            answer={answer as string | null}
-            onAnswerChange={handleAnswerChange}
-          />
-        )
-      case 'fill_blank': // 빈칸 채우기
-        return (
-          <FillBlank
-            question={question}
-            answer={answer as string[] | null}
-            onAnswerChange={handleAnswerChange}
-          />
-        )
-      case 'ordering': // 순서 맞추기
-        return (
-          <Ordering
-            question={question}
-            answer={answer as string[] | null}
-            onAnswerChange={handleAnswerChange}
-          />
-        )
+      case 'short_answer':
+        return <ShortAnswer {...commonProps} answer={answer as string | null} />
+      case 'ox':
+        return <OX {...commonProps} answer={answer as string | null} />
+      case 'fill_blank':
+        return <FillBlank {...commonProps} answer={answer as string[] | null} />
+      case 'ordering':
+        return <Ordering {...commonProps} answer={answer as string[] | null} />
       default:
         return null
     }
   }
 
-  const handleAutoSubmit = () => {
-    // 부정행위로 종료될 때 자동 제출 처리(나중에 API 연결 예정)
-  }
-
-  
-  const handleCheatingDetected = useCallback(() => {
+  const handleCheatingDetected = () => {
     if (isEnded) return
     const now = Date.now()
     if (now - lastCheatingAtRef.current < 800) return
     lastCheatingAtRef.current = now
-
     setCheatingCount((prev) => {
       const next = Math.min(prev + 1, 3)
-      setIsCheatingModalOpen(true)
+      setOpenModal('cheating')
       return next
     })
-  }, [isEnded])
-
-  const handleCheatingClose = () => {
-    setIsCheatingModalOpen(false)
   }
 
+  const handleCheatingClose = () => setOpenModal(null)
   const handleCheatingTerminate = () => {
-    setIsCheatingModalOpen(false)
+    setOpenModal(null)
     // TODO: 3회 부정행위 감지 시 자동 제출 및 결과 페이지 이동 처리 필요
-    handleAutoSubmit();
   }
 
-  // 응시 페이지를 떠날 때 전체화면 해제 (제출 완료, 시간/상태 종료 )
-  const exitFullscreenIfActive = useCallback(async () => {
+  const exitFullscreenIfActive = async () => {
     if (document.fullscreenElement) {
       try {
         await document.exitFullscreen()
@@ -167,16 +126,16 @@ function QuizPage() {
         // ignore
       }
     }
-  }, [])
+  }
 
-  // 제출 데이터 생성
   const buildSubmitPayload = () => {
     if (!data?.questions) return null
-    const answerList = data.questions.map((q) => ({
-      question_id: q.questionId,
-      type: q.type,
-      submitted_answer: answers[q.questionId] ?? null,
-    }))
+    const answerList = data.questions.map((q) => {
+      const raw = answers[q.questionId]
+      const submitted_answer =
+        raw != null ? raw : ARRAY_ANSWER_TYPES.has(q.type) ? [] : ''
+      return { question_id: q.questionId, type: q.type, submitted_answer }
+    })
     return {
       deployment_id: deploymentIdNumber,
       started_at: new Date().toISOString(),
@@ -191,23 +150,45 @@ function QuizPage() {
     submissionMutation.mutate(payload, {
       onSuccess: (result) => {
         setSubmittedSubmissionId(result.submissionId)
-        setIsSubmitCompleteModalOpen(true)
+        setOpenModal('submitComplete')
       },
     })
   }
 
   const handleSubmitCompleteConfirm = () => {
-    setIsSubmitCompleteModalOpen(false)
-    const goTo = () => {
-      if (submittedSubmissionId !== null) {
-        navigate(`/quiz/result/${submittedSubmissionId}`)
-        setSubmittedSubmissionId(null)
-      } else {
-        navigate('/mypage/quiz')
-      }
-    }
-    exitFullscreenIfActive().then(goTo)
+    setOpenModal(null)
+    const sid = submittedSubmissionId
+    setSubmittedSubmissionId(null)
+    exitFullscreenIfActive().then(() => {
+      navigate(sid !== null ? `/quiz/result/${sid}` : '/mypage/quiz')
+    })
   }
+
+  const handleEndConfirm = () => {
+    exitFullscreenIfActive().then(() => navigate('/mypage/quiz'))
+  }
+
+  const handleTimeEndTest = () => {
+    setRemainingSeconds(0)
+    setIsEnded(true)
+    setEndReason('time')
+  }
+
+  const handleStatusEndTest = () => {
+    setIsEnded(true)
+    setEndReason('status')
+  }
+
+  const handleFullscreenRetry = async () => {
+    try {
+      await document.documentElement.requestFullscreen()
+      setOpenModal(null)
+    } catch {
+      // 전체화면 전환 실패 시 무시
+    }
+  }
+
+  const handleCloseSubmitCompleteModal = () => setOpenModal(null)
 
   useEffect(() => {
     if (isEnded) return
@@ -239,7 +220,7 @@ function QuizPage() {
     const handleFullscreenChange = () => {
       if (cheatingCount >= 3) return
       if (!document.fullscreenElement) {
-        setIsFullscreenModalOpen(true)
+        setOpenModal('fullscreen')
       }
     }
 
@@ -287,45 +268,23 @@ function QuizPage() {
   }, [statusData, isEnded])
 
   const minutes = Math.floor(remainingSeconds / 60)
-  const seconds = remainingSeconds % 60
-  const paddedSeconds = seconds.toString().padStart(2, '0')
-  const formattedRemaining = `${minutes} : ${paddedSeconds}`
+  const seconds = (remainingSeconds % 60).toString().padStart(2, '0')
+  const formattedRemaining = `${minutes} : ${seconds}`
   const showTimeEndModal = isEnded && endReason === 'time'
   const showQuizEndModal = isEnded && endReason === 'status'
 
-  // 시험 종료 시 전체화면 해제 후 쪽지시험 리스트로 이동
-  const handleEndConfirm = () => {
-    exitFullscreenIfActive().then(() => navigate('/mypage/quiz'))
-  }
-
-  // 상태 종료 시 QuizEndModal 표시 후 5초 뒤 쪽지시험 리스트로 이동
   useEffect(() => {
     if (!showQuizEndModal) return
     const timer = window.setTimeout(() => {
       exitFullscreenIfActive().then(() => navigate('/mypage/quiz'))
     }, 5000)
     return () => window.clearTimeout(timer)
-  }, [showQuizEndModal, navigate, exitFullscreenIfActive])
+  }, [showQuizEndModal])
 
-  const handleTimeEndTest = () => {
-    setRemainingSeconds(0)
-    setIsEnded(true)
-    setEndReason('time')
-  }
-
-  const handleStatusEndTest = () => {
-    setIsEnded(true)
-    setEndReason('status')
-  }
-
-  const handleFullscreenRetry = async () => {
-    try {
-      await document.documentElement.requestFullscreen()
-      setIsFullscreenModalOpen(false)
-    } catch {
-      //전체화면 해제 실패 시 무시
-    }
-  }
+  const warningLevel = Math.min(
+    Math.max(cheatingCount, 1),
+    3
+  ) as 1 | 2 | 3
 
   if (isLoading) {
     return <Loading />
@@ -391,14 +350,14 @@ function QuizPage() {
       </footer>
 
       <CheatingWarningModal
-        isOpen={isCheatingModalOpen}
+        isOpen={openModal === 'cheating'}
         onClose={handleCheatingClose}
-        warningLevel={Math.min(Math.max(cheatingCount, 1), 3) as 1 | 2 | 3}
+        warningLevel={warningLevel}
         onConfirm={handleCheatingClose}
         onTerminate={handleCheatingTerminate}
       />
 
-      <Modal isOpen={isFullscreenModalOpen} onClose={() => {}}>
+      <Modal isOpen={openModal === 'fullscreen'} onClose={() => {}}>
         <Modal.Body>
           <div className="flex min-w-[250px] flex-col items-center gap-4 py-4">
             <p className="text-center text-[16px] text-foreground-secondary">
@@ -456,8 +415,8 @@ function QuizPage() {
 
       {/* 제출하기 완료 모달 */}
       <QuizSubmitCompleteModal
-        isOpen={isSubmitCompleteModalOpen}
-        onClose={() => setIsSubmitCompleteModalOpen(false)}
+        isOpen={openModal === 'submitComplete'}
+        onClose={handleCloseSubmitCompleteModal}
         onConfirm={handleSubmitCompleteConfirm}
       />
     </div>

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -45,6 +45,7 @@ function QuizPage() {
   const [endReason, setEndReason] = useState<
     'time' | 'status' | 'cheating' | null
   >(null)
+  // 타이머: 실 API duration_time(분)으로 초기화됨. 로딩 전까지 30분 표시
   const [remainingSeconds, setRemainingSeconds] = useState(30 * 60)
   const [cheatingCount, setCheatingCount] = useState(0)
   const [openModal, setOpenModal] = useState<OpenModal | null>(null)
@@ -240,18 +241,15 @@ function QuizPage() {
     }
   }, [handleCheatingDetected, cheatingCount])
 
-  // 문제 불러온 뒤 API의 duration_time, elapsed_time으로 타이머 초기화 (한 번만)
+  // 실 API duration_time(분), elapsed_time(분)으로 남은 시간 계산 후 타이머에 적용 (최초 1회)
   useEffect(() => {
     if (!data || hasInitializedTimerFromApi.current || isEnded) return
     hasInitializedTimerFromApi.current = true
-    const totalSeconds = data.durationTime * 60
+    const durationMinutes = data.durationTime
+    const totalSeconds = durationMinutes * 60
     const elapsedSeconds = (data.elapsedTime ?? 0) * 60
     const remaining = Math.max(0, totalSeconds - elapsedSeconds)
-    setRemainingSeconds(remaining)
-    if (remaining <= 0) {
-      setIsEnded(true)
-      setEndReason('time')
-    }
+    setRemainingSeconds(remaining > 0 ? remaining : totalSeconds)
   }, [data, isEnded])
 
   useEffect(() => {


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #148 

## 📑 구현 사항

- **잘못된 URL 접근 처리**: `/mypage/quiz/:deploymentId` 직접 접근 시 "잘못된 접근입니다" 모달을 띄우고, 3초 후 쪽지시험 목록(`/mypage/quiz`)으로 자동 이동
- **참가코드 검증 플로우**: 목록에서 참가코드 입력 후 시험 시작 시 `sessionStorage`에 검증 완료 저장 → 퀴즈 페이지 진입 시 검증 여부 확인, 미검증이면 경고 후 목록으로 리다이렉트
- **모달 미노출 수정**: `modal-root`가 준비된 뒤 한 번 더 리렌더되도록 `rootReady` state 추가해, 잘못된 접근 페이지에서 모달이 확실히 보이도록 처리
- **공통 상수·로직 정리**: `constants/quiz.ts` 추가(경로, sessionStorage 키, 자동 리다이렉트 시간), QuizPage에 `clearVerificationAndNavigate()` 헬퍼로 검증 제거 + 이동 로직 통합

## 🌀 어려웠던 점 / 고민했던 부분

- **모달이 안 뜨는 현상**: 첫 렌더에서 `modalRoot.current`를 ref로만 세팅하면 ref 갱신만 되고 리렌더가 일어나지 않아, 포털이 그려지지 않는 경우가 있었음. `modal-root`를 찾은 뒤 **state(`rootReady`)를 갱신**해 리렌더를 한 번 더 유도하는 방식으로 해결
- **접근 경로 두 가지 구분**: "목록 경로인데 deploymentId가 붙은 URL"(`/mypage/quiz/7`)과 "실제 퀴즈 응시 URL"(`/quiz/7`)을 구분해, 전자는 잘못된 접근 페이지(모달 후 리다이렉트), 후자는 참가코드 검증 후에만 진입 가능하도록 분기 처리
- **검증 제거 시점**: 시험 제출 완료·부정행위 종료·관리자 종료 등 여러 곳에서 `sessionStorage` 제거 후 이동하는 로직이 반복되어, `clearVerificationAndNavigate()` 한 곳으로 모아서 유지보수하기 쉽게 정리

## 📸 구현 이미지

https://github.com/user-attachments/assets/fde17c62-e373-4822-8b9e-bf73090c0822

## ❇️ 코드 설명

- **`constants/quiz.ts`**: 쪽지시험 목록 경로(`QUIZ_LIST_PATH`), 참가코드 검증용 sessionStorage 키 생성(`getQuizVerifiedKey(deploymentId)`), 잘못된 접근 모달 자동 리다이렉트 시간(`INVALID_ACCESS_AUTO_REDIRECT_MS`)을 한 곳에서 관리
- **`QuizInvalidAccessPage`**: 마운트 후에만 `InvalidAccessModal`을 렌더해 라우트 전환 직후에도 모달이 안정적으로 뜨도록 하고, `onConfirm`에서 `QUIZ_LIST_PATH`로 `replace` 이동
- **`InvalidAccessModal`**: `isOpen`일 때 `autoRedirectMs` 후 `onConfirm` 호출하는 `useEffect`로 3초 자동 리다이렉트, 공통 `Modal` + "잘못된 접근입니다" 문구·목록으로 이동 버튼 UI
- **`QuizPage`**: 진입 시 `getQuizVerifiedKey(deploymentIdNumber)`로 검증 여부 확인 → 미검증이면 `alert` 후 `QUIZ_LIST_PATH`로 이동. 시험 종료·제출 완료 시 `clearVerificationAndNavigate(submissionId)`로 검증 제거와 결과/목록 이동을 한 번에 처리
- **`Modal.tsx`**: `document.getElementById('modal-root')`로 root를 찾은 뒤 `setRootReady(true)`로 state 갱신해, root가 준비된 다음 렌더에서 포털이 그려지도록 보장

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.