### PR TITLE
feat: 페이지 이동 시 스크롤 위치 자동 상단에 고정 (#176)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { useEffect } from 'react'
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 
 import '@/App.css'
@@ -20,9 +21,20 @@ import { RequireAuth } from '@/components/auth/RequireAuth'
 import MyInfo from './components/MyInfo'
 import PasswordChange from './components/PasswordChange'
 
+function ScrollToTop() {
+  const { pathname } = useLocation()
+
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [pathname])
+
+  return null
+}
+
 function App() {
   return (
     <BrowserRouter>
+      <ScrollToTop />
       <Routes>
         {/* 헤더가 포함된 페이지 */}
         <Route element={<MainLayout />}>


### PR DESCRIPTION
제목: feat: 페이지 이동 시 스크롤 위치 상단 고정 (#이슈번호)

## #️⃣ 연관된 이슈
- Resolves #176 

## 📑 구현 사항
- `src/App.tsx`에 `ScrollToTop` 컴포넌트를 추가했습니다.
- `useLocation`의 `pathname`이 변경될 때마다 `window.scrollTo(0, 0)`를 호출하도록 구현했습니다.
- `<BrowserRouter>` 바로 아래에 `<ScrollToTop />`를 배치해 전체 라우트에 공통 적용했습니다.

## 🌀 어려웠던 점 / 고민했던 부분
- 페이지별 개별 처리 대신 라우터 레벨 공통 처리로 중복을 줄였습니다.
- `pathname` 기준으로 동작시켜 동일 경로 내 상태 변경에는 불필요하게 스크롤이 초기화되지 않도록 했습니다.

## 📸 구현 이미지


## ❇️ 코드 설명
- `src/App.tsx`
- `ScrollToTop`은 렌더링 UI 없이 라우트 변경 부수효과만 담당합니다.
- `useEffect(() => window.scrollTo(0, 0), [pathname])`로 전환 시점에 상단 이동을 보장합니다.

## 💬 리뷰 요청사항