### PR TITLE
[Refactor] 수강생 등록 에러 코드 개선 (#164)

### DIFF
--- a/src/components/common/Modal/variants/RegisterStudentModal.tsx
+++ b/src/components/common/Modal/variants/RegisterStudentModal.tsx
@@ -10,6 +10,7 @@ import {
   type RegisterStudentFormData,
 } from '@/schemas/modalSchemas'
 import { fetchCourses, fetchCohorts, enrollStudent } from '@/api/info'
+import axios from 'axios'
 
 interface RegisterStudentModalProps {
   isOpen: boolean
@@ -150,7 +151,10 @@ export function RegisterStudentModal({
 
             {enrollMutation.isError && (
               <p className="text-sm text-red-500">
-                등록 신청에 실패했습니다. 다시 시도해 주세요.
+                {axios.isAxiosError(enrollMutation.error) &&
+                enrollMutation.error.response?.status === 403
+                  ? '*등록 신청에 실패했습니다. 이미 해당 기수에 등록 신청하였습니다.'
+                  : '등록 신청에 실패했습니다. 다시 시도해 주세요.'}
               </p>
             )}
             <div className="pt-4">

--- a/src/pages/QuizResultPage.tsx
+++ b/src/pages/QuizResultPage.tsx
@@ -1,4 +1,5 @@
-import { useNavigate, useParams } from 'react-router-dom'
+import { useEffect } from 'react'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { Button, Loading } from '@/components/common'
 import { QUIZ_LIST_PATH } from '@/constants/quiz'
 import QuizHeader from '@/components/quiz/QuizHeader'
@@ -45,6 +46,7 @@ function buildResultHeaderMessage(
 
 function QuizResultPage() {
   const navigate = useNavigate()
+  const location = useLocation()
   const { submissionId } = useParams<{ submissionId: string }>()
   const submissionIdNumber = submissionId ? Number(submissionId) : 0
 
@@ -54,6 +56,14 @@ function QuizResultPage() {
   )
 
   const goToList = () => navigate(QUIZ_LIST_PATH)
+
+  // 결과 페이지 진입 시 히스토리에 목록 URL 추가 → 브라우저 뒤로가기 시 목록으로 이동
+  useEffect(() => {
+    if (!submissionId) return
+    const resultPath = location.pathname
+    window.history.pushState(null, '', QUIZ_LIST_PATH)
+    window.history.pushState(null, '', resultPath)
+  }, [submissionId, location.pathname])
 
   if (isLoading) {
     return (


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #164 

## 📑 구현 사항

- **수강생 등록 에러 코드 개선**
  - 이미 수강등록 된 과정/기수 등록신청 시, 모달에 **"*등록 신청에 실패했습니다. 이미 해당 기수에 등록 신청하였습니다."** 문구 노출
  그 외 에러(4xx/5xx)는 기존처럼 **"등록 신청에 실패했습니다. 다시 시도해 주세요."** 유지
  - 쪽지시험 결과페이지 에서 브라우저 뒤로가기 시 쪽지시험 목록페이지로 이동되게 디테일 추가

---

## 🌀 어려웠던 점 / 고민했던 부분

- 
---

## 📸 구현 이미지

<img width="351" height="397" alt="스크린샷 2026-02-09 오후 7 32 16" src="https://github.com/user-attachments/assets/92201035-6654-40f0-b78c-17499441c74e" />


## ❇️ 코드 설명

-

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.