### PR TITLE
refactor: useVerificationTokenFlow 리팩토링 (#169)

### DIFF
--- a/src/hooks/findAccountVerification/useVerificationTokenFlow.ts
+++ b/src/hooks/findAccountVerification/useVerificationTokenFlow.ts
@@ -3,6 +3,9 @@ import { useState, useCallback, useEffect, useRef } from 'react'
 import { useCountdown } from '@/hooks/useCountdown'
 import { useVerificationRequestScope } from '@/hooks/verification/useVerificationRequestScope'
 
+const DEFAULT_SEND_ERROR_MESSAGE = '전송에 실패했습니다.'
+const DEFAULT_VERIFY_ERROR_MESSAGE = '인증에 실패했습니다.'
+
 export type UseVerificationTokenFlowOptions = {
   identity: string
   isIdentityValid?: boolean
@@ -41,6 +44,19 @@ export type UseVerificationTokenFlowResult = {
   isActive: boolean
 }
 
+function resolveErrorMessage(
+  err: unknown,
+  getErrorMessage: ((err: unknown) => string) | undefined,
+  fallback: string
+): string | null {
+  const message = getErrorMessage
+    ? getErrorMessage(err)
+    : err instanceof Error
+      ? err.message
+      : fallback
+  return message?.trim() || null
+}
+
 export function useVerificationTokenFlow({
   identity,
   isIdentityValid,
@@ -56,6 +72,7 @@ export function useVerificationTokenFlow({
   onInvalidate,
 }: UseVerificationTokenFlowOptions): UseVerificationTokenFlowResult {
   const normalizedIdentity = identity.trim()
+  const trimmedCode = code.trim()
   const hasIdentity =
     isIdentityValid !== undefined
       ? isIdentityValid
@@ -78,30 +95,31 @@ export function useVerificationTokenFlow({
     enabled,
   })
 
+  const clearVerificationState = useCallback(
+    (options?: { invokeInvalidateCallback?: boolean }) => {
+      sendRequestSeqRef.current += 1
+      verifyRequestSeqRef.current += 1
+      setToken(null)
+      setCodeSent(false)
+      setSending(false)
+      setVerifying(false)
+      setNotice(null)
+      setError(null)
+      resetTimer()
+      if (options?.invokeInvalidateCallback) {
+        onInvalidate?.()
+      }
+    },
+    [resetTimer, onInvalidate]
+  )
+
   const invalidateVerification = useCallback(() => {
-    sendRequestSeqRef.current += 1
-    verifyRequestSeqRef.current += 1
-    setToken(null)
-    setCodeSent(false)
-    setSending(false)
-    setVerifying(false)
-    setNotice(null)
-    setError(null)
-    resetTimer()
-    onInvalidate?.()
-  }, [resetTimer, onInvalidate])
+    clearVerificationState({ invokeInvalidateCallback: true })
+  }, [clearVerificationState])
 
   const resetAll = useCallback(() => {
-    sendRequestSeqRef.current += 1
-    verifyRequestSeqRef.current += 1
-    setToken(null)
-    setCodeSent(false)
-    setSending(false)
-    setVerifying(false)
-    setNotice(null)
-    setError(null)
-    resetTimer()
-  }, [resetTimer])
+    clearVerificationState()
+  }, [clearVerificationState])
 
   useEffect(() => {
     if (!enabled) {
@@ -135,7 +153,11 @@ export function useVerificationTokenFlow({
 
   // 모달 닫힘 상태(enabled=false)에서는 전송/검증 방지
   const onSend = useCallback(async () => {
-    if (!enabled || !hasIdentity || sending || verifying || token != null) return
+    const hasPendingRequest = sending || verifying
+    const isBlocked =
+      !enabled || !hasIdentity || hasPendingRequest || token != null
+    if (isBlocked) return
+
     setError(null)
     setNotice(null)
     setSending(true)
@@ -158,12 +180,9 @@ export function useVerificationTokenFlow({
         !isCurrentRequest(requestedIdentity)
       )
         return
-      const sendErrorMessage = getSendErrorMessage
-        ? getSendErrorMessage(err)
-        : err instanceof Error
-          ? err.message
-          : '전송에 실패했습니다.'
-      setError(sendErrorMessage?.trim() || null)
+      setError(
+        resolveErrorMessage(err, getSendErrorMessage, DEFAULT_SEND_ERROR_MESSAGE)
+      )
     } finally {
       if (sendRequestSeqRef.current === requestSeq) {
         setSending(false)
@@ -184,21 +203,22 @@ export function useVerificationTokenFlow({
   ])
 
   const onVerify = useCallback(async () => {
-    if (
+    const hasPendingRequest = sending || verifying
+    const isBlocked =
       !enabled ||
       !hasIdentity ||
       !codeSent ||
       isExpired ||
-      sending ||
-      verifying ||
+      hasPendingRequest ||
       token != null
-    )
-      return
+    if (isBlocked) return
+    if (!trimmedCode) return
+
     setError(null)
     setNotice(null)
     setVerifying(true)
     const requestedIdentity = normalizedIdentity
-    const requestedCode = code.trim()
+    const requestedCode = trimmedCode
     const requestSeq = verifyRequestSeqRef.current + 1
     verifyRequestSeqRef.current = requestSeq
     try {
@@ -220,12 +240,13 @@ export function useVerificationTokenFlow({
         !isCurrentRequest(requestedIdentity)
       )
         return
-      const verifyErrorMessage = getVerifyErrorMessage
-        ? getVerifyErrorMessage(err)
-        : err instanceof Error
-          ? err.message
-          : '인증에 실패했습니다.'
-      setError(verifyErrorMessage?.trim() || null)
+      setError(
+        resolveErrorMessage(
+          err,
+          getVerifyErrorMessage,
+          DEFAULT_VERIFY_ERROR_MESSAGE
+        )
+      )
     } finally {
       if (verifyRequestSeqRef.current === requestSeq) {
         setVerifying(false)
@@ -234,13 +255,13 @@ export function useVerificationTokenFlow({
   }, [
     enabled,
     hasIdentity,
-    normalizedIdentity,
-    code,
     codeSent,
     isExpired,
     sending,
     verifying,
     token,
+    normalizedIdentity,
+    trimmedCode,
     verify,
     verifySuccessNotice,
     resetTimer,
@@ -254,7 +275,7 @@ export function useVerificationTokenFlow({
     enabled &&
     hasIdentity &&
     codeSent &&
-    !!code.trim() &&
+    !!trimmedCode &&
     !isExpired &&
     !verified &&
     !sending &&


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #169 

## 📑 구현 사항

- `useVerificationTokenFlow` 내부 상태 초기화 로직 중복 제거
- send/verify 에러 메시지 fallback 문자열 상수화
- 에러 메시지 결정 로직을 `resolveErrorMessage` 헬퍼로 통합
- `code.trim()` 반복 계산 제거(`trimmedCode` 도입)
- `onSend`/`onVerify`의 가드 조건을 `isBlocked` 중심으로 정리해 가독성 개선

## 🌀 어려웠던 점 / 고민했던 부분

- 동작을 바꾸지 않으면서(회귀 없이) 코드 구조만 단순화해야 해서, 요청 순서 보호 로직(`requestSeq`, `isCurrentRequest`)을 유지한 채 리팩토링 범위를 제한함
- `invalidateVerification`과 `resetAll`의 의도 차이(외부 콜백 호출 여부)를 유지하면서 중복 제거하는 구조를 고민함

## 📸 구현 이미지

- UI 변경 없음 (내부 훅 리팩토링)

## ❇️ 코드 설명

- 대상 파일: `src/hooks/findAccountVerification/useVerificationTokenFlow.ts`
- 변경 포인트
- `DEFAULT_SEND_ERROR_MESSAGE`, `DEFAULT_VERIFY_ERROR_MESSAGE` 상수 추가
- `resolveErrorMessage` 함수 추가로 send/verify catch 블록 중복 제거
- `clearVerificationState` 함수 도입 후
  - `invalidateVerification`: `onInvalidate` 콜백 포함 초기화
  - `resetAll`: 콜백 없는 초기화
- `trimmedCode`를 재사용해 `onVerify`/`canVerify`의 중복 trim 제거

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

