### PR TITLE
 refactor: 쪽지시험 결과·목록·응시 페이지 클린코드 리팩토링 (#155)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,15 +4,17 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import '@/App.css'
 import LandingPage from '@/pages/LandingPage'
 import TestPage from '@/pages/TestPage'
-import QuizInvalidAccessPage from '@/pages/QuizInvalidAccessPage'
+import {
+  QuizInvalidAccessPage,
+  QuizPage,
+  QuizResultPage,
+  MyPageQuiz,
+} from '@/features/quiz'
 import LoginPage from '@/pages/LoginPage'
 import SignupPage from '@/pages/SignupPage'
 import SignupEmailPage from '@/pages/SignupEmailPage'
 import SocialLoginCallbackPage from '@/pages/SocialLoginCallbackPage'
 import MyPage from '@/pages/MyPage'
-import MyPageQuiz from '@/components/MyPageQuiz'
-import QuizPage from '@/pages/QuizPage'
-import QuizResultPage from '@/pages/QuizResultPage'
 import MainLayout from '@/components/layout/MainLayout'
 import { RequireAuth } from '@/components/auth/RequireAuth'
 import MyInfo from './components/MyInfo'

--- a/src/components/MyPageQuiz.tsx
+++ b/src/components/MyPageQuiz.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo } from 'react'
-import { useInfiniteQuery } from '@tanstack/react-query'
-import { fetchExamDeployments } from '@/api/quiz'
+import { useExamDeploymentsInfiniteQuery } from '@/hooks/useQuiz'
 import QuizTabs, { Tabs } from '@/components/quiz/QuizTabs'
 import QuizContent from '@/components/quiz/QuizContent'
 
@@ -17,14 +16,7 @@ const MyPageQuiz = () => {
     [currentTab]
   )
 
