### PR TITLE
fix: 백엔드에 회원가입 이메일/휴대폰 중복 체크 API 요청 (#161)

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -62,14 +62,22 @@ export async function me(accessToken: string | null = null): Promise<User> {
   return data
 }
 
-export interface CheckNicknamePayload {
-  nickname: string
-}
-
 export async function checkNickname(
-  payload: CheckNicknamePayload
+  payload: { nickname: string }
 ): Promise<void> {
   await apiClient.post('/api/v1/accounts/check-nickname/', payload)
+}
+
+export async function checkEmail(payload: { email: string }): Promise<void> {
+  await apiClient.post('/api/v1/accounts/check-email/', payload)
+}
+
+export async function checkPhone(payload: {
+  phoneNumber: string
+}): Promise<void> {
+  await apiClient.post('/api/v1/accounts/check-phone/', {
+    phone_number: payload.phoneNumber,
+  })
 }
 
 export async function sendEmailVerification(

--- a/src/hooks/signup/useEmailVerification.ts
+++ b/src/hooks/signup/useEmailVerification.ts
@@ -53,7 +53,10 @@ export function useEmailVerification({
         : { ok: false, message: AUTH_MESSAGES.email.identityInvalid }
     },
 
-    send: (identity) => authApi.sendEmailVerification({ email: identity }),
+    send: async (identity) => {
+      await authApi.checkEmail({ email: identity })
+      await authApi.sendEmailVerification({ email: identity })
+    },
     verify: (identity, verificationCode) =>
       authApi.verifyEmailCode({ email: identity, verificationCode }),
     getToken: (response) => response.emailToken,

--- a/src/hooks/signup/useSmsVerification.ts
+++ b/src/hooks/signup/useSmsVerification.ts
@@ -72,7 +72,10 @@ export function useSmsVerification({
       return { ok: true }
     },
 
-    send: (identity) => authApi.sendSmsVerification({ phoneNumber: identity }),
+    send: async (identity) => {
+      await authApi.checkPhone({ phoneNumber: identity })
+      await authApi.sendSmsVerification({ phoneNumber: identity })
+    },
     verify: (identity, verificationCode) =>
       authApi.verifySmsCode({ phoneNumber: identity, verificationCode }),
     getToken: (response) => response.smsToken,

--- a/src/hooks/useVerificationFlow.ts
+++ b/src/hooks/useVerificationFlow.ts
@@ -43,8 +43,6 @@ type UseVerificationFlowArgs<TVerifyRes> = {
   }
 }
 
-const SECONDS_PER_MINUTE = 60
-
 export function useVerificationFlow<TVerifyRes>({
   identity,
   code,
@@ -63,7 +61,7 @@ export function useVerificationFlow<TVerifyRes>({
   getVerifyErrorMessage,
   text,
 }: UseVerificationFlowArgs<TVerifyRes>) {
-  const ttlMinutes = Math.ceil(ttlSec / SECONDS_PER_MINUTE)
+  const ttlMinutes = Math.ceil(ttlSec / 60)
   const {
     timeLeft: remain,
     formatTime: mmss,

--- a/src/mocks/handlers/auth.mock.ts
+++ b/src/mocks/handlers/auth.mock.ts
@@ -172,6 +172,54 @@ export const checkNicknameHandler = http.post(
   }
 )
 
+export const checkEmailHandler = http.post(
+  api('/api/v1/accounts/check-email/'),
+  async ({ request }) => {
+    await delay(80)
+    const body = (await request.json()) as { email?: string }
+    const email = normEmail(String(body.email ?? ''))
+
+    if (!email) {
+      return error(400, { error_detail: { email: ['이메일을 입력해주세요.'] } })
+    }
+
+    if (usersByEmail.has(email)) {
+      return error(409, { error_detail: '이미 가입된 이메일입니다.' })
+    }
+
+    return HttpResponse.json(
+      { detail: '사용가능한 이메일 입니다.' },
+      { status: 200 }
+    )
+  }
+)
+
+export const checkPhoneHandler = http.post(
+  api('/api/v1/accounts/check-phone/'),
+  async ({ request }) => {
+    await delay(80)
+    const body = (await request.json()) as { phone_number?: string }
+    const phone = normPhone(String(body.phone_number ?? ''))
+
+    if (phone.length < 10) {
+      return error(400, {
+        error_detail: { phone_number: ['휴대폰 번호를 확인해주세요.'] },
+      })
+    }
+
+    if (usedPhones.has(phone)) {
+      return error(409, {
+        error_detail: '이미 가입에 사용된 휴대전화 번호입니다.',
+      })
+    }
+
+    return HttpResponse.json(
+      { detail: '사용가능한 휴대전화 번호입니다.' },
+      { status: 200 }
+    )
+  }
+)
+
 export const sendEmailHandler = http.post(
   api('/api/v1/accounts/verification/send-email/'),
   async ({ request }) => {
@@ -435,6 +483,8 @@ export const authHandlers = [
   logoutHandler,
   meHandler,
   checkNicknameHandler,
+  checkEmailHandler,
+  checkPhoneHandler,
   sendEmailHandler,
   verifyEmailHandler,
   sendSmsHandler,

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -58,15 +58,15 @@ function LandingPage() {
             className={clsx(
               'mx-auto w-full max-w-[1200px] px-5',
               'min-h-[calc(100dvh-var(--header-offset,100px))]',
-              'flex flex-col justify-center',
+              'flex flex-col items-center justify-center',
               'py-8',
               'scroll-mt-[var(--header-offset,100px)]',
               'overflow-hidden'
             )}
           >
-            <h1 className="text-center text-3xl leading-snug font-bold sm:text-4xl lg:text-5xl">
-              쪽지 시험으로 <br />
-              실력을 차곡차곡 쌓아보세요
+            <h1 className="text-center text-3xl leading-snug font-bold whitespace-normal sm:text-4xl lg:text-5xl">
+              <span className="block sm:pb-1 lg:pb-2">쪽지시험으로</span>
+              <span className="block">실력을 차곡차곡 쌓아보세요</span>
             </h1>
 
             <div className="border-mono-200 mx-auto my-6 w-fit rounded-full border bg-white px-2 py-2 shadow-sm sm:my-10">
@@ -83,7 +83,7 @@ function LandingPage() {
                       onClick={() => handleTabClick(tab.id)}
                       aria-pressed={isActive}
                       className={clsx(
-                        'px-5 py-2 transition-all duration-200 sm:px-6',
+                        'h-9 px-4 text-sm whitespace-nowrap transition-all duration-200 sm:h-10 sm:px-6 sm:text-base lg:h-11 lg:px-7',
                         'focus-visible:ring-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
                         isActive
                           ? 'shadow-md'


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #161 

## 📑 구현 사항

- QA 중 확인한 “중복 계정/번호에서도 인증번호 전송이 먼저 시도되어 오류 원인이 늦게 노출되는 문제”를 기준으로, 백엔드와 협의해 중복 체크 API를 선호출하는 플로우로 반영
- 회원가입 인증번호 전송 전에 중복 체크 API를 선호출하도록 반영
- 이메일: `POST /api/v1/accounts/check-email/` 호출 후 `send-email` 호출
- 휴대폰: `POST /api/v1/accounts/check-phone/` 호출 후 `send-sms` 호출
- API 함수 추가
  - `checkEmail(payload: { email: string })`
  - `checkPhone(payload: { phoneNumber: string })`
- MSW 핸들러 추가
  - `checkEmailHandler`
  - `checkPhoneHandler`
- MSW `authHandlers` 목록에 신규 핸들러 등록

## 🌀 어려웠던 점 / 고민했던 부분

- 기존 에러 매핑 로직(`400/409`)을 유지하면서 선검증 API를 추가해도 사용자 메시지 흐름이 깨지지 않게 맞추는 점
- 실제 백엔드와 로컬 MSW 동작 차이로 인한 테스트 공백을 줄이기 위해 mock 엔드포인트를 함께 맞춰야 했던 점

## 📸 구현 이미지

- UI 변경 없음 (동작 플로우/API 호출 순서 변경)

## ❇️ 코드 설명

- `src/api/auth.ts`
  - 중복 체크 전용 API 함수 2개 추가
  - `checkPhone`에서 프론트 필드(`phoneNumber`)를 백엔드 스키마(`phone_number`)로 매핑
- `src/hooks/signup/useEmailVerification.ts`
  - 인증번호 전송 시 `checkEmail -> sendEmailVerification` 순서로 변경
- `src/hooks/signup/useSmsVerification.ts`
  - 인증번호 전송 시 `checkPhone -> sendSmsVerification` 순서로 변경
- `src/mocks/handlers/auth.mock.ts`
  - `check-email`, `check-phone` 핸들러 추가
  - `authHandlers`에 신규 핸들러 등록해 개발/테스트 환경 동작 일치

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.
