### PR TITLE
feat: 반응형 헤더 추가 (#167)

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -17,9 +17,12 @@ const dropdownButtonClass =
 
 export default function Header() {
   const [open, setOpen] = useState(false)
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [registerStudentModalOpen, setRegisterStudentModalOpen] =
     useState(false)
   const dropdownRef = useRef<HTMLDivElement | null>(null)
+  const mobileMenuRef = useRef<HTMLDivElement | null>(null)
+  const mobileMenuButtonRef = useRef<HTMLDivElement | null>(null)
 
   const navigate = useNavigate()
 
@@ -27,22 +30,31 @@ export default function Header() {
   const user = useAuthStore((s) => s.user)
   const logout = useAuthStore((s) => s.logout)
 
-  // 드롭다운 바깥 클릭하면 닫히기
+  // 드롭다운/모바일 메뉴 바깥 클릭하면 닫히기
   useEffect(() => {
-    if (!open) return
+    if (!open && !mobileMenuOpen) return
 
     const handleOutsideClick = (e: MouseEvent) => {
       const target = e.target as Node
-      if (!dropdownRef.current) return
-      if (!dropdownRef.current.contains(target)) setOpen(false)
+      const clickedOutsideDesktopMenu =
+        open && dropdownRef.current && !dropdownRef.current.contains(target)
+      const clickedOutsideMobileMenu =
+        mobileMenuOpen &&
+        mobileMenuRef.current &&
+        !mobileMenuRef.current.contains(target) &&
+        !mobileMenuButtonRef.current?.contains(target)
+
+      if (clickedOutsideDesktopMenu) setOpen(false)
+      if (clickedOutsideMobileMenu) setMobileMenuOpen(false)
     }
 
     document.addEventListener('mousedown', handleOutsideClick)
     return () => document.removeEventListener('mousedown', handleOutsideClick)
-  }, [open])
+  }, [open, mobileMenuOpen])
 
   const handleLogout = async () => {
     setOpen(false)
+    setMobileMenuOpen(false)
     await logout()
     navigate('/', { replace: true })
   }
@@ -51,16 +63,16 @@ export default function Header() {
     <header className="fixed top-0 right-0 left-0 z-50 w-full">
       {/* 상단 알림 바 */}
       <div className="w-full bg-[#222222] text-center text-sm text-white">
-        <div className="mx-auto max-w-[1200px] py-2 font-[Pretendard]">
+        <div className="mx-auto max-w-[1200px] truncate px-4 py-2 font-[Pretendard] text-[12px] sm:text-sm">
           🚨 선착순 모집! 국비지원 받고 4주 완성
         </div>
       </div>
 
       {/* 메인 헤더 */}
-      <div className="w-full border-b border-gray-200 bg-white">
+      <div className="relative w-full border-b border-gray-200 bg-white">
         <div className="mx-auto flex h-16 max-w-[1200px] items-center justify-between px-5">
           {/* 왼쪽: 로고 + 메뉴 */}
-          <div className="flex items-center gap-10">
+          <div className="flex items-center gap-6 lg:gap-10">
             <a href="/" className="flex items-center">
               <svg
                 width="150"
@@ -99,7 +111,7 @@ export default function Header() {
               </svg>
             </a>
 
-            <nav className="flex gap-10 font-[Pretendard] text-[18px] text-gray-700">
+            <nav className="hidden gap-10 font-[Pretendard] text-[18px] text-gray-700 lg:flex">
               <a
                 href="#"
                 className="transition-colors duration-200 hover:text-black"
@@ -115,8 +127,8 @@ export default function Header() {
             </nav>
           </div>
 
-          {/* 오른쪽 메뉴 */}
-          <div className="flex items-center gap-2 font-[Pretendard] text-[16px] text-gray-500">
+          {/* 오른쪽 메뉴: 데스크톱 */}
+          <div className="hidden items-center gap-2 font-[Pretendard] text-[16px] text-gray-500 lg:flex">
             {!isAuthenticated ? (
               <>
                 <Button
@@ -210,7 +222,133 @@ export default function Header() {
               </div>
             )}
           </div>
+
+          {/* 오른쪽 메뉴: 모바일 햄버거 */}
+          <div ref={mobileMenuButtonRef} className="lg:hidden">
+            <Button
+              type="button"
+              variant="link"
+              size="auto"
+              className="min-w-0 rounded-[8px]  p-1hover:no-underline"
+              onClick={() => {
+                setMobileMenuOpen((prev) => !prev)
+                setOpen(false)
+              }}
+              aria-expanded={mobileMenuOpen}
+              aria-label="모바일 메뉴 열기"
+            >
+              <span className="flex h-8 w-8 flex-col items-center justify-center gap-1">
+                <span className="block h-[2px] w-5 rounded bg-[#222222]" />
+                <span className="block h-[2px] w-5 rounded bg-[#222222]" />
+                <span className="block h-[2px] w-5 rounded bg-[#222222]" />
+              </span>
+            </Button>
+          </div>
         </div>
+
+        {mobileMenuOpen && (
+          <div
+            ref={mobileMenuRef}
+            className="border-t border-gray-200 bg-white shadow-[0_8px_20px_0_#00000014] lg:hidden"
+          >
+            <div className="mx-auto max-w-[1200px] px-5 py-4">
+              <nav className="flex flex-col gap-1 font-[Pretendard] text-[16px] text-gray-700">
+                <a
+                  href="#"
+                  className="rounded-[8px] px-2 py-2 transition-colors duration-200 hover:bg-primary-100 hover:text-black"
+                >
+                  커뮤니티
+                </a>
+                <a
+                  href="#"
+                  className="rounded-[8px] px-2 py-2 transition-colors duration-200 hover:bg-primary-100 hover:text-black"
+                >
+                  질의응답
+                </a>
+              </nav>
+
+              <div className="mt-3 border-t border-mono-200 pt-3">
+                {!isAuthenticated ? (
+                  <div className="flex flex-col gap-1">
+                    <Button
+                      type="button"
+                      variant="link"
+                      size="auto"
+                      className="w-full justify-start rounded-[8px] px-2 py-2 font-[Pretendard] text-[16px] text-mono-700 hover:bg-primary-100 hover:no-underline"
+                      onClick={() => {
+                        setMobileMenuOpen(false)
+                        navigate('/login')
+                      }}
+                    >
+                      로그인
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="link"
+                      size="auto"
+                      className="w-full justify-start rounded-[8px] px-2 py-2 font-[Pretendard] text-[16px] text-mono-700 hover:bg-primary-100 hover:no-underline"
+                      onClick={() => {
+                        setMobileMenuOpen(false)
+                        navigate('/signup')
+                      }}
+                    >
+                      회원가입
+                    </Button>
+                  </div>
+                ) : (
+                  <div>
+                    <div className="mb-2 rounded-[8px] bg-mono-100 px-3 py-2">
+                      <p className="text-[14px] font-semibold text-black">
+                        {user?.name ?? '유저'}
+                      </p>
+                      <p className="text-[13px] text-mono-500">
+                        {user?.email ?? ''}
+                      </p>
+                    </div>
+
+                    <div className="flex flex-col gap-1">
+                      <Button
+                        type="button"
+                        variant="link"
+                        size="auto"
+                        className="w-full justify-start rounded-[8px] px-2 py-2 text-left text-sm hover:bg-primary-100 hover:text-primary hover:no-underline"
+                        onClick={() => {
+                          setMobileMenuOpen(false)
+                          setRegisterStudentModalOpen(true)
+                        }}
+                      >
+                        수강생 등록
+                      </Button>
+
+                      <Button
+                        type="button"
+                        variant="link"
+                        size="auto"
+                        className="w-full justify-start rounded-[8px] px-2 py-2 text-left text-sm hover:bg-primary-100 hover:text-primary hover:no-underline"
+                        onClick={() => {
+                          setMobileMenuOpen(false)
+                          navigate('/mypage/profile')
+                        }}
+                      >
+                        마이페이지
+                      </Button>
+
+                      <Button
+                        type="button"
+                        variant="link"
+                        size="auto"
+                        className="w-full justify-start rounded-[8px] px-2 py-2 text-left text-sm hover:bg-primary-100 hover:text-primary hover:no-underline"
+                        onClick={handleLogout}
+                      >
+                        로그아웃
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
       </div>
 
       <RegisterStudentModal

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -229,7 +229,7 @@ export default function Header() {
               type="button"
               variant="link"
               size="auto"
-              className="min-w-0 rounded-[8px]  p-1hover:no-underline"
+              className="p-1hover:no-underline min-w-0 rounded-[8px]"
               onClick={() => {
                 setMobileMenuOpen((prev) => !prev)
                 setOpen(false)
@@ -255,26 +255,26 @@ export default function Header() {
               <nav className="flex flex-col gap-1 font-[Pretendard] text-[16px] text-gray-700">
                 <a
                   href="#"
-                  className="rounded-[8px] px-2 py-2 transition-colors duration-200 hover:bg-primary-100 hover:text-black"
+                  className="hover:bg-primary-100 rounded-[8px] px-2 py-2 transition-colors duration-200 hover:text-black"
                 >
                   커뮤니티
                 </a>
                 <a
                   href="#"
-                  className="rounded-[8px] px-2 py-2 transition-colors duration-200 hover:bg-primary-100 hover:text-black"
+                  className="hover:bg-primary-100 rounded-[8px] px-2 py-2 transition-colors duration-200 hover:text-black"
                 >
                   질의응답
                 </a>
               </nav>
 
-              <div className="mt-3 border-t border-mono-200 pt-3">
+              <div className="border-mono-200 mt-3 border-t pt-3">
                 {!isAuthenticated ? (
                   <div className="flex flex-col gap-1">
                     <Button
                       type="button"
                       variant="link"
                       size="auto"
-                      className="w-full justify-start rounded-[8px] px-2 py-2 font-[Pretendard] text-[16px] text-mono-700 hover:bg-primary-100 hover:no-underline"
+                      className="text-mono-700 hover:bg-primary-100 w-full justify-start rounded-[8px] px-2 py-2 font-[Pretendard] text-[16px] hover:no-underline"
                       onClick={() => {
                         setMobileMenuOpen(false)
                         navigate('/login')
@@ -286,7 +286,7 @@ export default function Header() {
                       type="button"
                       variant="link"
                       size="auto"
-                      className="w-full justify-start rounded-[8px] px-2 py-2 font-[Pretendard] text-[16px] text-mono-700 hover:bg-primary-100 hover:no-underline"
+                      className="text-mono-700 hover:bg-primary-100 w-full justify-start rounded-[8px] px-2 py-2 font-[Pretendard] text-[16px] hover:no-underline"
                       onClick={() => {
                         setMobileMenuOpen(false)
                         navigate('/signup')
@@ -297,13 +297,24 @@ export default function Header() {
                   </div>
                 ) : (
                   <div>
-                    <div className="mb-2 rounded-[8px] bg-mono-100 px-3 py-2">
-                      <p className="text-[14px] font-semibold text-black">
-                        {user?.name ?? '유저'}
-                      </p>
-                      <p className="text-[13px] text-mono-500">
-                        {user?.email ?? ''}
-                      </p>
+                    <div className="bg-mono-100 mb-2 flex items-center gap-4 rounded-[8px] px-1 py-2">
+                      <img
+                        src={
+                          user?.profile_img_url
+                            ? user.profile_img_url
+                            : '/프로필 사진.svg'
+                        }
+                        alt="프로필"
+                        className="h-[40px] w-[40px] shrink-0 rounded-full object-cover"
+                      />
+                      <div className="min-w-0">
+                        <p className="truncate text-[14px] font-semibold text-black">
+                          {user?.name ?? '유저'}
+                        </p>
+                        <p className="text-mono-500 truncate text-[13px]">
+                          {user?.email ?? ''}
+                        </p>
+                      </div>
                     </div>
 
                     <div className="flex flex-col gap-1">
@@ -311,7 +322,7 @@ export default function Header() {
                         type="button"
                         variant="link"
                         size="auto"
-                        className="w-full justify-start rounded-[8px] px-2 py-2 text-left text-sm hover:bg-primary-100 hover:text-primary hover:no-underline"
+                        className="hover:bg-primary-100 hover:text-primary w-full justify-start rounded-[8px] px-2 py-2 text-left text-sm hover:no-underline"
                         onClick={() => {
                           setMobileMenuOpen(false)
                           setRegisterStudentModalOpen(true)
@@ -324,7 +335,7 @@ export default function Header() {
                         type="button"
                         variant="link"
                         size="auto"
-                        className="w-full justify-start rounded-[8px] px-2 py-2 text-left text-sm hover:bg-primary-100 hover:text-primary hover:no-underline"
+                        className="hover:bg-primary-100 hover:text-primary w-full justify-start rounded-[8px] px-2 py-2 text-left text-sm hover:no-underline"
                         onClick={() => {
                           setMobileMenuOpen(false)
                           navigate('/mypage/profile')
@@ -337,7 +348,7 @@ export default function Header() {
                         type="button"
                         variant="link"
                         size="auto"
-                        className="w-full justify-start rounded-[8px] px-2 py-2 text-left text-sm hover:bg-primary-100 hover:text-primary hover:no-underline"
+                        className="hover:bg-primary-100 hover:text-primary w-full justify-start rounded-[8px] px-2 py-2 text-left text-sm hover:no-underline"
                         onClick={handleLogout}
                       >
                         로그아웃


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #167 

## 📑 구현 사항

- 헤더를 반응형으로 개선하여 작은 화면에서 햄버거 메뉴로 전환
- 모바일에서 메뉴 토글 시 다시 자동으로 열리던 버그 수정
- 모바일 로그인 상태 메뉴 상단에 프로필 이미지/이름/이메일 영역 추가
- 햄버거 아이콘 가시성(테두리, 아이콘 색상) 개선

## 🌀 어려웠던 점 / 고민했던 부분

- 메뉴 바깥 클릭 감지 로직에서 햄버거 버튼 클릭이 바깥 클릭으로 처리되어 토글 상태가 꼬이는 문제
- 데스크톱 드롭다운 동작은 유지하면서 모바일 메뉴 동작만 분리하는 구조 정리

## 📸 구현 이미지

<img width="982" height="1242" alt="스크린샷 2026-02-09 오후 4 28 48" src="https://github.com/user-attachments/assets/6c0eb6d9-eab8-44df-a70c-bef6ebf93535" />
<img width="966" height="1242" alt="스크린샷 2026-02-09 오후 4 28 54" src="https://github.com/user-attachments/assets/7fc77611-4c45-49ea-a77e-a5694aa71fc8" />


## ❇️ 코드 설명

- `src/components/common/Header.tsx`
- `mobileMenuOpen` 상태 및 `mobileMenuRef`, `mobileMenuButtonRef` 추가
- 바깥 클릭 닫기 로직에 모바일 버튼 영역 예외 처리 반영
- `lg` 기준으로 데스크톱 메뉴/모바일 메뉴를 분리 렌더링
- 모바일 로그인 카드에 `user.profile_img_url` 우선, 없으면 기본 이미지(`'/프로필 사진.svg'`) 표시
- 사용자명/이메일은 `truncate` 적용으로 좁은 화면 줄깨짐 방지

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