-  // 무한 스크롤: 페이지 단위로 목록 조회, 스크롤 시 다음 페이지 자동 요청
-  const deploymentsQuery = useInfiniteQuery({
-    queryKey: ['examDeployments', 'infinite', currentStatus],
-    queryFn: ({ pageParam }) =>
-      fetchExamDeployments({ page: pageParam as number, status: currentStatus }),
-    initialPageParam: 1,
-    getNextPageParam: (last) => (last.hasNext ? last.page + 1 : undefined),
-  })
+  const deploymentsQuery = useExamDeploymentsInfiniteQuery(currentStatus)
   const quizzes = useMemo(
     () => deploymentsQuery.data?.pages.flatMap((p) => p.results) ?? [],
     [deploymentsQuery.data?.pages]

--- a/src/components/MyPageQuiz.tsx
+++ b/src/components/MyPageQuiz.tsx
@@ -6,28 +6,30 @@ import QuizContent from '@/components/quiz/QuizContent'
 type TabKey = 'all' | 'done' | 'todo'
 
 const INITIAL_TAB: TabKey = 'all'
+const PAGE_TITLE = '쪽지시험'
 const TITLE_CLASS = 'title-xl text-[#121212] min-w-[744px] mb-8'
 const CONTAINER_CLASS = 'space-y-6'
 
-const MyPageQuiz = () => {
+function getStatusFromTab(tab: TabKey): 'all' | 'done' | 'pending' {
+  return Tabs.find((t) => t.key === tab)?.status ?? 'all'
+}
+
+function MyPageQuiz() {
   const [currentTab, setCurrentTab] = useState<TabKey>(INITIAL_TAB)
-  const currentStatus = useMemo(
-    () => Tabs.find((tab) => tab.key === currentTab)?.status || 'all',
-    [currentTab]
-  )
+  const currentStatus = useMemo(() => getStatusFromTab(currentTab), [currentTab])
 
   const deploymentsQuery = useExamDeploymentsInfiniteQuery(currentStatus)
-  const quizzes = useMemo(
+  const quizList = useMemo(
     () => deploymentsQuery.data?.pages.flatMap((p) => p.results) ?? [],
     [deploymentsQuery.data?.pages]
   )
 
   return (
     <div className={CONTAINER_CLASS}>
-      <h1 className={TITLE_CLASS}>쪽지시험</h1>
+      <h1 className={TITLE_CLASS}>{PAGE_TITLE}</h1>
       <QuizTabs currentTab={currentTab} onTabChange={setCurrentTab} />
       <QuizContent
-        quizzes={quizzes}
+        quizzes={quizList}
         isLoading={deploymentsQuery.isLoading}
         isError={deploymentsQuery.isError}
         currentTab={currentTab}

--- a/src/components/MyPageQuiz.tsx
+++ b/src/components/MyPageQuiz.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState } from 'react'
 import { useExamDeploymentsInfiniteQuery } from '@/hooks/useQuiz'
 import QuizTabs, { Tabs } from '@/components/quiz/QuizTabs'
 import QuizContent from '@/components/quiz/QuizContent'
@@ -16,13 +16,10 @@ function getStatusFromTab(tab: TabKey): 'all' | 'done' | 'pending' {
 
 function MyPageQuiz() {
   const [currentTab, setCurrentTab] = useState<TabKey>(INITIAL_TAB)
-  const currentStatus = useMemo(() => getStatusFromTab(currentTab), [currentTab])
+  const currentStatus = getStatusFromTab(currentTab)
 
   const deploymentsQuery = useExamDeploymentsInfiniteQuery(currentStatus)
-  const quizList = useMemo(
-    () => deploymentsQuery.data?.pages.flatMap((p) => p.results) ?? [],
-    [deploymentsQuery.data?.pages]
-  )
+  const quizList = deploymentsQuery.data?.pages.flatMap((p) => p.results) ?? []
 
   return (
     <div className={CONTAINER_CLASS}>

--- a/src/components/quiz/QuizCard.tsx
+++ b/src/components/quiz/QuizCard.tsx
@@ -79,10 +79,6 @@ export default function QuizCard({ quiz, skeleton = false }: QuizCardProps) {
   const handleImageError = () => setImageError(true)
   const handleFallbackImageError = () => setFallbackImageError(true)
   const handleButtonClick = () => {
-    // 디버깅: quiz 객체 전체 확인
-    console.log('[QuizCard] quiz 객체 전체:', JSON.stringify(quiz, null, 2))
-    console.log('[QuizCard] quiz.id (deploymentId로 사용될 값):', quiz.id)
-    
     if (isDone && quiz.submissionId) {
       navigate(`/quiz/result/${quiz.submissionId}`)
     } else {
@@ -91,24 +87,19 @@ export default function QuizCard({ quiz, skeleton = false }: QuizCardProps) {
   }
   const handleModalClose = () => setIsModalOpen(false)
 
-  // 아이콘 렌더링: 썸네일 → 과목 폴백 → 첫 글자
-  const renderIcon = () => {
-    if (imageUrl && !imageError) {
-      return <img src={imageUrl} onError={handleImageError} alt="" />
-    }
-    if (!fallbackImageError) {
-      return (
-        <img src={fallbackImageUrl} onError={handleFallbackImageError} alt="" />
-      )
-    }
-    return (
-      <div className={FALLBACK_ICON_CLASS}>{subjectName.charAt(0)}</div>
-    )
-  }
+  const showPrimaryImage = imageUrl && !imageError
+  const showFallbackImage = !fallbackImageError
+  const cardIcon = showPrimaryImage ? (
+    <img src={imageUrl} onError={handleImageError} alt="" />
+  ) : showFallbackImage ? (
+    <img src={fallbackImageUrl} onError={handleFallbackImageError} alt="" />
+  ) : (
+    <div className={FALLBACK_ICON_CLASS}>{subjectName.charAt(0)}</div>
+  )
 
   return (
     <div className={CARD_CLASS}>
-      <div className={ICON_CONTAINER_CLASS}>{renderIcon()}</div>
+      <div className={ICON_CONTAINER_CLASS}>{cardIcon}</div>
 
       <div className={INFO_CONTAINER_CLASS}>
         <div className={TITLE_CONTAINER_CLASS}>
@@ -128,15 +119,15 @@ export default function QuizCard({ quiz, skeleton = false }: QuizCardProps) {
 
       {!isDone && (
         <StartQuizModal
-  isOpen={isModalOpen}
-  onClose={handleModalClose}
-  deploymentId={quiz.id}          // ✅ 다시 목록에서 받은 id 사용
-  imageUrl={imageUrl || fallbackImageUrl}
-  subjectName={quiz.exam.subject.title}
-  quizName={quiz.exam.title}
-  questionCount={quiz.questionCount}
-  timeLimit={quiz.durationTime}
-/>
+          isOpen={isModalOpen}
+          onClose={handleModalClose}
+          deploymentId={quiz.id}
+          imageUrl={imageUrl || fallbackImageUrl}
+          subjectName={quiz.exam.subject.title}
+          quizName={quiz.exam.title}
+          questionCount={quiz.questionCount}
+          timeLimit={quiz.durationTime}
+        />
       )}
     </div>
   )

--- a/src/components/quiz/ResultQuestionItem.tsx
+++ b/src/components/quiz/ResultQuestionItem.tsx
@@ -1,0 +1,118 @@
+import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
+import type { ExamSubmissionResult } from '@/mappers/examSubmissionResult'
+import SingleChoice from './SingleChoice'
+import MultipleChoice from './MultipleChoice'
+import OX from './OX'
+import FillBlank from './FillBlank'
+import Ordering from './Ordering'
+import ShortAnswer from './ShortAnswer'
+
+type ResultQuestion = ExamSubmissionResult['questions'][0]
+type QuizQuestion = ExamDeploymentDetailResult['questions'][0]
+
+interface ResultQuestionItemProps {
+  question: ResultQuestion
+  index: number
+}
+
+function mapResultQuestionToQuizQuestion(
+  question: ResultQuestion,
+  index: number
+): QuizQuestion {
+  return {
+    questionId: question.id,
+    number: index + 1,
+    type: question.type as QuizQuestion['type'],
+    question: question.question,
+    point: question.point,
+    prompt: question.prompt,
+    blankCount: question.blankCount,
+    options: question.options,
+    answerInput: null,
+  }
+}
+
+/**
+ * 결과 페이지용 문항 1개 렌더링. 타입에 따라 SingleChoice/MultipleChoice/... 표시.
+ */
+export default function ResultQuestionItem({ question, index }: ResultQuestionItemProps) {
+  const mapped = mapResultQuestionToQuizQuestion(question, index)
+  const submitted = question.submittedAnswer
+  const noop = () => {}
+
+  switch (question.type) {
+    case 'single_choice':
+      return (
+        <SingleChoice
+          question={mapped}
+          answer={(submitted?.[0] ?? null) as string | null}
+          onAnswerChange={noop}
+          isResult
+          correctAnswer={(question.answer?.[0] ?? null) as string | null}
+          isCorrect={question.isCorrect}
+          explanation={question.explanation}
+        />
+      )
+    case 'multiple_choice':
+      return (
+        <MultipleChoice
+          question={mapped}
+          answer={(submitted ?? null) as string[] | null}
+          onAnswerChange={noop}
+          isResult
+          correctAnswer={(question.answer ?? null) as string[] | null}
+          isCorrect={question.isCorrect}
+          explanation={question.explanation}
+        />
+      )
+    case 'short_answer':
+      return (
+        <ShortAnswer
+          question={mapped}
+          answer={(submitted?.[0] ?? '') as string}
+          onAnswerChange={noop}
+          isResult
+          isCorrect={question.isCorrect}
+          explanation={question.explanation}
+        />
+      )
+    case 'ox':
+      return (
+        <OX
+          question={mapped}
+          answer={(submitted?.[0] ?? null) as string | null}
+          onAnswerChange={noop}
+          isResult
+          correctAnswer={(question.answer?.[0] ?? null) as string | null}
+          isCorrect={question.isCorrect}
+          explanation={question.explanation}
+        />
+      )
+    case 'fill_blank':
+      return (
+        <FillBlank
+          question={mapped}
+          answer={(submitted ?? null) as string[] | null}
+          onAnswerChange={noop}
+          isResult
+          correctAnswer={(question.answer ?? null) as string[] | null}
+          isCorrect={question.isCorrect}
+          explanation={question.explanation}
+        />
+      )
+    case 'ordering':
+      return (
+        <Ordering
+          question={mapped}
+          answer={(submitted ?? null) as string[] | null}
+          onAnswerChange={noop}
+          isResult
+          correctAnswer={(question.answer ?? null) as string[] | null}
+          isCorrect={question.isCorrect}
+          explanation={question.explanation}
+        />
+      )
+    default:
+      return null
+  }
+}

--- a/src/components/quiz/index.ts
+++ b/src/components/quiz/index.ts
@@ -1,4 +1,5 @@
 export { default as QuizCard } from './QuizCard'
+export { default as ResultQuestionItem } from './ResultQuestionItem'
 export { default as SingleChoice } from './SingleChoice'
 export { default as MultipleChoice } from './MultipleChoice'
 export { default as OX } from './OX'

--- a/src/constants/quiz.ts
+++ b/src/constants/quiz.ts
@@ -10,3 +10,17 @@ export function getQuizVerifiedKey(deploymentId: number): string {
 
 /** 잘못된 접근 모달에서 목록으로 자동 이동까지의 시간(ms) */
 export const INVALID_ACCESS_AUTO_REDIRECT_MS = 3000
+
+/** 부정행위 감지 디바운스(ms) */
+export const CHEATING_DEBOUNCE_MS = 800
+
+/** 관리자 종료 모달 자동 이동 대기(ms) */
+export const STATUS_END_AUTO_NAVIGATE_MS = 5000
+
+/** API 응답 전 타이머 기본 남은 시간(초) */
+export const INITIAL_REMAINING_SECONDS = 30 * 60
+
+/** 제출 시 배열로 보내야 하는 문항 타입 */
+export const ARRAY_ANSWER_TYPES = new Set<
+  'multiple_choice' | 'fill_blank' | 'ordering'
+>(['multiple_choice', 'fill_blank', 'ordering'])

--- a/src/constants/quiz.ts
+++ b/src/constants/quiz.ts
@@ -14,11 +14,21 @@ export const INVALID_ACCESS_AUTO_REDIRECT_MS = 3000
 /** 부정행위 감지 디바운스(ms) */
 export const CHEATING_DEBOUNCE_MS = 800
 
+/** 부정행위 경고 모달 단계 (1~3) */
+export const CHEATING_WARNING_LEVEL_MIN = 1
+export const CHEATING_WARNING_LEVEL_MAX = 3
+
 /** 관리자 종료 모달 자동 이동 대기(ms) */
 export const STATUS_END_AUTO_NAVIGATE_MS = 5000
 
 /** API 응답 전 타이머 기본 남은 시간(초) */
 export const INITIAL_REMAINING_SECONDS = 30 * 60
+
+/** 타이머 간격(ms) */
+export const QUIZ_TIMER_INTERVAL_MS = 1000
+
+/** 분당 초 수 */
+export const SECONDS_PER_MINUTE = 60
 
 /** 제출 시 배열로 보내야 하는 문항 타입 */
 export const ARRAY_ANSWER_TYPES = new Set<

--- a/src/features/quiz/index.ts
+++ b/src/features/quiz/index.ts
@@ -1,0 +1,15 @@
+/**
+ * 쪽지시험 도메인 진입점.
+ * 페이지·컴포넌트·훅·상수·API를 한 곳에서 re-export.
+ */
+
+export * from '@/constants/quiz'
+export * from '@/api/quiz'
+export * from '@/hooks/useQuiz'
+export * from '@/hooks/quiz'
+export * from '@/components/quiz'
+
+export { default as QuizPage } from '@/pages/QuizPage'
+export { default as QuizResultPage } from '@/pages/QuizResultPage'
+export { default as QuizInvalidAccessPage } from '@/pages/QuizInvalidAccessPage'
+export { default as MyPageQuiz } from '@/components/MyPageQuiz'

--- a/src/hooks/quiz/index.ts
+++ b/src/hooks/quiz/index.ts
@@ -1,0 +1,8 @@
+export { useQuizAccessCheck } from './useQuizAccessCheck'
+export { useCheatingDetection, type QuizOpenModal } from './useCheatingDetection'
+export {
+  useQuizSubmissionFlow,
+  type EndReason,
+} from './useQuizSubmissionFlow'
+export { useQuizTimer } from './useQuizTimer'
+export { useAdminStatusPolling } from './useAdminStatusPolling'

--- a/src/hooks/quiz/useAdminStatusPolling.ts
+++ b/src/hooks/quiz/useAdminStatusPolling.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react'
+import type { EndReason } from './useQuizSubmissionFlow'
+
+/**
+ * statusData가 closed / private / forceSubmit 이면 시험 종료(관리자) 처리.
+ */
+export function useAdminStatusPolling(
+  statusData: { examStatus?: string; forceSubmit?: boolean } | undefined,
+  isEnded: boolean,
+  setIsEnded: (ended: boolean) => void,
+  setEndReason: (reason: EndReason) => void
+) {
+  useEffect(() => {
+    if (isEnded) return
+    if (
+      statusData?.examStatus === 'closed' ||
+      statusData?.examStatus === 'private' ||
+      statusData?.forceSubmit
+    ) {
+      setIsEnded(true)
+      setEndReason('status')
+    }
+  }, [statusData, isEnded, setIsEnded, setEndReason])
+}

--- a/src/hooks/quiz/useAdminStatusPolling.ts
+++ b/src/hooks/quiz/useAdminStatusPolling.ts
@@ -10,15 +10,14 @@ export function useAdminStatusPolling(
   setIsEnded: (ended: boolean) => void,
   setEndReason: (reason: EndReason) => void
 ) {
+  const isAdminEndedStatus =
+    statusData?.forceSubmit === true ||
+    statusData?.examStatus === 'closed' ||
+    statusData?.examStatus === 'private'
+
   useEffect(() => {
-    if (isEnded) return
-    if (
-      statusData?.examStatus === 'closed' ||
-      statusData?.examStatus === 'private' ||
-      statusData?.forceSubmit
-    ) {
-      setIsEnded(true)
-      setEndReason('status')
-    }
-  }, [statusData, isEnded, setIsEnded, setEndReason])
+    if (isEnded || !isAdminEndedStatus) return
+    setIsEnded(true)
+    setEndReason('status')
+  }, [isAdminEndedStatus, isEnded, setIsEnded, setEndReason])
 }

--- a/src/hooks/quiz/useCheatingDetection.ts
+++ b/src/hooks/quiz/useCheatingDetection.ts
@@ -1,0 +1,69 @@
+import { useRef, useState, useEffect } from 'react'
+import { CHEATING_DEBOUNCE_MS } from '@/constants/quiz'
+
+export type QuizOpenModal = 'cheating' | 'fullscreen' | 'submitComplete'
+
+/**
+ * 부정행위 감지: visibilitychange, blur, fullscreen 해제, Escape/F11.
+ * 디바운스 적용, 최대 3회까지 카운트.
+ */
+export function useCheatingDetection(
+  isEnded: boolean,
+  setOpenModal: (modal: QuizOpenModal | null) => void
+) {
+  const [cheatingCount, setCheatingCount] = useState(0)
+  const lastCheatingAtRef = useRef(0)
+
+  const handleCheatingDetected = () => {
+    if (isEnded) return
+    const now = Date.now()
+    if (now - lastCheatingAtRef.current < CHEATING_DEBOUNCE_MS) return
+    lastCheatingAtRef.current = now
+    setCheatingCount((prev) => Math.min(prev + 1, 3))
+    setOpenModal('cheating')
+  }
+
+  useEffect(() => {
+    if (isEnded) return
+    const onVisibilityChange = () => {
+      if (document.hidden) handleCheatingDetected()
+    }
+    const onWindowBlur = () => handleCheatingDetected()
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      handleCheatingDetected()
+      e.preventDefault()
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    window.addEventListener('blur', onWindowBlur)
+    window.addEventListener('beforeunload', onBeforeUnload)
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      window.removeEventListener('blur', onWindowBlur)
+      window.removeEventListener('beforeunload', onBeforeUnload)
+    }
+  }, [isEnded, handleCheatingDetected])
+
+  useEffect(() => {
+    if (isEnded) return
+    const onFullscreenChange = () => {
+      if (cheatingCount >= 3) return
+      if (!document.fullscreenElement) setOpenModal('fullscreen')
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' || e.key === 'F11') {
+        e.preventDefault()
+        handleCheatingDetected()
+      }
+    }
+    document.addEventListener('fullscreenchange', onFullscreenChange)
+    window.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('fullscreenchange', onFullscreenChange)
+      window.removeEventListener('keydown', onKeyDown)
+    }
+  }, [isEnded, cheatingCount, setOpenModal, handleCheatingDetected])
+
+  const handleCheatingClose = () => setOpenModal(null)
+
+  return { cheatingCount, handleCheatingDetected, handleCheatingClose }
+}

--- a/src/hooks/quiz/useCheatingDetection.ts
+++ b/src/hooks/quiz/useCheatingDetection.ts
@@ -6,6 +6,7 @@ export type QuizOpenModal = 'cheating' | 'fullscreen' | 'submitComplete'
 /**
  * 부정행위 감지: visibilitychange, blur, fullscreen 해제, Escape/F11.
  * 디바운스 적용, 최대 3회까지 카운트.
+ * (handleCheatingDetected를 ref에 넣어 effect 의존성에서 제외 → 매 렌더마다 리스너 재등록 방지)
  */
 export function useCheatingDetection(
   isEnded: boolean,
@@ -13,6 +14,7 @@ export function useCheatingDetection(
 ) {
   const [cheatingCount, setCheatingCount] = useState(0)
   const lastCheatingAtRef = useRef(0)
+  const handlerRef = useRef<() => void>(() => {})
 
   const handleCheatingDetected = () => {
     if (isEnded) return
@@ -22,15 +24,16 @@ export function useCheatingDetection(
     setCheatingCount((prev) => Math.min(prev + 1, 3))
     setOpenModal('cheating')
   }
+  handlerRef.current = handleCheatingDetected
 
   useEffect(() => {
     if (isEnded) return
     const onVisibilityChange = () => {
-      if (document.hidden) handleCheatingDetected()
+      if (document.hidden) handlerRef.current()
     }
-    const onWindowBlur = () => handleCheatingDetected()
+    const onWindowBlur = () => handlerRef.current()
     const onBeforeUnload = (e: BeforeUnloadEvent) => {
-      handleCheatingDetected()
+      handlerRef.current()
       e.preventDefault()
     }
     document.addEventListener('visibilitychange', onVisibilityChange)
@@ -41,7 +44,7 @@ export function useCheatingDetection(
       window.removeEventListener('blur', onWindowBlur)
       window.removeEventListener('beforeunload', onBeforeUnload)
     }
-  }, [isEnded, handleCheatingDetected])
+  }, [isEnded])
 
   useEffect(() => {
     if (isEnded) return
@@ -52,7 +55,7 @@ export function useCheatingDetection(
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape' || e.key === 'F11') {
         e.preventDefault()
-        handleCheatingDetected()
+        handlerRef.current()
       }
     }
     document.addEventListener('fullscreenchange', onFullscreenChange)
@@ -61,7 +64,7 @@ export function useCheatingDetection(
       document.removeEventListener('fullscreenchange', onFullscreenChange)
       window.removeEventListener('keydown', onKeyDown)
     }
-  }, [isEnded, cheatingCount, setOpenModal, handleCheatingDetected])
+  }, [isEnded, cheatingCount, setOpenModal])
 
   const handleCheatingClose = () => setOpenModal(null)
 

--- a/src/hooks/quiz/useQuizAccessCheck.ts
+++ b/src/hooks/quiz/useQuizAccessCheck.ts
@@ -1,19 +1,15 @@
 import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { QUIZ_LIST_PATH, getQuizVerifiedKey } from '@/constants/quiz'
-
-const INVALID_ACCESS_MESSAGE =
-  '접근할 수 없습니다. 쪽지시험 목록에서 참가코드를 입력한 후 응시해 주세요.'
+import { getQuizVerifiedKey } from '@/constants/quiz'
 
 /**
- * 참가코드 검증 여부 확인. 미검증 시 alert 후 목록으로 리다이렉트.
+ * 참가코드 검증 여부 확인. 미검증 시 모달 표시용 플래그 반환(호출처에서 InvalidAccessModal 표시).
  */
 export function useQuizAccessCheck(
   deploymentId: string | undefined,
   deploymentIdNumber: number
 ) {
-  const navigate = useNavigate()
   const [isAccessAllowed, setIsAccessAllowed] = useState<boolean | null>(null)
+  const [showInvalidAccessModal, setShowInvalidAccessModal] = useState(false)
 
   useEffect(() => {
     const hasValidDeployment = deploymentId && deploymentIdNumber > 0
@@ -22,12 +18,11 @@ export function useQuizAccessCheck(
       sessionStorage.getItem(getQuizVerifiedKey(deploymentIdNumber))
 
     if (!isVerified) {
-      window.alert(INVALID_ACCESS_MESSAGE)
-      navigate(QUIZ_LIST_PATH, { replace: true })
+      setShowInvalidAccessModal(true)
       return
     }
     setIsAccessAllowed(true)
-  }, [deploymentId, deploymentIdNumber, navigate])
+  }, [deploymentId, deploymentIdNumber])
 
-  return { isAccessAllowed }
+  return { isAccessAllowed, showInvalidAccessModal }
 }

--- a/src/hooks/quiz/useQuizAccessCheck.ts
+++ b/src/hooks/quiz/useQuizAccessCheck.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { QUIZ_LIST_PATH, getQuizVerifiedKey } from '@/constants/quiz'
+
+const INVALID_ACCESS_MESSAGE =
+  '접근할 수 없습니다. 쪽지시험 목록에서 참가코드를 입력한 후 응시해 주세요.'
+
+/**
+ * 참가코드 검증 여부 확인. 미검증 시 alert 후 목록으로 리다이렉트.
+ */
+export function useQuizAccessCheck(
+  deploymentId: string | undefined,
+  deploymentIdNumber: number
+) {
+  const navigate = useNavigate()
+  const [isAccessAllowed, setIsAccessAllowed] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    const hasValidDeployment = deploymentId && deploymentIdNumber > 0
+    const isVerified =
+      hasValidDeployment &&
+      sessionStorage.getItem(getQuizVerifiedKey(deploymentIdNumber))
+
+    if (!isVerified) {
+      window.alert(INVALID_ACCESS_MESSAGE)
+      navigate(QUIZ_LIST_PATH, { replace: true })
+      return
+    }
+    setIsAccessAllowed(true)
+  }, [deploymentId, deploymentIdNumber, navigate])
+
+  return { isAccessAllowed }
+}

--- a/src/hooks/quiz/useQuizSubmissionFlow.ts
+++ b/src/hooks/quiz/useQuizSubmissionFlow.ts
@@ -48,25 +48,29 @@ export function useQuizSubmissionFlow({
     }
   }
 
+  // 결과 또는 목록 이동
   const navigateToResultOrList = (submissionId: number | null) => {
     exitFullscreenIfActive().then(() =>
-      navigate(
+      navigate(// submissionId가 null이 아니면 제출 결과 페이지로 이동, 아니면 목록 페이지로 이동
         submissionId != null ? `/quiz/result/${submissionId}` : QUIZ_LIST_PATH
       )
     )
   }
 
+  // 검증 제거·결과/목록 이동
   const clearVerificationAndNavigate = (submissionId: number | null) => {
     sessionStorage.removeItem(getQuizVerifiedKey(deploymentIdNumber))
     navigateToResultOrList(submissionId)
   }
 
+  // 제출 성공 처리
   const applySubmitSuccess = (result: { submissionId: number }) => {
     setSubmittedSubmissionId(result.submissionId)
     submittedSubmissionIdRef.current = result.submissionId
     queryClient.invalidateQueries({ queryKey: ['examDeployments'] })
   }
 
+  // 제출 요청 데이터 생성
   const buildSubmitPayload = () => {
     if (!data?.questions) return null
     const answerList = data.questions.map((q) => {
@@ -80,6 +84,7 @@ export function useQuizSubmissionFlow({
             ? []
             : ''
       return { question_id: q.questionId, type: q.type, submitted_answer }
+      // 문제 ID, 문제 유형, 제출 답안 반환
     })
     return {
       deployment_id: deploymentIdNumber,
@@ -138,22 +143,23 @@ export function useQuizSubmissionFlow({
     clearVerificationAndNavigate(sid)
   }
 
+  // 부정행위 감지 시 시험 종료 처리
   const handleCheatingTerminate = () => {
-    setOpenModal(null)
-    setIsEnded(true)
-    setEndReason('cheating')
+    setOpenModal(null) // 모달 닫기
+    setIsEnded(true) // 시험 종료 상태 true로 설정
+    setEndReason('cheating') // 시험 종료 이유 'cheating'으로 설정
     const payload = buildSubmitPayload()
-    if (!payload) {
+    if (!payload) { // 제출 요청 데이터가 없으면 종료
       clearVerificationAndNavigate(null)
       return
     }
-    submissionMutation.mutate(payload, {
+    submissionMutation.mutate(payload, { // 제출 요청
       onSuccess: (result) => {
-        applySubmitSuccess(result)
+        applySubmitSuccess(result) // 제출 성공 처리
         clearVerificationAndNavigate(result.submissionId)
       },
       onError: () => {
-        queryClient.invalidateQueries({ queryKey: ['examDeployments'] })
+        queryClient.invalidateQueries({ queryKey: ['examDeployments'] }) 
         clearVerificationAndNavigate(null)
       },
     })
@@ -163,9 +169,7 @@ export function useQuizSubmissionFlow({
     submissionMutation,
     submittedSubmissionId,
     submittedSubmissionIdRef,
-    applySubmitSuccess,
     clearVerificationAndNavigate,
-    buildSubmitPayload,
     handleSubmit,
     handleSubmitCompleteConfirm,
     handleEndConfirm,

--- a/src/hooks/quiz/useQuizSubmissionFlow.ts
+++ b/src/hooks/quiz/useQuizSubmissionFlow.ts
@@ -1,0 +1,175 @@
+import { useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { useExamSubmissionMutation } from '@/hooks/useQuiz'
+import { QUIZ_LIST_PATH, getQuizVerifiedKey, ARRAY_ANSWER_TYPES } from '@/constants/quiz'
+import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
+import type { QuizOpenModal } from './useCheatingDetection'
+
+export type EndReason = 'time' | 'status' | 'cheating' | null
+
+interface UseQuizSubmissionFlowParams {
+  deploymentIdNumber: number
+  data: ExamDeploymentDetailResult | undefined
+  answers: Record<number, string | string[] | null>
+  cheatingCount: number
+  setOpenModal: (modal: QuizOpenModal | null) => void
+  setIsEnded: (ended: boolean) => void
+  setEndReason: (reason: EndReason) => void
+  setRemainingSeconds: (seconds: number) => void
+}
+
+/**
+ * 제출 mutation, 검증 제거·결과/목록 이동, 시간 종료 시 자동 제출 로직.
+ */
+export function useQuizSubmissionFlow({
+  deploymentIdNumber,
+  data,
+  answers,
+  cheatingCount,
+  setOpenModal,
+  setIsEnded,
+  setEndReason,
+  setRemainingSeconds,
+}: UseQuizSubmissionFlowParams) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const submissionMutation = useExamSubmissionMutation()
+  const [submittedSubmissionId, setSubmittedSubmissionId] = useState<number | null>(null)
+  const submittedSubmissionIdRef = useRef<number | null>(null)
+  const hasAutoSubmittedRef = useRef(false)
+
+  const exitFullscreenIfActive = async () => {
+    if (!document.fullscreenElement) return
+    try {
+      await document.exitFullscreen()
+    } catch {
+      // ignore
+    }
+  }
+
+  const navigateToResultOrList = (submissionId: number | null) => {
+    exitFullscreenIfActive().then(() =>
+      navigate(
+        submissionId != null ? `/quiz/result/${submissionId}` : QUIZ_LIST_PATH
+      )
+    )
+  }
+
+  const clearVerificationAndNavigate = (submissionId: number | null) => {
+    sessionStorage.removeItem(getQuizVerifiedKey(deploymentIdNumber))
+    navigateToResultOrList(submissionId)
+  }
+
+  const applySubmitSuccess = (result: { submissionId: number }) => {
+    setSubmittedSubmissionId(result.submissionId)
+    submittedSubmissionIdRef.current = result.submissionId
+    queryClient.invalidateQueries({ queryKey: ['examDeployments'] })
+  }
+
+  const buildSubmitPayload = () => {
+    if (!data?.questions) return null
+    const answerList = data.questions.map((q) => {
+      const raw = answers[q.questionId]
+      const submitted_answer =
+        raw != null
+          ? raw
+          : ARRAY_ANSWER_TYPES.has(
+              q.type as 'multiple_choice' | 'fill_blank' | 'ordering'
+            )
+            ? []
+            : ''
+      return { question_id: q.questionId, type: q.type, submitted_answer }
+    })
+    return {
+      deployment_id: deploymentIdNumber,
+      started_at: new Date().toISOString(),
+      cheating_count: cheatingCount,
+      answers: answerList,
+    }
+  }
+
+  const endQuizByTime = () => {
+    setRemainingSeconds(0)
+    setIsEnded(true)
+    setEndReason('time')
+  }
+
+  const submitAndEndByTime = () => {
+    if (hasAutoSubmittedRef.current) return
+    hasAutoSubmittedRef.current = true
+    const payload = buildSubmitPayload()
+    if (!payload) {
+      endQuizByTime()
+      return
+    }
+    submissionMutation.mutate(payload, {
+      onSuccess: applySubmitSuccess,
+      onError: () => {
+        queryClient.invalidateQueries({ queryKey: ['examDeployments'] })
+      },
+    })
+    endQuizByTime()
+  }
+
+  const handleSubmit = () => {
+    const payload = buildSubmitPayload()
+    if (!payload) return
+    submissionMutation.mutate(payload, {
+      onSuccess: (result) => {
+        applySubmitSuccess(result)
+        setOpenModal('submitComplete')
+      },
+    })
+  }
+
+  const handleSubmitCompleteConfirm = () => {
+    const sid = submittedSubmissionId
+    setOpenModal(null)
+    setSubmittedSubmissionId(null)
+    submittedSubmissionIdRef.current = null
+    clearVerificationAndNavigate(sid)
+  }
+
+  const handleEndConfirm = () => {
+    const sid = submittedSubmissionIdRef.current ?? submittedSubmissionId
+    setSubmittedSubmissionId(null)
+    submittedSubmissionIdRef.current = null
+    clearVerificationAndNavigate(sid)
+  }
+
+  const handleCheatingTerminate = () => {
+    setOpenModal(null)
+    setIsEnded(true)
+    setEndReason('cheating')
+    const payload = buildSubmitPayload()
+    if (!payload) {
+      clearVerificationAndNavigate(null)
+      return
+    }
+    submissionMutation.mutate(payload, {
+      onSuccess: (result) => {
+        applySubmitSuccess(result)
+        clearVerificationAndNavigate(result.submissionId)
+      },
+      onError: () => {
+        queryClient.invalidateQueries({ queryKey: ['examDeployments'] })
+        clearVerificationAndNavigate(null)
+      },
+    })
+  }
+
+  return {
+    submissionMutation,
+    submittedSubmissionId,
+    submittedSubmissionIdRef,
+    applySubmitSuccess,
+    clearVerificationAndNavigate,
+    buildSubmitPayload,
+    handleSubmit,
+    handleSubmitCompleteConfirm,
+    handleEndConfirm,
+    handleCheatingTerminate,
+    submitAndEndByTime,
+  }
+}

--- a/src/hooks/quiz/useQuizTimer.ts
+++ b/src/hooks/quiz/useQuizTimer.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef, useState } from 'react'
+import { INITIAL_REMAINING_SECONDS } from '@/constants/quiz'
+import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
+
+/**
+ * API 기준 남은 시간 초기화, 1초 간격 감소, 시간 종료 시 ref로 전달된 제출·종료 함수 호출.
+ */
+export function useQuizTimer(
+  data: ExamDeploymentDetailResult | undefined,
+  isEnded: boolean,
+  submitAndEndByTimeRef: React.MutableRefObject<() => void>
+) {
+  const [remainingSeconds, setRemainingSeconds] = useState(INITIAL_REMAINING_SECONDS)
+  const hasInitializedTimerFromApi = useRef(false)
+
+  useEffect(() => {
+    if (!data || hasInitializedTimerFromApi.current || isEnded) return
+    hasInitializedTimerFromApi.current = true
+    const durationMinutes = data.durationTime
+    const totalSeconds = durationMinutes * 60
+    const elapsedSeconds = (data.elapsedTime ?? 0) * 60
+    const remaining = Math.max(0, totalSeconds - elapsedSeconds)
+    setRemainingSeconds(remaining > 0 ? remaining : totalSeconds)
+  }, [data, isEnded])
+
+  useEffect(() => {
+    if (isEnded) return
+    const timer = setInterval(() => {
+      setRemainingSeconds((prev) => {
+        if (prev <= 1) {
+          submitAndEndByTimeRef.current()
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+    return () => clearInterval(timer)
+  }, [isEnded, submitAndEndByTimeRef])
+
+  const minutes = Math.floor(remainingSeconds / 60)
+  const seconds = (remainingSeconds % 60).toString().padStart(2, '0')
+  const formattedRemaining = `${minutes} : ${seconds}`
+
+  return { remainingSeconds, setRemainingSeconds, formattedRemaining }
+}

--- a/src/hooks/quiz/useQuizTimer.ts
+++ b/src/hooks/quiz/useQuizTimer.ts
@@ -1,5 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
-import { INITIAL_REMAINING_SECONDS } from '@/constants/quiz'
+import {
+  INITIAL_REMAINING_SECONDS,
+  QUIZ_TIMER_INTERVAL_MS,
+  SECONDS_PER_MINUTE,
+} from '@/constants/quiz'
 import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
 
 /**
@@ -17,8 +21,8 @@ export function useQuizTimer(
     if (!data || hasInitializedTimerFromApi.current || isEnded) return
     hasInitializedTimerFromApi.current = true
     const durationMinutes = data.durationTime
-    const totalSeconds = durationMinutes * 60
-    const elapsedSeconds = (data.elapsedTime ?? 0) * 60
+    const totalSeconds = durationMinutes * SECONDS_PER_MINUTE
+    const elapsedSeconds = (data.elapsedTime ?? 0) * SECONDS_PER_MINUTE
     const remaining = Math.max(0, totalSeconds - elapsedSeconds)
     setRemainingSeconds(remaining > 0 ? remaining : totalSeconds)
   }, [data, isEnded])
@@ -33,7 +37,7 @@ export function useQuizTimer(
         }
         return prev - 1
       })
-    }, 1000)
+    }, QUIZ_TIMER_INTERVAL_MS)//타이머 간격 1초 간격으로 설정
     return () => clearInterval(timer)
   }, [isEnded, submitAndEndByTimeRef])
 

--- a/src/hooks/useQuiz.ts
+++ b/src/hooks/useQuiz.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query'
 import {
   checkExamCode,
   fetchExamDeploymentDetail,
@@ -12,13 +12,32 @@ import {
 
 export const useExamDeploymentsQuery = (params: FetchExamDeploymentsParams, enabled = true) => {
   /**
-   * 쪽지시험 목록 쿼리
+   * 쪽지시험 목록 쿼리 (단일 페이지)
    * 사용 예:
    * const { data } = useExamDeploymentsQuery({ page: 1, status: 'all' })
    */
   return useQuery({
     queryKey: ['examDeployments', params.page ?? 1, params.status ?? 'all'],
     queryFn: () => fetchExamDeployments(params),
+    enabled,
+  })
+}
+
+export const useExamDeploymentsInfiniteQuery = (
+  status: FetchExamDeploymentsParams['status'] = 'all',
+  enabled = true
+) => {
+  /**
+   * 쪽지시험 목록 무한 스크롤 쿼리
+   * 사용 예:
+   * const { data, fetchNextPage, hasNextPage, ... } = useExamDeploymentsInfiniteQuery('all')
+   */
+  return useInfiniteQuery({
+    queryKey: ['examDeployments', 'infinite', status ?? 'all'],
+    queryFn: ({ pageParam }) =>
+      fetchExamDeployments({ page: pageParam as number, status: status ?? 'all' }),
+    initialPageParam: 1,
+    getNextPageParam: (last) => (last.hasNext ? last.page + 1 : undefined),
     enabled,
   })
 }

--- a/src/mocks/data/examDeployments.json
+++ b/src/mocks/data/examDeployments.json
@@ -9,7 +9,7 @@
       "subject": {
         "id": 10,
         "title": "HTML",
-        "thumbnail_img_url": "https://cdn.ozcoding/html.png"
+        "thumbnail_img_url": "/icons/Course/html.svg"
       }
     },
     "question_count": 10,
@@ -32,7 +32,7 @@
       "subject": {
         "id": 11,
         "title": "CSS",
-        "thumbnail_img_url": "https://cdn.ozcoding/css.png"
+        "thumbnail_img_url": "/icons/Course/css.svg"
       }
     },
     "question_count": 12,
@@ -55,7 +55,7 @@
       "subject": {
         "id": 12,
         "title": "JavaScript",
-        "thumbnail_img_url": "https://cdn.ozcoding/js.png"
+        "thumbnail_img_url": "/icons/Course/JavaScript.svg"
       }
     },
     "question_count": 15,
@@ -78,7 +78,7 @@
       "subject": {
         "id": 13,
         "title": "React",
-        "thumbnail_img_url": "https://cdn.ozcoding/react.png"
+        "thumbnail_img_url": "/icons/Course/React.svg"
       }
     },
     "question_count": 8,
@@ -101,7 +101,7 @@
       "subject": {
         "id": 14,
         "title": "TypeScript",
-        "thumbnail_img_url": "https://cdn.ozcoding/ts.png"
+        "thumbnail_img_url": "/icons/Course/typescript.svg"
       }
     },
     "question_count": 14,
@@ -124,7 +124,7 @@
       "subject": {
         "id": 15,
         "title": "네트워크",
-        "thumbnail_img_url": "https://cdn.ozcoding/network.png"
+        "thumbnail_img_url": "/icons/Course/html.svg"
       }
     },
     "question_count": 9,
@@ -147,7 +147,7 @@
       "subject": {
         "id": 16,
         "title": "Node.js",
-        "thumbnail_img_url": "https://cdn.ozcoding/node.png"
+        "thumbnail_img_url": "/icons/Course/nodejs.svg"
       }
     },
     "question_count": 11,
@@ -170,7 +170,7 @@
       "subject": {
         "id": 17,
         "title": "웹",
-        "thumbnail_img_url": "https://cdn.ozcoding/web.png"
+        "thumbnail_img_url": "/icons/Course/html.svg"
       }
     },
     "question_count": 7,
@@ -193,7 +193,7 @@
       "subject": {
         "id": 18,
         "title": "DB",
-        "thumbnail_img_url": "https://cdn.ozcoding/db.png"
+        "thumbnail_img_url": "/icons/Course/DB.svg"
       }
     },
     "question_count": 16,
@@ -216,7 +216,7 @@
       "subject": {
         "id": 19,
         "title": "Git",
-        "thumbnail_img_url": "https://cdn.ozcoding/git.png"
+        "thumbnail_img_url": "/icons/Course/github.svg"
       }
     },
     "question_count": 10,
@@ -239,7 +239,7 @@
       "subject": {
         "id": 20,
         "title": "알고리즘",
-        "thumbnail_img_url": "https://cdn.ozcoding/algo.png"
+        "thumbnail_img_url": "/icons/Course/html.svg"
       }
     },
     "question_count": 13,
@@ -262,7 +262,7 @@
       "subject": {
         "id": 21,
         "title": "OS",
-        "thumbnail_img_url": "https://cdn.ozcoding/os.png"
+        "thumbnail_img_url": "/icons/Course/html.svg"
       }
     },
     "question_count": 9,
@@ -285,7 +285,7 @@
       "subject": {
         "id": 22,
         "title": "CS",
-        "thumbnail_img_url": "https://cdn.ozcoding/cs.png"
+        "thumbnail_img_url": "/icons/Course/html.svg"
       }
     },
     "question_count": 12,
@@ -308,7 +308,7 @@
       "subject": {
         "id": 23,
         "title": "네트워크",
-        "thumbnail_img_url": "https://cdn.ozcoding/network.png"
+        "thumbnail_img_url": "/icons/Course/html.svg"
       }
     },
     "question_count": 11,
@@ -331,7 +331,7 @@
       "subject": {
         "id": 24,
         "title": "테스트",
-        "thumbnail_img_url": "https://cdn.ozcoding/test.png"
+        "thumbnail_img_url": "/icons/Course/html.svg"
       }
     },
     "question_count": 10,
@@ -354,7 +354,7 @@
       "subject": {
         "id": 25,
         "title": "보안",
-        "thumbnail_img_url": "https://cdn.ozcoding/security.png"
+        "thumbnail_img_url": "/icons/Course/html.svg"
       }
     },
     "question_count": 8,
@@ -377,7 +377,7 @@
       "subject": {
         "id": 26,
         "title": "디자인",
-        "thumbnail_img_url": "https://cdn.ozcoding/design.png"
+        "thumbnail_img_url": "/icons/Course/html.svg"
       }
     },
     "question_count": 14,
