### PR TITLE
feat: Ordering 문항 디벨롭 및 쪽지시험 응시·결과 UX 개선 (#160)

### DIFF
--- a/src/components/quiz/Ordering.tsx
+++ b/src/components/quiz/Ordering.tsx
@@ -93,6 +93,73 @@ function DraggableLabel({
   )
 }
 
+/** 슬롯 안에 들어간 라벨(드래그 가능, 슬롯 간 맞바꾸기용) */
+interface DraggableSlotLabelProps {
+  slotIndex: number
+  label: string
+  onRemove: () => void
+  isResult?: boolean
+  isSlotCorrect?: boolean
+}
+
+function DraggableSlotLabel({
+  slotIndex,
+  label,
+  onRemove,
+  isResult,
+  isSlotCorrect,
+}: DraggableSlotLabelProps) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({
+      id: `slot-label-${slotIndex}`,
+      disabled: !!isResult,
+      data: { label, slotIndex },
+    })
+
+  const getLabelInnerClass = () => {
+    if (!isResult || isSlotCorrect === undefined) {
+      return 'text-primary bg-primary-100 text-[18px] font-normal w-8 h-8 flex items-center justify-center rounded-[4px]'
+    }
+    return isSlotCorrect
+      ? 'text-success text-[20px] font-bold bg-surface w-10 h-10 flex items-center justify-center rounded-[4px]'
+      : 'text-warning text-[20px] font-bold bg-surface w-10 h-10 flex items-center justify-center rounded-[4px]'
+  }
+
+  const style = transform
+    ? { transform: CSS.Translate.toString(transform), opacity: isDragging ? 0.5 : 1 }
+    : undefined
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="relative flex h-full w-full items-center justify-center"
+    >
+      {!isResult && (
+        <Button
+          type="button"
+          variant="link"
+          size="auto"
+          onClick={(e) => {
+            e.stopPropagation()
+            onRemove()
+          }}
+          className="absolute -top-1 -right-1 z-10 flex h-4 w-4 min-w-0 items-center justify-center rounded-full border border-gray-300 bg-white p-0 text-xs text-gray-400 hover:text-gray-600 hover:no-underline"
+          aria-label="제거"
+        >
+          ×
+        </Button>
+      )}
+      <span
+        className={`${getLabelInnerClass()} ${!isResult ? 'cursor-grab active:cursor-grabbing' : ''}`}
+        {...(isResult ? {} : { ...listeners, ...attributes })}
+      >
+        {label}
+      </span>
+    </div>
+  )
+}
+
 interface DroppableSlotProps {
   id: string
   index: number
@@ -130,26 +197,21 @@ function DroppableSlot({
       className={`flex h-[62px] w-[62px] items-center justify-center rounded-[4px] bg-surface p-[3px] transition-colors ${slotBorderClass}`}
     >
       {label ? (
-        <div className="relative flex h-full w-full items-center justify-center">
-          {!isResult && (
-            <Button
-              type="button"
-              variant="link"
-              size="auto"
-              onClick={(e) => {
-                e.stopPropagation()
-                onRemove()
-              }}
-              className="absolute -top-1 -right-1 flex h-4 w-4 min-w-0 items-center justify-center rounded-full border border-gray-300 bg-white p-0 text-xs text-gray-400 hover:text-gray-600 hover:no-underline"
-              aria-label="제거"
-            >
-              ×
-            </Button>
-          )}
-          <span className={getLabelInnerClass()}>{label}</span>
-        </div>
+        isResult ? (
+          <div className="relative flex h-full w-full items-center justify-center">
+            <span className={getLabelInnerClass()}>{label}</span>
+          </div>
+        ) : (
+          <DraggableSlotLabel
+            slotIndex={index}
+            label={label}
+            onRemove={onRemove}
+            isResult={isResult}
+            isSlotCorrect={isSlotCorrect}
+          />
+        )
       ) : (
-        <span className="text-mono-600 text-sm font-medium">{index + 1}</span>
+        <span className="text-surface text-sm font-medium">{index + 1}</span>
       )}
     </div>
   )
@@ -174,12 +236,18 @@ export default function Ordering({
     initializeSlots(options, answer, optionLabels)
   )
 
-  // 부모에서 넘긴 answer와 동기화. questionId, options 길이, answer 값(직렬화)만으로 동기화 여부 판단.
+  // 부모에서 넘긴 answer와 동기화. 우리가 방금 보낸 답안과 같으면 슬롯 덮어쓰지 않음(중간 제거 시 나머지 슬롯 자리 유지).
   const prevSyncKey = useRef<string | null>(null)
+  const lastSentAnswerRef = useRef<string | null>(null)
   useEffect(() => {
     const syncKey = `${question.questionId}:${options.length}:${JSON.stringify(answer)}`
     if (prevSyncKey.current === syncKey) return
     prevSyncKey.current = syncKey
+    if (lastSentAnswerRef.current !== null && lastSentAnswerRef.current === JSON.stringify(answer)) {
+      lastSentAnswerRef.current = null
+      return
+    }
+    lastSentAnswerRef.current = null
     setSlots(initializeSlots(options, answer, optionLabels))
   }, [question.questionId, answer, options, optionLabels])
 
@@ -204,33 +272,50 @@ export default function Ordering({
     const { active, over } = event
     if (!over) return
 
-    // 슬롯이 아닌 곳(예: 다른 라벨 위)에 드롭한 경우 무시
     const overId = over.id as string
     if (!overId.startsWith('slot-')) return
     const slotIndex = parseInt(overId.replace('slot-', ''), 10)
     if (Number.isNaN(slotIndex) || slotIndex < 0 || slotIndex >= slots.length)
       return
 
-    const draggedLabel = (active.id as string).replace('label-', '')
-    const newSlots = [...slots]
-    const existingSlotIndex = newSlots.findIndex(
-      (label) => label === draggedLabel
-    )
+    const activeId = active.id as string
+    let draggedLabel: string
+    let sourceSlotIndex: number
 
-    if (existingSlotIndex !== -1) {
-      newSlots[existingSlotIndex] = null
+    if (activeId.startsWith('slot-label-')) {
+      sourceSlotIndex = parseInt(activeId.replace('slot-label-', ''), 10)
+      draggedLabel = slots[sourceSlotIndex] ?? ''
+    } else {
+      draggedLabel = activeId.replace('label-', '')
+      sourceSlotIndex = slots.findIndex((label) => label === draggedLabel)
     }
 
+    if (!draggedLabel) return
+
+    const newSlots = [...slots]
+    const targetLabel = newSlots[slotIndex]
+
+    if (sourceSlotIndex !== -1) {
+      newSlots[sourceSlotIndex] = targetLabel
+    } else if (targetLabel !== null) {
+      const firstEmpty = newSlots.findIndex((l) => l === null)
+      if (firstEmpty !== -1) newSlots[firstEmpty] = targetLabel
+    }
     newSlots[slotIndex] = draggedLabel
+
+    const nextAnswer = convertLabelsToAnswers(newSlots)
+    lastSentAnswerRef.current = JSON.stringify(nextAnswer)
     setSlots(newSlots)
-    onAnswerChange(question.questionId, convertLabelsToAnswers(newSlots))
+    onAnswerChange(question.questionId, nextAnswer)
   }
 
   const handleRemoveFromSlot = (index: number) => {
     const newSlots = [...slots]
     newSlots[index] = null
+    const nextAnswer = convertLabelsToAnswers(newSlots)
+    lastSentAnswerRef.current = JSON.stringify(nextAnswer)
     setSlots(newSlots)
-    onAnswerChange(question.questionId, convertLabelsToAnswers(newSlots))
+    onAnswerChange(question.questionId, nextAnswer)
   }
 
   const isLabelUsed = (label: string) => slots.includes(label)

--- a/src/components/quiz/ResultQuestionItem.tsx
+++ b/src/components/quiz/ResultQuestionItem.tsx
@@ -10,6 +10,20 @@ import ShortAnswer from './ShortAnswer'
 type ResultQuestion = ExamSubmissionResult['questions'][0]
 type QuizQuestion = ExamDeploymentDetailResult['questions'][0]
 
+/** 결과 API 문항 타입 → 내부 타입 (자식 컴포넌트용) */
+const RESULT_API_TYPE_TO_INTERNAL: Record<string, string> = {
+  SINGLE_CHOICE: 'single_choice',
+  MULTI_SELECT: 'multiple_choice',
+  OX: 'ox',
+  SHORT_ANSWER: 'short_answer',
+  FILL_IN_BLANK: 'fill_blank',
+  ORDERING: 'ordering',
+}
+
+function toInternalType(apiType: string): QuizQuestion['type'] {
+  return (RESULT_API_TYPE_TO_INTERNAL[apiType] ?? apiType) as QuizQuestion['type']
+}
+
 interface ResultQuestionItemProps {
   question: ResultQuestion
   index: number
@@ -22,7 +36,7 @@ function mapResultQuestionToQuizQuestion(
   return {
     questionId: question.id,
     number: index + 1,
-    type: question.type as QuizQuestion['type'],
+    type: toInternalType(question.type),
     question: question.question,
     point: question.point,
     prompt: question.prompt,
@@ -41,7 +55,7 @@ export default function ResultQuestionItem({ question, index }: ResultQuestionIt
   const noop = () => {}
 
   switch (question.type) {
-    case 'single_choice':
+    case 'SINGLE_CHOICE':
       return (
         <SingleChoice
           question={mapped}
@@ -53,7 +67,7 @@ export default function ResultQuestionItem({ question, index }: ResultQuestionIt
           explanation={question.explanation}
         />
       )
-    case 'multiple_choice':
+    case 'MULTI_SELECT':
       return (
         <MultipleChoice
           question={mapped}
@@ -65,7 +79,7 @@ export default function ResultQuestionItem({ question, index }: ResultQuestionIt
           explanation={question.explanation}
         />
       )
-    case 'short_answer':
+    case 'SHORT_ANSWER':
       return (
         <ShortAnswer
           question={mapped}
@@ -76,7 +90,7 @@ export default function ResultQuestionItem({ question, index }: ResultQuestionIt
           explanation={question.explanation}
         />
       )
-    case 'ox':
+    case 'OX':
       return (
         <OX
           question={mapped}
@@ -88,7 +102,7 @@ export default function ResultQuestionItem({ question, index }: ResultQuestionIt
           explanation={question.explanation}
         />
       )
-    case 'fill_blank':
+    case 'FILL_IN_BLANK':
       return (
         <FillBlank
           question={mapped}
@@ -100,7 +114,7 @@ export default function ResultQuestionItem({ question, index }: ResultQuestionIt
           explanation={question.explanation}
         />
       )
-    case 'ordering':
+    case 'ORDERING':
       return (
         <Ordering
           question={mapped}

--- a/src/constants/quiz.ts
+++ b/src/constants/quiz.ts
@@ -34,3 +34,26 @@ export const SECONDS_PER_MINUTE = 60
 export const ARRAY_ANSWER_TYPES = new Set<
   'multiple_choice' | 'fill_blank' | 'ordering'
 >(['multiple_choice', 'fill_blank', 'ordering'])
+
+/** 제출 API용: 내부 타입 → API 타입 (SINGLE_CHOICE, MULTI_SELECT 등) */
+export const EXAM_QUESTION_TYPE_TO_API = {
+  single_choice: 'SINGLE_CHOICE',
+  fill_blank: 'FILL_IN_BLANK',
+  ordering: 'ORDERING',
+  multiple_choice: 'MULTI_SELECT',
+  short_answer: 'SHORT_ANSWER',
+  ox: 'OX',
+} as const
+
+export type ExamQuestionTypeApi =
+  (typeof EXAM_QUESTION_TYPE_TO_API)[keyof typeof EXAM_QUESTION_TYPE_TO_API]
+
+/** 결과 조회 API 응답 타입 → 내부 타입 (렌더링용 자식 컴포넌트에 전달) */
+export const API_TO_EXAM_QUESTION_TYPE: Record<ExamQuestionTypeApi, string> = {
+  SINGLE_CHOICE: 'single_choice',
+  FILL_IN_BLANK: 'fill_blank',
+  ORDERING: 'ordering',
+  MULTI_SELECT: 'multiple_choice',
+  SHORT_ANSWER: 'short_answer',
+  OX: 'ox',
+}

--- a/src/mappers/examSubmissionResult.ts
+++ b/src/mappers/examSubmissionResult.ts
@@ -1,3 +1,4 @@
+/** 결과 조회 API 응답 (서버가 snake_case + 대문자 type 사용) */
 export interface ExamSubmissionResultResponse {
   id: number
   submitter_id: number
@@ -10,7 +11,7 @@ export interface ExamSubmissionResultResponse {
   questions: Array<{
     id: number
     question: string
-    prompt: string
+    prompt: string | null
     blank_count: number
     options: string[]
     type: string
@@ -61,33 +62,35 @@ export interface ExamSubmissionResult {
 export const mapExamSubmissionResult = (
   response: ExamSubmissionResultResponse
 ): ExamSubmissionResult => {
+  const questions = response.questions ?? []
+  const exam = response.exam
   return {
     id: response.id,
     submitterId: response.submitter_id,
     deploymentId: response.deployment_id,
     exam: {
-      id: response.exam.id,
-      title: response.exam.title,
-      thumbnailImgUrl: response.exam.thumbnail_img_url,
+      id: exam?.id ?? 0,
+      title: exam?.title ?? '',
+      thumbnailImgUrl: exam?.thumbnail_img_url ?? '',
     },
-    questions: response.questions.map((question) => ({
-      id: question.id,
-      question: question.question,
-      prompt: question.prompt,
-      blankCount: question.blank_count,
-      options: question.options,
-      type: question.type,
-      answer: question.answer,
-      point: question.point,
-      explanation: question.explanation,
-      isCorrect: question.is_correct,
-      submittedAnswer: question.submitted_answer,
+    questions: questions.map((q) => ({
+      id: q.id,
+      question: q.question ?? '',
+      prompt: q.prompt ?? '',
+      blankCount: q.blank_count ?? 0,
+      options: Array.isArray(q.options) ? q.options : [],
+      type: q.type ?? '',
+      answer: Array.isArray(q.answer) ? q.answer : [],
+      point: q.point ?? 0,
+      explanation: q.explanation ?? '',
+      isCorrect: q.is_correct ?? false,
+      submittedAnswer: Array.isArray(q.submitted_answer) ? q.submitted_answer : [],
     })),
-    cheatingCount: response.cheating_count,
-    totalScore: response.total_score,
-    correctAnswerCount: response.correct_answer_count,
-    elapsedTime: response.elapsed_time,
-    startedAt: response.started_at,
-    submittedAt: response.submitted_at,
+    cheatingCount: response.cheating_count ?? 0,
+    totalScore: response.total_score ?? 0,
+    correctAnswerCount: response.correct_answer_count ?? 0,
+    elapsedTime: response.elapsed_time ?? 0,
+    startedAt: response.started_at ?? '',
+    submittedAt: response.submitted_at ?? '',
   }
 }

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -51,7 +51,7 @@ function QuizPage() {
   const [isEnded, setIsEnded] = useState(false)
   const [endReason, setEndReason] = useState<'time' | 'status' | 'cheating' | null>(null)
   const [openModal, setOpenModal] = useState<
-    'cheating' | 'fullscreen' | 'submitComplete' | null
+    'cheating' | 'fullscreen' | 'submitComplete' | 'leaveWarning' | null
   >(null)
   const [answers, setAnswers] = useState<Record<number, string | string[] | null>>({})
 
@@ -98,6 +98,36 @@ function QuizPage() {
 
   submitAndEndByTimeRef.current = submitAndEndByTime
   useAdminStatusPolling(statusData, isEnded, setIsEnded, setEndReason)
+
+  const hasPushedHistoryRef = useRef(false)
+  const quizPathnameRef = useRef('')
+  useEffect(() => {
+    if (isEnded || !isAccessAllowed || isLoading || !deploymentId) return
+    if (hasPushedHistoryRef.current) return
+    hasPushedHistoryRef.current = true
+    const pathname = window.location.pathname
+    quizPathnameRef.current = pathname
+    window.history.pushState({ quizPage: true }, '', pathname)
+  }, [isEnded, isAccessAllowed, isLoading, deploymentId])
+
+  useEffect(() => {
+    if (isEnded) return
+    const onPopState = () => {
+      window.history.pushState(
+        { quizPage: true },
+        '',
+        quizPathnameRef.current || window.location.pathname
+      )
+      setOpenModal('leaveWarning')
+    }
+    window.addEventListener('popstate', onPopState)
+    return () => window.removeEventListener('popstate', onPopState)
+  }, [isEnded])
+
+  const handleLeaveWarningConfirm = () => {
+    setOpenModal(null)
+    submitAndEndByTime()
+  }
 
   const handleAnswerChange = (questionId: number, value: string | string[]) => {
     setAnswers((prev) => ({ ...prev, [questionId]: value }))
@@ -315,6 +345,31 @@ function QuizPage() {
         onClose={() => setOpenModal(null)}
         onConfirm={handleSubmitCompleteConfirm}
       />
+
+      <Modal
+        isOpen={openModal === 'leaveWarning'}
+        onClose={() => setOpenModal(null)}
+      >
+        <Modal.Body>
+          <div className="flex min-w-[250px] flex-col items-center gap-4 py-4">
+            <p className="text-center text-[16px] text-foreground-secondary">
+              응시페이지 이탈하여 답안이 제출되고 시험이 종료됩니다.
+            </p>
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button
+            variant="primary"
+            size="md"
+            rounded="default"
+            className="w-full"
+            onClick={handleLeaveWarningConfirm}
+            disabled={submissionMutation.isPending}
+          >
+            {submissionMutation.isPending ? '제출 중...' : '확인'}
+          </Button>
+        </Modal.Footer>
+      </Modal>
     </div>
   )
 }

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -152,6 +152,18 @@ function QuizPage() {
     }
   }
 
+  /** 부정행위 경고 모달 확인: 전체화면이 아니면 전체화면으로 전환 후 모달 닫기 */
+  const handleCheatingConfirm = async () => {
+    if (!document.fullscreenElement) {
+      try {
+        await document.documentElement.requestFullscreen()
+      } catch {
+        // 전체화면 전환 실패 시에도 모달은 닫음
+      }
+    }
+    handleCheatingClose()
+  }
+
   const handleStatusEndTest = () => {
     setIsEnded(true)
     setEndReason('status')
@@ -236,7 +248,7 @@ function QuizPage() {
         isOpen={openModal === 'cheating'}
         onClose={handleCheatingClose}
         warningLevel={warningLevel}
-        onConfirm={handleCheatingClose}
+        onConfirm={handleCheatingConfirm}
         onTerminate={handleCheatingTerminate}
       />
 

--- a/src/pages/QuizResultPage.tsx
+++ b/src/pages/QuizResultPage.tsx
@@ -8,14 +8,24 @@ import { ResultQuestionItem } from '@/components/quiz'
 
 // 분당 밀리초 수
 const MS_PER_MINUTE = 60_000
+// 분당 초 수
+const SECONDS_PER_MINUTE = 60
 
-// 응시시간
+/**
+ * 응시시간(분) 계산
+ * - API의 elapsed_time(초)이 0 이상이면 우선 사용
+ * - 없으면 started_at ~ submitted_at 차이로 계산 (1분 미만이면 0)
+ * - fallback은 0 미만이면 0으로 처리
+ */
 function getElapsedMinutes(
   startedAt: string | undefined,
   submittedAt: string | undefined,
-  fallback: number
+  elapsedTimeSeconds: number
 ): number {
-  if (!startedAt || !submittedAt) return fallback
+  if (elapsedTimeSeconds >= 0) {
+    return Math.max(0, Math.floor(elapsedTimeSeconds / SECONDS_PER_MINUTE))
+  }
+  if (!startedAt || !submittedAt) return 0
   const started = new Date(startedAt).getTime()
   const submitted = new Date(submittedAt).getTime()
   return Math.max(0, Math.floor((submitted - started) / MS_PER_MINUTE))
@@ -58,7 +68,7 @@ function QuizResultPage() {
   const elapsedMinutes = getElapsedMinutes(
     data?.startedAt,
     data?.submittedAt,
-    data?.elapsedTime ?? 0
+    data?.elapsedTime ?? -1
   )
   const maxScore =
     data?.questions.reduce((sum, q) => sum + (q.point ?? 0), 0) ?? 0


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #160 

## 📑 구현 사항

- **Ordering(순서 맞추기) 문항**
  - API 문항 타입 상수 매핑 (`EXAM_QUESTION_TYPE_TO_API`, `API_TO_EXAM_QUESTION_TYPE`) 추가 후 문항 타입을 API 스펙에 맞춰 렌더링
  - Ordering 컴포넌트: 슬롯 간 **맞바꾸기(swap)**, 슬롯 내 **라벨 드래그**로 순서 변경, 중간 슬롯 제거 시 **자리 유지**
  - 결과 조회 응답 타입·매퍼 보강(snake_case, null 처리) 및 결과 페이지에서 Ordering 정답/해설 표시

- **응시 페이지 이탈 경고**
  - **브라우저 뒤로가기**: `popstate` 리스너 + 동일 URL로 `history.pushState` 한 번 추가 → 뒤로가기 시 같은 퀴즈 URL로만 이동해 라우트 유지 후 이탈 경고 모달 표시
  - **헤더 뒤로가기 링크**: `QuizHeader`에 `onBackClick` prop 추가 → 클릭 시 바로 이탈 경고 모달만 표시(다른 페이지로 이동하지 않음)
  - 모달 **확인** 시 `submitAndNavigateFromLeave()`로 답안 자동 제출 후 결과 페이지 이동, **닫기** 시 모달만 닫고 응시 페이지 유지

- **부정행위·전체화면**
  - 부정행위 경고 모달 확인 시 전체화면이 아니면 전체화면으로 전환 후 모달 닫기
  - 결과 페이지 / 마이페이지 퀴즈 목록 진입 시 전체화면이면 자동 해제

- **기타**
  - 결과 페이지 응시시간 0분 표시 개선(elapsed_time 우선, 음수 방지)

---

## 🌀 어려웠던 점 / 고민했던 부분

- **브라우저 뒤로가기 시 모달이 안 뜨는 문제**
  - `useBlocker`는 데이터 라우터(createBrowserRouter)에서만 동작하고, 현재 앱은 `BrowserRouter`를 사용해 에러로 인해 빈 화면이 나옴 → `useBlocker` 제거 후 **History API(popstate + pushState)** 로 처리
  - 뒤로가기 한 번에 이전 페이지로 나가면 React Router가 라우트를 바꿔 QuizPage가 언마운트되어 모달을 띄울 수 없음 → **진입 시 동일 URL로 `pushState` 한 번** 해서 히스토리를 `[이전, 퀴즈, 퀴즈]`처럼 만들고, 뒤로가기를 누르면 같은 퀴즈 URL로만 이동하도록 해 라우트 유지 후 모달 표시

- **헤더 뒤로가기 링크**
  - `<Link to="/mypage/quiz">`는 클릭 시 바로 이동하므로 `popstate`가 발생하지 않음 → 헤더에 **`onBackClick` 옵션**을 두고, 응시 페이지에서는 링크 대신 버튼으로 렌더링해 클릭 시 `setOpenModal('leaveWarning')`만 호출하도록 분기

- **popstate 핸들러에서 setState**
  - popstate 콜백이 예전 클로저의 `setOpenModal`을 참조할 수 있어, **ref에 최신 `setOpenModal`을 넣어 두고** `setOpenModalRef.current('leaveWarning')`로 호출하도록 변경

- **Ordering 슬롯·드래그**
  - 라벨을 슬롯에 넣었다 뺐다 할 때 인덱스 꼬임과 자리 유지 요구사항을 맞추기 위해, 슬롯 배열 초기화·드래그 종료 시 swap/제거 로직을 정리하고 `@dnd-kit`의 `useDraggable`/`useDroppable`로 라벨·슬롯 드래그를 일관되게 처리

---

## 📸 구현 이미지

---
- **Ordering 디벨롭**

https://github.com/user-attachments/assets/4a493fa9-2894-4001-8231-69602acf6c1d

- **응시 중 뒤로가기 패치 ver.1**

https://github.com/user-attachments/assets/c998eab9-2be6-445a-9c6d-3eb764e38bc3

- **응시 중 뒤로가기 패치 ver.2**

https://github.com/user-attachments/assets/fdfe20a8-7a73-4ba1-9062-67fa5a050ce7



## ❇️ 코드 설명

- **이탈 경고**: QuizPage에서 `popstate` 리스너 + 진입 시 동일 URL `pushState`로 뒤로가기 시 모달 표시·URL 유지. 확인 시 `handleLeaveWarningConfirm` → `submitAndNavigateFromLeave()`로 제출 후 결과 페이지 이동.
- **QuizHeader**: `onBackClick` 전달 시 Link 대신 button 렌더링, 클릭 시 이탈 경고 모달만 오픈.
- **useQuizSubmissionFlow**: `submitAndNavigateFromLeave`에서 payload 제출 후 성공 시 결과 페이지, 실패 시 목록으로 이동.
- **Ordering**: `@dnd-kit`으로 라벨↔슬롯 드래그·슬롯 간 swap·제거 시 해당 슬롯만 비우며 자리 유지.
- **전체화면**: QuizResultPage·MyPageQuiz 마운트 시 `fullscreenElement` 있으면 `exitFullscreen()` 호출.

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.