@@ -400,7 +400,7 @@
       "subject": {
         "id": 27,
         "title": "웹",
-        "thumbnail_img_url": "https://cdn.ozcoding/web.png"
+        "thumbnail_img_url": "/icons/Course/html.svg"
       }
     },
     "question_count": 9,
@@ -423,7 +423,7 @@
       "subject": {
         "id": 28,
         "title": "프론트엔드",
-        "thumbnail_img_url": "https://cdn.ozcoding/fe.png"
+        "thumbnail_img_url": "/icons/Course/html.svg"
       }
     },
     "question_count": 10,
@@ -446,7 +446,7 @@
       "subject": {
         "id": 29,
         "title": "JavaScript",
-        "thumbnail_img_url": "https://cdn.ozcoding/js.png"
+        "thumbnail_img_url": "/icons/Course/JavaScript.svg"
       }
     },
     "question_count": 12,
@@ -469,7 +469,7 @@
       "subject": {
         "id": 30,
         "title": "브라우저",
-        "thumbnail_img_url": "https://cdn.ozcoding/browser.png"
+        "thumbnail_img_url": "/icons/Course/html.svg"
       }
     },
     "question_count": 11,
@@ -492,7 +492,7 @@
       "subject": {
         "id": 31,
         "title": "웹",
-        "thumbnail_img_url": "https://cdn.ozcoding/web.png"
+        "thumbnail_img_url": "/icons/Course/html.svg"
       }
     },
     "question_count": 13,
@@ -515,7 +515,7 @@
       "subject": {
         "id": 32,
         "title": "배포",
-        "thumbnail_img_url": "https://cdn.ozcoding/deploy.png"
+        "thumbnail_img_url": "/icons/Course/html.svg"
       }
     },
     "question_count": 10,
@@ -538,7 +538,7 @@
       "subject": {
         "id": 33,
         "title": "웹",
-        "thumbnail_img_url": "https://cdn.ozcoding/web.png"
+        "thumbnail_img_url": "/icons/Course/html.svg"
       }
     },
     "question_count": 9,
@@ -561,7 +561,7 @@
       "subject": {
         "id": 34,
         "title": "React",
-        "thumbnail_img_url": "https://cdn.ozcoding/react.png"
+        "thumbnail_img_url": "/icons/Course/React.svg"
       }
     },
     "question_count": 12,

--- a/src/mocks/data/examSubmissionResult.json
+++ b/src/mocks/data/examSubmissionResult.json
@@ -93,7 +93,7 @@
     }
   ],
   "cheating_count": 0,
-  "total_score": 25,
+  "total_score": 15,
   "correct_answer_count": 3,
   "elapsed_time": 15,
   "started_at": "2025-12-31T14:18:40.762Z",

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,4 +1,4 @@
-import { http, HttpResponse } from 'msw'
+import { http, HttpResponse, passthrough } from 'msw'
 import { checkCodeHandler } from './handlers/quiz/checkCode'
 import { examDeploymentDetailHandler } from './handlers/quiz/examDeploymentDetail'
 import { examDeploymentStatusHandler } from './handlers/quiz/examDeploymentStatus'
@@ -9,6 +9,7 @@ import { authHandlers } from './handlers/auth.mock'
 import {
   coursesHandler,
   cohortsHandler,
+  enrolledCoursesHandler,
   enrollStudentHandler,
 } from './handlers/info'
 
@@ -16,8 +17,15 @@ export const helloHandler = http.get('/api/hello', () => {
   return HttpResponse.json({ message: 'Hello, world!', code: 200 })
 })
 
+/** SPA 라우트 문서 요청(페이지 로드/새로고침) — MSW 미처리 경고 방지용 통과 */
+export const mypageProfilePassthroughHandler = http.get(
+  '/mypage/profile',
+  () => passthrough()
+)
+
 export const handlers = [
   helloHandler,
+  mypageProfilePassthroughHandler,
   ...authHandlers,
   // Quiz 핸들러들
   examDeploymentsHandler,
@@ -26,8 +34,9 @@ export const handlers = [
   examDeploymentStatusHandler,
   examSubmissionHandler,
   examSubmissionResultHandler,
-  // Info (수강생 등록) 핸들러들
+  // Info (수강생 등록·내 과정) 핸들러들
   coursesHandler,
   cohortsHandler,
+  enrolledCoursesHandler,
   enrollStudentHandler,
 ]

--- a/src/mocks/handlers/info/enrolledCourses.ts
+++ b/src/mocks/handlers/info/enrolledCourses.ts
@@ -1,0 +1,15 @@
+import { http, HttpResponse } from 'msw'
+import { unauthorizedResponse } from './constants'
+import type { CourseEnrollment } from '@/types/info'
+
+/** GET /api/v1/accounts/me/enrolled-courses/ — 내 수강 중인 과정 목록 (목 데이터) */
+export const enrolledCoursesHandler = http.get(
+  '/api/v1/accounts/me/enrolled-courses/',
+  ({ request }) => {
+    const res = unauthorizedResponse(request)
+    if (res) return res
+
+    const mockEnrolled: CourseEnrollment[] = []
+    return HttpResponse.json(mockEnrolled)
+  }
+)

--- a/src/mocks/handlers/info/index.ts
+++ b/src/mocks/handlers/info/index.ts
@@ -1,4 +1,5 @@
 export * from './constants'
 export * from './courses'
 export * from './cohorts'
+export * from './enrolledCourses'
 export * from './enrollStudent'

--- a/src/mocks/handlers/quiz/checkCode.ts
+++ b/src/mocks/handlers/quiz/checkCode.ts
@@ -1,30 +1,32 @@
 import { http, HttpResponse } from 'msw'
 
-export const checkCodeHandler = http.post(
-  '/api/v1/exams/deployments/:deploymentId/check-code',
-  async ({ request }) => {
+/** 실 API와 동일한 경로: /check_code (언더스코어) */
+const CHECK_CODE_PATH = '/api/v1/exams/deployments/:deploymentId/check_code'
 
-    let body: { code?: string } = {}
-    try {
-      body = (await request.json()) as { code?: string }
-    } catch {
-      body = {}
-    }
+/** 목 데이터에서 허용하는 참가코드 (아무 코드나 통과시키려면 여기 추가) */
+const VALID_CODES = new Set(['123456', '000000'])
 
-    if (!body.code) {
-      return HttpResponse.json(
-        { error_detail: "이 필드는 필수 항목입니다." },
-        { status: 400 }
-      )
-    }
-
-    if (body.code !== '123456') {
-      return HttpResponse.json(
-        { error_detail: '응시 코드가 일치하지 않습니다.' },
-        { status: 400 }
-      )
-    }
-
-    return HttpResponse.json({}, { status: 200 })
+export const checkCodeHandler = http.post(CHECK_CODE_PATH, async ({ request }) => {
+  let body: { code?: string } = {}
+  try {
+    body = (await request.json()) as { code?: string }
+  } catch {
+    body = {}
   }
-)
+
+  if (!body.code || String(body.code).trim() === '') {
+    return HttpResponse.json(
+      { error_detail: '이 필드는 필수 항목입니다.' },
+      { status: 400 }
+    )
+  }
+
+  if (!VALID_CODES.has(String(body.code).trim())) {
+    return HttpResponse.json(
+      { error_detail: '코드번호가 일치하지 않습니다.' },
+      { status: 400 }
+    )
+  }
+
+  return HttpResponse.json({}, { status: 204 })
+})

--- a/src/mocks/handlers/quiz/examSubmission.ts
+++ b/src/mocks/handlers/quiz/examSubmission.ts
@@ -43,10 +43,13 @@ export const examSubmissionHandler = http.post('/api/v1/exams/submissions', asyn
   const correctAnswerCount = Math.min(answerCount, Math.floor(score / 5))
 
   const submissionId = mapSubmissionId(body.deployment_id)
-  return HttpResponse.json({
-    submission_id: submissionId,
-    score,
-    correct_answer_count: correctAnswerCount,
-    redirect_url: `/exam/result/${submissionId}`,
-  })
+  return HttpResponse.json(
+    {
+      submission_id: submissionId,
+      score,
+      correct_answer_count: correctAnswerCount,
+      redirect_url: `/quiz/result/${submissionId}`,
+    },
+    { status: 201 }
+  )
 })

--- a/src/mocks/handlers/quiz/examSubmissionResult.ts
+++ b/src/mocks/handlers/quiz/examSubmissionResult.ts
@@ -1,9 +1,27 @@
 import { http, HttpResponse } from 'msw'
 import examSubmissionResult from '@/mocks/data/examSubmissionResult.json'
 
+/** POST 제출 시 사용하는 공식: submission_id = 300 + deployment_id */
+const SUBMISSION_ID_OFFSET = 300
+
 export const examSubmissionResultHandler = http.get(
   '/api/v1/exams/submissions/:submissionId',
-  () => {
-    return HttpResponse.json(examSubmissionResult)
+  ({ params }) => {
+    const submissionId = Number(params.submissionId)
+    if (!Number.isFinite(submissionId) || submissionId < 1) {
+      return HttpResponse.json(
+        { error_detail: '제출 결과를 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    const deploymentId = submissionId - SUBMISSION_ID_OFFSET
+    const payload = {
+      ...examSubmissionResult,
+      id: submissionId,
+      submitter_id: examSubmissionResult.submitter_id,
+      deployment_id: deploymentId > 0 ? deploymentId : examSubmissionResult.deployment_id,
+    }
+    return HttpResponse.json(payload)
   }
 )

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -35,46 +35,36 @@ import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
 
 type Question = ExamDeploymentDetailResult['questions'][0]
 
+const DEFAULT_EXAM_NAME = '쪽지시험'
 
 function QuizPage() {
-  const { deploymentId } = useParams<{ deploymentId: string }>() // 쪽지시험 고유 ID
-  const deploymentIdNumber = deploymentId ? Number(deploymentId) : 0 // 쪽지시험 고유 ID 숫자
+  const { deploymentId } = useParams<{ deploymentId: string }>()
+  const deploymentIdNumber = deploymentId ? Number(deploymentId) : 0
 
-  const [isEnded, setIsEnded] = useState(false) // 시험 종료 여부
-  const [endReason, setEndReason] = useState< // 시험 종료 이유
-    'time' | 'status' | 'cheating' | null
-  >(null)
-  const [openModal, setOpenModal] = useState< // 모달 열림 상태
+  const [isEnded, setIsEnded] = useState(false)
+  const [endReason, setEndReason] = useState<'time' | 'status' | 'cheating' | null>(null)
+  const [openModal, setOpenModal] = useState<
     'cheating' | 'fullscreen' | 'submitComplete' | null
   >(null)
+  const [answers, setAnswers] = useState<Record<number, string | string[] | null>>({})
 
-  const { data, isLoading } = useExamDeploymentDetailQuery( // 쪽지시험 상세 조회
-    deploymentIdNumber,
-    !!deploymentId
-  )
-  const { data: statusData } = useExamDeploymentStatusQuery( // 쪽지시험 상태 조회
+  const { data, isLoading } = useExamDeploymentDetailQuery(deploymentIdNumber, !!deploymentId)
+  const { data: statusData } = useExamDeploymentStatusQuery(
     deploymentIdNumber,
     !!deploymentId && !isEnded
   )
 
-  const { isAccessAllowed } = useQuizAccessCheck(deploymentId, deploymentIdNumber) // 쪽지시험 접근 가능 여부
+  const { isAccessAllowed } = useQuizAccessCheck(deploymentId, deploymentIdNumber)
+  const { cheatingCount, handleCheatingClose } = useCheatingDetection(isEnded, setOpenModal)
 
-  const { cheatingCount, handleCheatingClose } = // 부정행위 감지 핸들러
-    useCheatingDetection(isEnded, setOpenModal)
+  const submitAndEndByTimeRef = useRef<() => void>(() => {})
+  const { setRemainingSeconds, formattedRemaining } = useQuizTimer(
+    data,
+    isEnded,
+    submitAndEndByTimeRef
+  )
 
-  const [answersState, setAnswersState] = useState< // 답안 상태 관리
-    Record<number, string | string[] | null>
-  >({})
-
-  const submitAndEndByTimeRef = useRef<() => void>(() => {}) // 타이머 종료 핸들러
-
-  const { setRemainingSeconds, formattedRemaining } = useQuizTimer( // 타이머 상태 관리
-      data,
-      isEnded,
-      submitAndEndByTimeRef
-    )
-
-  const { // 쪽지시험 제출 처리
+  const {
     submissionMutation,
     submittedSubmissionId,
     submittedSubmissionIdRef,
@@ -87,7 +77,7 @@ function QuizPage() {
   } = useQuizSubmissionFlow({
     deploymentIdNumber,
     data,
-    answers: answersState,
+    answers,
     cheatingCount,
     setOpenModal,
     setIsEnded,
@@ -95,22 +85,16 @@ function QuizPage() {
     setRemainingSeconds,
   })
 
-  submitAndEndByTimeRef.current = submitAndEndByTime // 타이머 종료 핸들러
+  submitAndEndByTimeRef.current = submitAndEndByTime
+  useAdminStatusPolling(statusData, isEnded, setIsEnded, setEndReason)
 
-  useAdminStatusPolling( // 쪽지시험 상태 폴링
-    statusData,
-    isEnded,
-    setIsEnded,
-    setEndReason
-  )
-
-  const handleAnswerChange = (questionId: number, answer: string | string[]) => { // 답안 변경 핸들러
-    setAnswersState((prev) => ({ ...prev, [questionId]: answer })) // 답안 상태 업데이트
+  const handleAnswerChange = (questionId: number, value: string | string[]) => {
+    setAnswers((prev) => ({ ...prev, [questionId]: value }))
   }
 
-  const renderQuestion = (question: Question) => { // 문제 렌더링
-    const answer = answersState[question.questionId] ?? null
-    const commonProps = { question, onAnswerChange: handleAnswerChange } 
+  const renderQuestion = (question: Question) => {
+    const answer = answers[question.questionId] ?? null
+    const commonProps = { question, onAnswerChange: handleAnswerChange }
     switch (question.type) {
       case 'single_choice':
         return <SingleChoice {...commonProps} answer={answer as string | null} />
@@ -131,10 +115,9 @@ function QuizPage() {
     }
   }
 
-  const showTimeEndModal = isEnded && endReason === 'time' // 시험 시간 종료 모달 표시 여부
-  const showQuizEndModal = isEnded && endReason === 'status' // 시험 종료 모달 표시 여부
+  const showTimeEndModal = isEnded && endReason === 'time'
+  const showQuizEndModal = isEnded && endReason === 'status'
 
-  // clearVerificationAndNavigate를 의존성에서 제외해 매 렌더마다 타이머가 리셋되는 버그 방지
   const clearAndNavigateRef = useRef(clearVerificationAndNavigate)
   clearAndNavigateRef.current = clearVerificationAndNavigate
   useEffect(() => {
@@ -145,18 +128,20 @@ function QuizPage() {
     return () => window.clearTimeout(timer)
   }, [showQuizEndModal])
 
-  const warningLevel = Math.min( // 부정행위
-    Math.max(cheatingCount, 1),
-    3
-  ) as 1 | 2 | 3
+  const warningLevel = Math.min(Math.max(cheatingCount, 1), 3) as 1 | 2 | 3
 
-  const handleFullscreenRetry = async () => { // 전체화면 전환
+  const handleFullscreenRetry = async () => {
     try {
       await document.documentElement.requestFullscreen()
       setOpenModal(null)
     } catch {
       // 전체화면 전환 실패 시 무시
     }
+  }
+
+  const handleStatusEndTest = () => {
+    setIsEnded(true)
+    setEndReason('status')
   }
 
   if (isAccessAllowed !== true || isLoading) {
@@ -166,7 +151,7 @@ function QuizPage() {
   return (
     <div>
       <QuizHeader
-        subjectName={data?.examName || '쪽지시험'}
+        subjectName={data?.examName ?? DEFAULT_EXAM_NAME}
         timeRemaining={formattedRemaining}
         timeRemainingSuffix="남음"
         cheatingCount={cheatingCount}
@@ -188,10 +173,7 @@ function QuizPage() {
             variant="secondary"
             size="sm"
             rounded="default"
-            onClick={() => {
-              setIsEnded(true)
-              setEndReason('status')
-            }}
+            onClick={handleStatusEndTest}
           >
             상태 종료 테스트
           </Button>

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -32,6 +32,8 @@ import {
   ShortAnswer,
 } from '@/components/quiz'
 import {
+  CHEATING_WARNING_LEVEL_MAX,
+  CHEATING_WARNING_LEVEL_MIN,
   INVALID_ACCESS_AUTO_REDIRECT_MS,
   QUIZ_LIST_PATH,
   STATUS_END_AUTO_NAVIGATE_MS,
@@ -126,6 +128,10 @@ function QuizPage() {
 
   const showTimeEndModal = isEnded && endReason === 'time'
   const showQuizEndModal = isEnded && endReason === 'status'
+  const warningLevel = Math.min(
+    Math.max(cheatingCount, CHEATING_WARNING_LEVEL_MIN),
+    CHEATING_WARNING_LEVEL_MAX
+  ) as 1 | 2 | 3
 
   const clearAndNavigateRef = useRef(clearVerificationAndNavigate)
   clearAndNavigateRef.current = clearVerificationAndNavigate
@@ -136,8 +142,6 @@ function QuizPage() {
     }, STATUS_END_AUTO_NAVIGATE_MS)
     return () => window.clearTimeout(timer)
   }, [showQuizEndModal])
-
-  const warningLevel = Math.min(Math.max(cheatingCount, 1), 3) as 1 | 2 | 3
 
   const handleFullscreenRetry = async () => {
     try {
@@ -268,8 +272,9 @@ function QuizPage() {
             />
             <p className="text-center text-[16px] text-foreground-secondary">
               시험 시간이 종료되었습니다.
-              {submittedSubmissionId != null &&
-                ' 답안이 제출되었습니다. (풀지 못한 문항은 0점 처리됩니다)'}
+              {submittedSubmissionId != null
+                ? ' 답안이 제출되었습니다. (풀지 못한 문항은 0점 처리됩니다)'
+                : ''}
             </p>
           </div>
         </Modal.Body>

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import {
   Button,
   CheatingWarningModal,
@@ -15,8 +14,14 @@ import QuizWarningBox from '@/components/QuizWarningBox'
 import {
   useExamDeploymentDetailQuery,
   useExamDeploymentStatusQuery,
-  useExamSubmissionMutation,
 } from '@/hooks/useQuiz'
+import {
+  useQuizAccessCheck,
+  useCheatingDetection,
+  useQuizSubmissionFlow,
+  useQuizTimer,
+  useAdminStatusPolling,
+} from '@/hooks/quiz'
 import {
   SingleChoice,
   MultipleChoice,
@@ -25,50 +30,23 @@ import {
   Ordering,
   ShortAnswer,
 } from '@/components/quiz'
-import { QUIZ_LIST_PATH, getQuizVerifiedKey } from '@/constants/quiz'
+import { STATUS_END_AUTO_NAVIGATE_MS } from '@/constants/quiz'
 import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
 
 type Question = ExamDeploymentDetailResult['questions'][0]
 
-/** 열린 모달: cheating=부정행위 안내(1차·2차 경고 → 3차 시 종료), fullscreen=전체화면 해제 안내, submitComplete=제출 완료 */
-type OpenModal = 'cheating' | 'fullscreen' | 'submitComplete'
-
-const ARRAY_ANSWER_TYPES = new Set<Question['type']>([
-  'multiple_choice',
-  'fill_blank',
-  'ordering',
-])
-
-const CHEATING_DEBOUNCE_MS = 800
-const INITIAL_REMAINING_SECONDS = 30 * 60
-const STATUS_END_AUTO_NAVIGATE_MS = 5000
-
-// 문제풀이 후 "제출하기"로 답안 제출 → 자동 채점 → 결과 페이지 이동
-// 시간 초과 시: 푼 문항 제출, 미응답 0점 처리, 목록 응시완료 반영
-
 function QuizPage() {
-  const navigate = useNavigate()
-  const queryClient = useQueryClient()
   const { deploymentId } = useParams<{ deploymentId: string }>()
   const deploymentIdNumber = deploymentId ? Number(deploymentId) : 0
-  const [isAccessAllowed, setIsAccessAllowed] = useState<boolean | null>(null)
+
   const [isEnded, setIsEnded] = useState(false)
   const [endReason, setEndReason] = useState<
     'time' | 'status' | 'cheating' | null
   >(null)
-  const [remainingSeconds, setRemainingSeconds] = useState(INITIAL_REMAINING_SECONDS)
-  const [cheatingCount, setCheatingCount] = useState(0)
-  const [openModal, setOpenModal] = useState<OpenModal | null>(null)
-  const [submittedSubmissionId, setSubmittedSubmissionId] = useState<
-    number | null
+  const [openModal, setOpenModal] = useState<
+    'cheating' | 'fullscreen' | 'submitComplete' | null
   >(null)
-  const lastCheatingAtRef = useRef(0)
-  const hasInitializedTimerFromApi = useRef(false)
-  const hasAutoSubmittedRef = useRef(false)
-  const submittedSubmissionIdRef = useRef<number | null>(null)
-  const submitAndEndByTimeRef = useRef<() => void>(() => {})
 
-  const submissionMutation = useExamSubmissionMutation()
   const { data, isLoading } = useExamDeploymentDetailQuery(
     deploymentIdNumber,
     !!deploymentId
@@ -77,17 +55,60 @@ function QuizPage() {
     deploymentIdNumber,
     !!deploymentId && !isEnded
   )
-  const [answers, setAnswers] = useState<
+
+  const { isAccessAllowed } = useQuizAccessCheck(deploymentId, deploymentIdNumber)
+
+  const { cheatingCount, handleCheatingClose } =
+    useCheatingDetection(isEnded, setOpenModal)
+
+  const [answersState, setAnswersState] = useState<
     Record<number, string | string[] | null>
   >({})
 
-  // —— 답안 & 문제 렌더링 ——
+  const submitAndEndByTimeRef = useRef<() => void>(() => {})
+
+  const { setRemainingSeconds, formattedRemaining } = useQuizTimer(
+      data,
+      isEnded,
+      submitAndEndByTimeRef
+    )
+
+  const {
+    submissionMutation,
+    submittedSubmissionId,
+    submittedSubmissionIdRef,
+    clearVerificationAndNavigate,
+    handleSubmit,
+    handleSubmitCompleteConfirm,
+    handleEndConfirm,
+    handleCheatingTerminate,
+    submitAndEndByTime,
+  } = useQuizSubmissionFlow({
+    deploymentIdNumber,
+    data,
+    answers: answersState,
+    cheatingCount,
+    setOpenModal,
+    setIsEnded,
+    setEndReason,
+    setRemainingSeconds,
+  })
+
+  submitAndEndByTimeRef.current = submitAndEndByTime
+
+  useAdminStatusPolling(
+    statusData,
+    isEnded,
+    setIsEnded,
+    setEndReason
+  )
+
   const handleAnswerChange = (questionId: number, answer: string | string[]) => {
-    setAnswers((prev) => ({ ...prev, [questionId]: answer }))
+    setAnswersState((prev) => ({ ...prev, [questionId]: answer }))
   }
 
   const renderQuestion = (question: Question) => {
-    const answer = answers[question.questionId] ?? null
+    const answer = answersState[question.questionId] ?? null
     const commonProps = { question, onAnswerChange: handleAnswerChange }
     switch (question.type) {
       case 'single_choice':
@@ -109,261 +130,6 @@ function QuizPage() {
     }
   }
 
-  // —— 부정행위 감지 ——
-  const handleCheatingDetected = () => {
-    if (isEnded) return
-    const now = Date.now()
-    if (now - lastCheatingAtRef.current < CHEATING_DEBOUNCE_MS) return
-    lastCheatingAtRef.current = now
-    setCheatingCount((prev) => Math.min(prev + 1, 3))
-    setOpenModal('cheating')
-  }
-
-  const handleCheatingClose = () => setOpenModal(null)
-
-  // —— 공통: 전체화면 해제, 제출 성공 반영, 결과/목록 이동 ——
-  const exitFullscreenIfActive = async () => {
-    if (!document.fullscreenElement) return
-    try {
-      await document.exitFullscreen()
-    } catch {
-      // ignore
-    }
-  }
-
-  const applySubmitSuccess = (result: { submissionId: number }) => {
-    setSubmittedSubmissionId(result.submissionId)
-    submittedSubmissionIdRef.current = result.submissionId
-    queryClient.invalidateQueries({ queryKey: ['examDeployments'] })
-  }
-
-  const navigateToResultOrList = (submissionId: number | null) => {
-    exitFullscreenIfActive().then(() =>
-      navigate(
-        submissionId != null ? `/quiz/result/${submissionId}` : QUIZ_LIST_PATH
-      )
-    )
-  }
-
-  const clearVerificationAndNavigate = (submissionId: number | null) => {
-    sessionStorage.removeItem(getQuizVerifiedKey(deploymentIdNumber))
-    navigateToResultOrList(submissionId)
-  }
-
-  // 푼 문항은 제출값, 미응답은 '' 또는 []로 제출(서버에서 0점 처리)
-  const buildSubmitPayload = () => {
-    if (!data?.questions) return null
-    const answerList = data.questions.map((q) => {
-      const raw = answers[q.questionId]
-      const submitted_answer =
-        raw != null ? raw : ARRAY_ANSWER_TYPES.has(q.type) ? [] : ''
-      return { question_id: q.questionId, type: q.type, submitted_answer }
-    })
-    return {
-      deployment_id: deploymentIdNumber,
-      started_at: new Date().toISOString(),
-      cheating_count: cheatingCount,
-      answers: answerList,
-    }
-  }
-
-  // 3회 부정행위 감지 시: 시험 종료 처리 후 현재 답안 자동 제출 → 결과 페이지 이동
-  const handleCheatingTerminate = () => {
-    setOpenModal(null)
-    setIsEnded(true)
-    setEndReason('cheating')
-    const payload = buildSubmitPayload()
-    if (!payload) {
-      clearVerificationAndNavigate(null)
-      return
-    }
-    submissionMutation.mutate(payload, {
-      onSuccess: (result) => {
-        applySubmitSuccess(result)
-        clearVerificationAndNavigate(result.submissionId)
-      },
-      onError: () => {
-        queryClient.invalidateQueries({ queryKey: ['examDeployments'] })
-        clearVerificationAndNavigate(null)
-      },
-    })
-  }
-
-  const handleSubmit = () => {
-    const payload = buildSubmitPayload()
-    if (!payload) return
-    submissionMutation.mutate(payload, {
-      onSuccess: (result) => {
-        applySubmitSuccess(result)
-        setOpenModal('submitComplete')
-      },
-    })
-  }
-
-  const handleSubmitCompleteConfirm = () => {
-    const sid = submittedSubmissionId
-    setOpenModal(null)
-    setSubmittedSubmissionId(null)
-    submittedSubmissionIdRef.current = null
-    clearVerificationAndNavigate(sid)
-  }
-
-  const handleEndConfirm = () => {
-    const sid = submittedSubmissionIdRef.current ?? submittedSubmissionId
-    setSubmittedSubmissionId(null)
-    submittedSubmissionIdRef.current = null
-    clearVerificationAndNavigate(sid)
-  }
-
-  // —— 시간 종료 (버튼/실제 만료 공통) ——
-  const endQuizByTime = () => {
-    setRemainingSeconds(0)
-    setIsEnded(true)
-    setEndReason('time')
-  }
-
-  const submitAndEndByTime = () => {
-    if (hasAutoSubmittedRef.current) return
-    hasAutoSubmittedRef.current = true
-    const payload = buildSubmitPayload()
-    if (!payload) {
-      endQuizByTime()
-      return
-    }
-    submissionMutation.mutate(payload, {
-      onSuccess: applySubmitSuccess,
-      onError: () => {
-        queryClient.invalidateQueries({ queryKey: ['examDeployments'] })
-      },
-    })
-    endQuizByTime()
-  }
-  submitAndEndByTimeRef.current = submitAndEndByTime
-
-  const handleTimeEndTest = () => submitAndEndByTime()
-  const handleStatusEndTest = () => {
-    setIsEnded(true)
-    setEndReason('status')
-  }
-
-  const handleFullscreenRetry = async () => {
-    try {
-      await document.documentElement.requestFullscreen()
-      setOpenModal(null)
-    } catch {
-      // 전체화면 전환 실패 시 무시
-    }
-  }
-
-  const handleCloseSubmitCompleteModal = () => setOpenModal(null)
-
-  // 참가코드 검증 없이 URL로 직접 접근 시 경고 팝업 후 목록으로 리다이렉트
-  useEffect(() => {
-    const hasValidDeployment =
-      deploymentId && deploymentIdNumber > 0
-    const isVerified =
-      hasValidDeployment &&
-      sessionStorage.getItem(getQuizVerifiedKey(deploymentIdNumber))
-
-    if (!isVerified) {
-      window.alert(
-        '접근할 수 없습니다. 쪽지시험 목록에서 참가코드를 입력한 후 응시해 주세요.'
-      )
-      navigate(QUIZ_LIST_PATH, { replace: true })
-      return
-    }
-    setIsAccessAllowed(true)
-  }, [deploymentId, deploymentIdNumber, navigate])
-
-  // —— 부수효과: 이벤트 리스너 & 타이머 ——
-  useEffect(() => {
-    if (isEnded) return
-    const handleVisibilityChange = () => {
-      if (document.hidden) {
-        handleCheatingDetected()
-      }
-    }
-    const handleWindowBlur = () => {
-      handleCheatingDetected()
-    }
-    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      handleCheatingDetected()
-      event.preventDefault()
-    }
-
-    document.addEventListener('visibilitychange', handleVisibilityChange)
-    window.addEventListener('blur', handleWindowBlur)
-    window.addEventListener('beforeunload', handleBeforeUnload)
-
-    return () => {
-      document.removeEventListener('visibilitychange', handleVisibilityChange)
-      window.removeEventListener('blur', handleWindowBlur)
-      window.removeEventListener('beforeunload', handleBeforeUnload)
-    }
-  }, [handleCheatingDetected, isEnded])
-
-  useEffect(() => {
-    const handleFullscreenChange = () => {
-      if (cheatingCount >= 3) return
-      if (!document.fullscreenElement) {
-        setOpenModal('fullscreen')
-      }
-    }
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape' || event.key === 'F11') {
-        event.preventDefault()
-        handleCheatingDetected()
-      }
-    }
-
-    document.addEventListener('fullscreenchange', handleFullscreenChange)
-    window.addEventListener('keydown', handleKeyDown)
-    return () => {
-      document.removeEventListener('fullscreenchange', handleFullscreenChange)
-      window.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [handleCheatingDetected, cheatingCount])
-
-  useEffect(() => {
-    if (!data || hasInitializedTimerFromApi.current || isEnded) return
-    hasInitializedTimerFromApi.current = true
-    const durationMinutes = data.durationTime
-    const totalSeconds = durationMinutes * 60
-    const elapsedSeconds = (data.elapsedTime ?? 0) * 60
-    const remaining = Math.max(0, totalSeconds - elapsedSeconds)
-    setRemainingSeconds(remaining > 0 ? remaining : totalSeconds)
-  }, [data, isEnded])
-
-  useEffect(() => {
-    if (isEnded) return
-    const timer = setInterval(() => {
-      setRemainingSeconds((prev) => {
-        if (prev <= 1) {
-          submitAndEndByTimeRef.current()
-          return 0
-        }
-        return prev - 1
-      })
-    }, 1000)
-    return () => clearInterval(timer)
-  }, [isEnded])
-
-  useEffect(() => {
-    if (isEnded) return
-    if (
-      statusData?.examStatus === 'closed' ||
-      statusData?.examStatus === 'private' ||
-      statusData?.forceSubmit
-    ) {
-      setIsEnded(true)
-      setEndReason('status')
-    }
-  }, [statusData, isEnded])
-
-  const minutes = Math.floor(remainingSeconds / 60)
-  const seconds = (remainingSeconds % 60).toString().padStart(2, '0')
-  const formattedRemaining = `${minutes} : ${seconds}`
   const showTimeEndModal = isEnded && endReason === 'time'
   const showQuizEndModal = isEnded && endReason === 'status'
 
@@ -373,12 +139,21 @@ function QuizPage() {
       clearVerificationAndNavigate(submittedSubmissionIdRef.current)
     }, STATUS_END_AUTO_NAVIGATE_MS)
     return () => window.clearTimeout(timer)
-  }, [showQuizEndModal])
+  }, [showQuizEndModal, clearVerificationAndNavigate])
 
   const warningLevel = Math.min(
     Math.max(cheatingCount, 1),
     3
   ) as 1 | 2 | 3
+
+  const handleFullscreenRetry = async () => {
+    try {
+      await document.documentElement.requestFullscreen()
+      setOpenModal(null)
+    } catch {
+      // 전체화면 전환 실패 시 무시
+    }
+  }
 
   if (isAccessAllowed !== true || isLoading) {
     return <Loading />
@@ -400,7 +175,7 @@ function QuizPage() {
             variant="secondary"
             size="sm"
             rounded="default"
-            onClick={handleTimeEndTest}
+            onClick={submitAndEndByTime}
             aria-label="시험 완료 처리, 작성한 문항 제출·미작성 0점 제출 후 결과 페이지 이동·목록 응시완료"
           >
             타이머 종료 테스트
@@ -409,7 +184,10 @@ function QuizPage() {
             variant="secondary"
             size="sm"
             rounded="default"
-            onClick={handleStatusEndTest}
+            onClick={() => {
+              setIsEnded(true)
+              setEndReason('status')
+            }}
           >
             상태 종료 테스트
           </Button>
@@ -475,7 +253,6 @@ function QuizPage() {
         </Modal.Footer>
       </Modal>
 
-      {/* 시간 종료 모달: 자동 제출 후 확인 시 결과 페이지 또는 목록으로 */}
       <Modal isOpen={showTimeEndModal} onClose={handleEndConfirm}>
         <Modal.Body>
           <div className="flex min-w-[250px] flex-col items-center gap-6 py-4">
@@ -505,17 +282,15 @@ function QuizPage() {
         </Modal.Footer>
       </Modal>
 
-      {/* 관리자에 의한 종료 모달: 5초 후 쪽지시험 리스트로 자동 이동 */}
       <QuizEndModal
         isOpen={showQuizEndModal}
         onClose={handleEndConfirm}
         onConfirm={handleEndConfirm}
       />
 
-      {/* 제출하기 완료 모달 */}
       <QuizSubmitCompleteModal
         isOpen={openModal === 'submitComplete'}
-        onClose={handleCloseSubmitCompleteModal}
+        onClose={() => setOpenModal(null)}
         onConfirm={handleSubmitCompleteConfirm}
       />
     </div>

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -35,45 +35,46 @@ import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
 
 type Question = ExamDeploymentDetailResult['questions'][0]
 
-function QuizPage() {
-  const { deploymentId } = useParams<{ deploymentId: string }>()
-  const deploymentIdNumber = deploymentId ? Number(deploymentId) : 0
 
-  const [isEnded, setIsEnded] = useState(false)
-  const [endReason, setEndReason] = useState<
+function QuizPage() {
+  const { deploymentId } = useParams<{ deploymentId: string }>() // 쪽지시험 고유 ID
+  const deploymentIdNumber = deploymentId ? Number(deploymentId) : 0 // 쪽지시험 고유 ID 숫자
+
+  const [isEnded, setIsEnded] = useState(false) // 시험 종료 여부
+  const [endReason, setEndReason] = useState< // 시험 종료 이유
     'time' | 'status' | 'cheating' | null
   >(null)
-  const [openModal, setOpenModal] = useState<
+  const [openModal, setOpenModal] = useState< // 모달 열림 상태
     'cheating' | 'fullscreen' | 'submitComplete' | null
   >(null)
 
-  const { data, isLoading } = useExamDeploymentDetailQuery(
+  const { data, isLoading } = useExamDeploymentDetailQuery( // 쪽지시험 상세 조회
     deploymentIdNumber,
     !!deploymentId
   )
-  const { data: statusData } = useExamDeploymentStatusQuery(
+  const { data: statusData } = useExamDeploymentStatusQuery( // 쪽지시험 상태 조회
     deploymentIdNumber,
     !!deploymentId && !isEnded
   )
 
-  const { isAccessAllowed } = useQuizAccessCheck(deploymentId, deploymentIdNumber)
+  const { isAccessAllowed } = useQuizAccessCheck(deploymentId, deploymentIdNumber) // 쪽지시험 접근 가능 여부
 
-  const { cheatingCount, handleCheatingClose } =
+  const { cheatingCount, handleCheatingClose } = // 부정행위 감지 핸들러
     useCheatingDetection(isEnded, setOpenModal)
 
-  const [answersState, setAnswersState] = useState<
+  const [answersState, setAnswersState] = useState< // 답안 상태 관리
     Record<number, string | string[] | null>
   >({})
 
-  const submitAndEndByTimeRef = useRef<() => void>(() => {})
+  const submitAndEndByTimeRef = useRef<() => void>(() => {}) // 타이머 종료 핸들러
 
-  const { setRemainingSeconds, formattedRemaining } = useQuizTimer(
+  const { setRemainingSeconds, formattedRemaining } = useQuizTimer( // 타이머 상태 관리
       data,
       isEnded,
       submitAndEndByTimeRef
     )
 
-  const {
+  const { // 쪽지시험 제출 처리
     submissionMutation,
     submittedSubmissionId,
     submittedSubmissionIdRef,
@@ -94,22 +95,22 @@ function QuizPage() {
     setRemainingSeconds,
   })
 
-  submitAndEndByTimeRef.current = submitAndEndByTime
+  submitAndEndByTimeRef.current = submitAndEndByTime // 타이머 종료 핸들러
 
-  useAdminStatusPolling(
+  useAdminStatusPolling( // 쪽지시험 상태 폴링
     statusData,
     isEnded,
     setIsEnded,
     setEndReason
   )
 
-  const handleAnswerChange = (questionId: number, answer: string | string[]) => {
-    setAnswersState((prev) => ({ ...prev, [questionId]: answer }))
+  const handleAnswerChange = (questionId: number, answer: string | string[]) => { // 답안 변경 핸들러
+    setAnswersState((prev) => ({ ...prev, [questionId]: answer })) // 답안 상태 업데이트
   }
 
-  const renderQuestion = (question: Question) => {
+  const renderQuestion = (question: Question) => { // 문제 렌더링
     const answer = answersState[question.questionId] ?? null
-    const commonProps = { question, onAnswerChange: handleAnswerChange }
+    const commonProps = { question, onAnswerChange: handleAnswerChange } 
     switch (question.type) {
       case 'single_choice':
         return <SingleChoice {...commonProps} answer={answer as string | null} />
@@ -130,23 +131,26 @@ function QuizPage() {
     }
   }
 
-  const showTimeEndModal = isEnded && endReason === 'time'
-  const showQuizEndModal = isEnded && endReason === 'status'
+  const showTimeEndModal = isEnded && endReason === 'time' // 시험 시간 종료 모달 표시 여부
+  const showQuizEndModal = isEnded && endReason === 'status' // 시험 종료 모달 표시 여부
 
+  // clearVerificationAndNavigate를 의존성에서 제외해 매 렌더마다 타이머가 리셋되는 버그 방지
+  const clearAndNavigateRef = useRef(clearVerificationAndNavigate)
+  clearAndNavigateRef.current = clearVerificationAndNavigate
   useEffect(() => {
     if (!showQuizEndModal) return
     const timer = window.setTimeout(() => {
-      clearVerificationAndNavigate(submittedSubmissionIdRef.current)
+      clearAndNavigateRef.current(submittedSubmissionIdRef.current)
     }, STATUS_END_AUTO_NAVIGATE_MS)
     return () => window.clearTimeout(timer)
-  }, [showQuizEndModal, clearVerificationAndNavigate])
+  }, [showQuizEndModal])
 
-  const warningLevel = Math.min(
+  const warningLevel = Math.min( // 부정행위
     Math.max(cheatingCount, 1),
     3
   ) as 1 | 2 | 3
 
-  const handleFullscreenRetry = async () => {
+  const handleFullscreenRetry = async () => { // 전체화면 전환
     try {
       await document.documentElement.requestFullscreen()
       setOpenModal(null)

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import {
   Button,
   CheatingWarningModal,
+  InvalidAccessModal,
   Loading,
   Modal,
   NotFound,
@@ -30,7 +31,11 @@ import {
   Ordering,
   ShortAnswer,
 } from '@/components/quiz'
-import { STATUS_END_AUTO_NAVIGATE_MS } from '@/constants/quiz'
+import {
+  INVALID_ACCESS_AUTO_REDIRECT_MS,
+  QUIZ_LIST_PATH,
+  STATUS_END_AUTO_NAVIGATE_MS,
+} from '@/constants/quiz'
 import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
 
 type Question = ExamDeploymentDetailResult['questions'][0]
@@ -54,7 +59,11 @@ function QuizPage() {
     !!deploymentId && !isEnded
   )
 
-  const { isAccessAllowed } = useQuizAccessCheck(deploymentId, deploymentIdNumber)
+  const navigate = useNavigate()
+  const { isAccessAllowed, showInvalidAccessModal } = useQuizAccessCheck(
+    deploymentId,
+    deploymentIdNumber
+  )
   const { cheatingCount, handleCheatingClose } = useCheatingDetection(isEnded, setOpenModal)
 
   const submitAndEndByTimeRef = useRef<() => void>(() => {})
@@ -142,6 +151,16 @@ function QuizPage() {
   const handleStatusEndTest = () => {
     setIsEnded(true)
     setEndReason('status')
+  }
+
+  if (showInvalidAccessModal) {
+    return (
+      <InvalidAccessModal
+        isOpen
+        onConfirm={() => navigate(QUIZ_LIST_PATH, { replace: true })}
+        autoRedirectMs={INVALID_ACCESS_AUTO_REDIRECT_MS}
+      />
+    )
   }
 
   if (isAccessAllowed !== true || isLoading) {

--- a/src/pages/QuizResultPage.tsx
+++ b/src/pages/QuizResultPage.tsx
@@ -6,6 +6,15 @@ import QuizResultTop from '@/components/quiz/QuizResultTop'
 import { useExamSubmissionResultQuery } from '@/hooks/useQuiz'
 import { ResultQuestionItem } from '@/components/quiz'
 
+const MS_PER_MINUTE = 60_000
+
+function getElapsedMinutes(startedAt: string | undefined, submittedAt: string | undefined, fallback: number): number {
+  if (!startedAt || !submittedAt) return fallback
+  const started = new Date(startedAt).getTime()
+  const submitted = new Date(submittedAt).getTime()
+  return Math.max(0, Math.floor((submitted - started) / MS_PER_MINUTE))
+}
+
 function QuizResultPage() {
   const navigate = useNavigate()
   const { submissionId } = useParams<{ submissionId: string }>()
@@ -16,9 +25,7 @@ function QuizResultPage() {
     !!submissionId
   )
 
-  const handleSubmit = () => {
-    navigate(QUIZ_LIST_PATH)
-  }
+  const goToList = () => navigate(QUIZ_LIST_PATH)
 
   if (isLoading) {
     return (
@@ -30,26 +37,21 @@ function QuizResultPage() {
 
   const questionCount = data?.questions.length ?? 0
   const cheatingCount = data?.cheatingCount ?? 0
-
-  // startedAt / submittedAt 기준 실제 응시 시간 (분 단위, 초는 버림)
-  let elapsedMinutes = data?.elapsedTime ?? 0
-  if (data?.startedAt && data?.submittedAt) {
-    const started = new Date(data.startedAt)
-    const submitted = new Date(data.submittedAt)
-    const diffMs = submitted.getTime() - started.getTime()
-    elapsedMinutes = Math.max(0, Math.floor(diffMs / 60000))
-  }
-
+  const elapsedMinutes = getElapsedMinutes(
+    data?.startedAt,
+    data?.submittedAt,
+    data?.elapsedTime ?? 0
+  )
   const maxScore =
-    data?.questions.reduce((sum, question) => sum + (question.point ?? 0), 0) ??
-    0
+    data?.questions.reduce((sum, q) => sum + (q.point ?? 0), 0) ?? 0
   const totalScore = data?.totalScore ?? 0
+  const headerMessage = `총 문항 수: ${questionCount} ㆍ 부정행위: ${cheatingCount}회 ㆍ 응시시간: ${elapsedMinutes}분 ㆍ 응시 결과 점수: ${totalScore}점/${maxScore}점`
 
   return (
     <div>
       <QuizHeader
         subjectName={data?.exam.title}
-        message={`총 문항 수: ${questionCount} ㆍ 부정행위: ${cheatingCount}회 ㆍ 응시시간: ${elapsedMinutes}분 ㆍ 응시 결과 점수: ${totalScore}점/${maxScore}점`}
+        message={headerMessage}
         showExamStatus={false}
       />
 
@@ -72,7 +74,7 @@ function QuizResultPage() {
             variant="primary"
             size="xs"
             rounded="default"
-            onClick={handleSubmit}
+            onClick={goToList}
           >
             완료
           </Button>

--- a/src/pages/QuizResultPage.tsx
+++ b/src/pages/QuizResultPage.tsx
@@ -6,14 +6,32 @@ import QuizResultTop from '@/components/quiz/QuizResultTop'
 import { useExamSubmissionResultQuery } from '@/hooks/useQuiz'
 import { ResultQuestionItem } from '@/components/quiz'
 
+// 분당 밀리초 수
 const MS_PER_MINUTE = 60_000
 
-function getElapsedMinutes(startedAt: string | undefined, submittedAt: string | undefined, fallback: number): number {
+// 응시시간
+function getElapsedMinutes(
+  startedAt: string | undefined,
+  submittedAt: string | undefined,
+  fallback: number
+): number {
   if (!startedAt || !submittedAt) return fallback
   const started = new Date(startedAt).getTime()
   const submitted = new Date(submittedAt).getTime()
   return Math.max(0, Math.floor((submitted - started) / MS_PER_MINUTE))
 }
+
+// 결과 헤더 메시지
+function buildResultHeaderMessage(
+  questionCount: number,
+  cheatingCount: number,
+  elapsedMinutes: number,
+  totalScore: number,
+  maxScore: number
+): string {
+  return `총 문항 수: ${questionCount} ㆍ 부정행위: ${cheatingCount}회 ㆍ 응시시간: ${elapsedMinutes}분 ㆍ 응시 결과 점수: ${totalScore}점/${maxScore}점`
+}
+
 
 function QuizResultPage() {
   const navigate = useNavigate()
@@ -45,7 +63,13 @@ function QuizResultPage() {
   const maxScore =
     data?.questions.reduce((sum, q) => sum + (q.point ?? 0), 0) ?? 0
   const totalScore = data?.totalScore ?? 0
-  const headerMessage = `총 문항 수: ${questionCount} ㆍ 부정행위: ${cheatingCount}회 ㆍ 응시시간: ${elapsedMinutes}분 ㆍ 응시 결과 점수: ${totalScore}점/${maxScore}점`
+  const headerMessage = buildResultHeaderMessage(
+    questionCount,
+    cheatingCount,
+    elapsedMinutes,
+    totalScore,
+    maxScore
+  )
 
   return (
     <div>

--- a/src/pages/QuizResultPage.tsx
+++ b/src/pages/QuizResultPage.tsx
@@ -1,19 +1,10 @@
 import { useNavigate, useParams } from 'react-router-dom'
 import { Button, Loading } from '@/components/common'
+import { QUIZ_LIST_PATH } from '@/constants/quiz'
 import QuizHeader from '@/components/quiz/QuizHeader'
 import QuizResultTop from '@/components/quiz/QuizResultTop'
 import { useExamSubmissionResultQuery } from '@/hooks/useQuiz'
-import {
-  SingleChoice,
-  MultipleChoice,
-  OX,
-  FillBlank,
-  Ordering,
-  ShortAnswer,
-} from '@/components/quiz'
-import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
-
-type QuizQuestion = ExamDeploymentDetailResult['questions'][0]
+import { ResultQuestionItem } from '@/components/quiz'
 
 function QuizResultPage() {
   const navigate = useNavigate()
@@ -26,7 +17,7 @@ function QuizResultPage() {
   )
 
   const handleSubmit = () => {
-    navigate('/mypage/quiz')
+    navigate(QUIZ_LIST_PATH)
   }
 
   if (isLoading) {
@@ -54,101 +45,6 @@ function QuizResultPage() {
     0
   const totalScore = data?.totalScore ?? 0
 
-  const renderQuestion = (
-    question: NonNullable<typeof data>['questions'][0],
-    index: number
-  ) => {
-    const mapped: QuizQuestion = {
-      questionId: question.id,
-      number: index + 1,
-      type: question.type as QuizQuestion['type'],
-      question: question.question,
-      point: question.point,
-      prompt: question.prompt,
-      blankCount: question.blankCount,
-      options: question.options,
-      answerInput: null,
-    }
-
-    const submitted = question.submittedAnswer
-
-    switch (question.type) {
-      case 'single_choice':
-        return (
-          <SingleChoice
-            question={mapped}
-            answer={(submitted?.[0] ?? null) as string | null}
-            onAnswerChange={() => {}}
-            isResult
-            correctAnswer={(question.answer?.[0] ?? null) as string | null}
-            isCorrect={question.isCorrect}
-            explanation={question.explanation}
-          />
-        )
-      case 'multiple_choice':
-        return (
-          <MultipleChoice
-            question={mapped}
-            answer={(submitted ?? null) as string[] | null}
-            onAnswerChange={() => {}}
-            isResult
-            correctAnswer={(question.answer ?? null) as string[] | null}
-            isCorrect={question.isCorrect}
-            explanation={question.explanation}
-          />
-        )
-      case 'short_answer':
-        return (
-          <ShortAnswer
-            question={mapped}
-            answer={(submitted?.[0] ?? '') as string}
-            onAnswerChange={() => {}}
-            isResult
-            isCorrect={question.isCorrect}
-            explanation={question.explanation}
-          />
-        )
-      case 'ox':
-        return (
-          <OX
-            question={mapped}
-            answer={(submitted?.[0] ?? null) as string | null}
-            onAnswerChange={() => {}}
-            isResult
-            correctAnswer={(question.answer?.[0] ?? null) as string | null}
-            isCorrect={question.isCorrect}
-            explanation={question.explanation}
-          />
-        )
-      case 'fill_blank':
-        return (
-          <FillBlank
-            question={mapped}
-            answer={(submitted ?? null) as string[] | null}
-            onAnswerChange={() => {}}
-            isResult
-            correctAnswer={(question.answer ?? null) as string[] | null}
-            isCorrect={question.isCorrect}
-            explanation={question.explanation}
-          />
-        )
-      case 'ordering':
-        return (
-          <Ordering
-            question={mapped}
-            answer={(submitted ?? null) as string[] | null}
-            onAnswerChange={() => {}}
-            isResult
-            correctAnswer={(question.answer ?? null) as string[] | null}
-            isCorrect={question.isCorrect}
-            explanation={question.explanation}
-          />
-        )
-      default:
-        return null
-    }
-  }
-
   return (
     <div>
       <QuizHeader
@@ -163,7 +59,7 @@ function QuizResultPage() {
           <div className="w-[1290px] space-y-6 py-10 pt-16">
             {data?.questions?.map((question, index) => (
               <div key={question.id} className="space-y-4">
-                {renderQuestion(question, index)}
+                <ResultQuestionItem question={question} index={index} />
               </div>
             ))}
           </div>


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #155 

## 📑 구현 사항

- **리팩토링**: 쪽지시험 목록·응시·결과 페이지 및 훅의 가독성·유지보수성 개선
  - 매직넘버 상수화(부정행위 경고 단계, 타이머 간격 등), 복잡한 조건·변수명 정리
  - QuizResultPage 헤더 문구 생성 로직 함수 추상화, QuizPage 시험 종료 메시지 삼항 명시
  - MyPageQuiz 불필요한 useMemo 제거, QuizCard 디버그 로그 제거·아이콘 렌더 정리
  - useQuizSubmissionFlow 반환 API 정리, useAdminStatusPolling 조건 변수 추출
- **버그 수정**: 비인가 접근 시 alert → InvalidAccessModal 통일, 관리자 종료 모달 타이머 리셋 현상 수정, 부정행위 감지 리스너 ref 고정
- **목 데이터(MSW)**: 참가코드·제출·결과 API 정리, enrolled-courses·mypage/profile 핸들러 추가, 썸네일 CDN → 로컬 아이콘 경로 변경으로 ERR_FAILED 제거

---

## 🌀 어려웠던 점 / 고민했던 부분

- **구현하면서 많이 고민했던 부분**
  - 리팩토링할 때 어디까지 손대도 되는지 정하는 게 어려웠음. 상수로 빼기, 변수·함수 이름 정리 정도로 범위를 정했음
  - 어떤 코드를 “불필요하다”고 볼지, 주석·디버그 로그·미사용 반환값을 제거해도 되는지 하나씩 판단하는 데 생각이 많이 필요해서 시간이 걸림
- **에러를 고치면서 겪었던 부분**
  - MSW 목 데이터 환경에서 `GET /mypage/profile`, `GET enrolled-courses` 등 핸들러가 없어서 경고·에러가 났고, passthrough·enrolledCourses 핸들러를 추가해서 해결함
  - 쪽지시험 목록 썸네일이 CDN(cdn.ozcoding) URL이라 로드 실패(ERR_FAILED)와 MSW passthrough 에러가 났고, 로컬 아이콘 경로로 바꿔서 해결함
  - ViewMyInfo에서 수강 과정 API 응답이 없을 때 HTML이 그대로 들어가면서 `courses.map` 에러가 났고, enrolled-courses 목 핸들러를 추가해 빈 배열을 주도록 수정함
---

## 📸 구현 이미지

-

---

## ❇️ 코드 설명

- **상수 정리** (`constants/quiz.ts`): `CHEATING_WARNING_LEVEL_MIN/MAX`, `QUIZ_TIMER_INTERVAL_MS`, `SECONDS_PER_MINUTE` 등으로 매직넘버 제거
- **조건·의도 이름 붙이기**: `useAdminStatusPolling`의 `isAdminEndedStatus`, QuizCard의 `showPrimaryImage`/`showFallbackImage`/`cardIcon` 등으로 “위에서 아래로” 읽히도록 정리
- **함수 추상화**: QuizResultPage의 `buildResultHeaderMessage`, `getElapsedMinutes`로 헤더 문구·응시시간 계산 책임 분리
- **훅 공개 API 축소**: `useQuizSubmissionFlow`에서 외부 미사용 `applySubmitSuccess`, `buildSubmitPayload` 반환 제거

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.