### PR TITLE
fix: refresh 토큰 처리 및 쪽지시험 제출·결과 페이지 동작 수정 (#178)

### DIFF
--- a/src/api/quiz.ts
+++ b/src/api/quiz.ts
@@ -139,10 +139,18 @@ export const submitExam = async (payload: ExamSubmissionPayload) => {
  * 쪽지시험 결과 조회
  * 사용 예:
  * const data = await fetchExamSubmissionResult(350)
+ * 백엔드가 { data: { id, questions, exam, ... } } 형태로 감싸서 보낼 수 있음.
  */
 export const fetchExamSubmissionResult = async (submissionId: number) => {
   const response = await apiClient.get<ExamSubmissionResultResponse>(
     `/api/v1/exams/submissions/${submissionId}`
   )
-  return mapExamSubmissionResultDetail(response.data)
+  const raw = response.data as unknown as Record<string, unknown>
+  const payload: ExamSubmissionResultResponse =
+    raw?.data != null && typeof raw.data === 'object'
+      ? (raw.data as ExamSubmissionResultResponse)
+      : raw?.result != null && typeof raw.result === 'object'
+        ? (raw.result as ExamSubmissionResultResponse)
+        : (response.data as ExamSubmissionResultResponse)
+  return mapExamSubmissionResultDetail(payload)
 }

--- a/src/api/refresh.ts
+++ b/src/api/refresh.ts
@@ -3,10 +3,11 @@ import { apiClient } from '@/api/client'
 /** 401 응답 인터셉터에서 리프레시 재시도 무한 루프 방지용 플래그 */
 export const REFRESH_REQUEST_CONFIG = { __isRefreshRequest: true } as const
 
-export async function refreshToken(token: string): Promise<string> {
+/** 쿠키에 담긴 refresh 토큰으로 accessToken 재발급 (body 없이 withCredentials만 사용) */
+export async function refreshToken(): Promise<string> {
   const { data } = await apiClient.post<{ access_token?: string }>(
     '/api/v1/accounts/me/refresh/',
-    { refresh_token: token },
+    {},
     REFRESH_REQUEST_CONFIG as object
   )
   const accessToken = data?.access_token

--- a/src/api/refresh.ts
+++ b/src/api/refresh.ts
@@ -3,11 +3,16 @@ import { apiClient } from '@/api/client'
 /** 401 응답 인터셉터에서 리프레시 재시도 무한 루프 방지용 플래그 */
 export const REFRESH_REQUEST_CONFIG = { __isRefreshRequest: true } as const
 
-/** 쿠키에 담긴 refresh 토큰으로 accessToken 재발급 (body 없이 withCredentials만 사용) */
-export async function refreshToken(): Promise<string> {
+/**
+ * accessToken 재발급.
+ * - token 없음: 쿠키만 전송 (백엔드가 쿠키에서 읽는 경우).
+ * - token 있음: body에 refresh_token 전송 (쿠키 없을 때 fallback).
+ */
+export async function refreshToken(token?: string): Promise<string> {
+  const body = token != null ? { refresh_token: token } : {}
   const { data } = await apiClient.post<{ access_token?: string }>(
     '/api/v1/accounts/me/refresh/',
-    {},
+    body,
     REFRESH_REQUEST_CONFIG as object
   )
   const accessToken = data?.access_token

--- a/src/api/setupRefreshInterceptor.ts
+++ b/src/api/setupRefreshInterceptor.ts
@@ -5,6 +5,7 @@ import type { User } from '@/types/auth'
 const LOGIN_PATH = '/login'
 
 type AuthState = {
+  refreshToken: string | null
   user: User | null
   setAuth: (payload: Partial<{
     accessToken: string | null
@@ -52,7 +53,7 @@ export function setupRefreshInterceptor(
         return Promise.reject(error)
       }
 
-      const { user, setAuth } = state
+      const { refreshToken, user, setAuth } = state
       if (!user) {
         clearAuthAndRedirectToLogin(getAuthState)
         return Promise.reject(error)
@@ -60,7 +61,14 @@ export function setupRefreshInterceptor(
 
       try {
         if (!refreshPromise) {
-          refreshPromise = callRefreshToken()
+          refreshPromise = (async () => {
+            try {
+              return await callRefreshToken()
+            } catch {
+              if (refreshToken) return await callRefreshToken(refreshToken)
+              throw new Error('Refresh failed')
+            }
+          })()
             .then((newToken) => {
               setAuth({ accessToken: newToken, user })
               return newToken

--- a/src/api/setupRefreshInterceptor.ts
+++ b/src/api/setupRefreshInterceptor.ts
@@ -5,13 +5,12 @@ import type { User } from '@/types/auth'
 const LOGIN_PATH = '/login'
 
 type AuthState = {
-  refreshToken: string | null
   user: User | null
-  setAuth: (payload: {
+  setAuth: (payload: Partial<{
     accessToken: string | null
     refreshToken: string | null
-    user: User
-  }) => void
+    user: User | null
+  }>) => void
   clearAuth: () => void
 }
 
@@ -53,17 +52,17 @@ export function setupRefreshInterceptor(
         return Promise.reject(error)
       }
 
-      const { refreshToken, user, setAuth } = state
-      if (!refreshToken || !user) {
+      const { user, setAuth } = state
+      if (!user) {
         clearAuthAndRedirectToLogin(getAuthState)
         return Promise.reject(error)
       }
 
       try {
         if (!refreshPromise) {
-          refreshPromise = callRefreshToken(refreshToken)
+          refreshPromise = callRefreshToken()
             .then((newToken) => {
-              setAuth({ accessToken: newToken, refreshToken, user })
+              setAuth({ accessToken: newToken, user })
               return newToken
             })
             .finally(() => {

--- a/src/components/auth/RequireAuth.tsx
+++ b/src/components/auth/RequireAuth.tsx
@@ -19,15 +19,20 @@ export function RequireAuth() {
     if (accessToken) return
     let cancelled = false
     setRestoring(true)
-    restore()
-      .finally(() => {
-        if (!cancelled) {
-          setRestoring(false)
-          setRestoreAttempted(true)
-        }
-      })
+    // persist 복원이 끝날 시간을 주어, rehydration 전에 restore 실패 → clearAuth 되는 것 방지
+    const timer = window.setTimeout(() => {
+      if (cancelled) return
+      restore()
+        .finally(() => {
+          if (!cancelled) {
+            setRestoring(false)
+            setRestoreAttempted(true)
+          }
+        })
+    }, 50)
     return () => {
       cancelled = true
+      window.clearTimeout(timer)
     }
   }, [accessToken, restore])
 

--- a/src/components/auth/RequireAuth.tsx
+++ b/src/components/auth/RequireAuth.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useState } from 'react'
 import { Navigate, Outlet, useLocation } from 'react-router-dom'
+import { Loading } from '@/components/common'
 import { useAuthStore } from '@/store/authStore'
 
 // 로그인이 필요한 페이지에 사용되는 컴포넌트, 로그인이 되어있지 않으면 로그인 페이지로 이동
@@ -7,15 +9,40 @@ type LocationState = {
 }
 
 export function RequireAuth() {
-  const isAuthenticated = useAuthStore((s) => !!s.accessToken)
+  const accessToken = useAuthStore((s) => s.accessToken)
+  const restore = useAuthStore((s) => s.restore)
   const location = useLocation()
+  const [restoring, setRestoring] = useState(false)
+  const [restoreAttempted, setRestoreAttempted] = useState(false)
 
-  if (!isAuthenticated) {
-    const from = location.pathname + location.search
+  useEffect(() => {
+    if (accessToken) return
+    let cancelled = false
+    setRestoring(true)
+    restore()
+      .finally(() => {
+        if (!cancelled) {
+          setRestoring(false)
+          setRestoreAttempted(true)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [accessToken, restore])
+
+  if (accessToken) return <Outlet />
+
+  if (restoring || !restoreAttempted) {
     return (
-      <Navigate to="/login" replace state={{ from } satisfies LocationState} />
+      <div className="flex min-h-screen items-center justify-center">
+        <Loading />
+      </div>
     )
   }
 
-  return <Outlet />
+  const from = location.pathname + location.search
+  return (
+    <Navigate to="/login" replace state={{ from } satisfies LocationState} />
+  )
 }

--- a/src/components/quiz/ResultQuestionItem.tsx
+++ b/src/components/quiz/ResultQuestionItem.tsx
@@ -20,8 +20,28 @@ const RESULT_API_TYPE_TO_INTERNAL: Record<string, string> = {
   ORDERING: 'ordering',
 }
 
+/** API가 snake_case(single_choice) 또는 대문자(SINGLE_CHOICE)로 올 수 있음 → switch용 통일 타입 */
+const SNAKE_TO_SWITCH_TYPE: Record<string, string> = {
+  single_choice: 'SINGLE_CHOICE',
+  multiple_choice: 'MULTI_SELECT',
+  ox: 'OX',
+  short_answer: 'SHORT_ANSWER',
+  fill_blank: 'FILL_IN_BLANK',
+  ordering: 'ORDERING',
+  SINGLE_CHOICE: 'SINGLE_CHOICE',
+  MULTI_SELECT: 'MULTI_SELECT',
+  OX: 'OX',
+  SHORT_ANSWER: 'SHORT_ANSWER',
+  FILL_IN_BLANK: 'FILL_IN_BLANK',
+  ORDERING: 'ORDERING',
+}
+
 function toInternalType(apiType: string): QuizQuestion['type'] {
   return (RESULT_API_TYPE_TO_INTERNAL[apiType] ?? apiType) as QuizQuestion['type']
+}
+
+function normalizeResultType(type: string): string {
+  return SNAKE_TO_SWITCH_TYPE[type] ?? type
 }
 
 interface ResultQuestionItemProps {
@@ -53,8 +73,9 @@ export default function ResultQuestionItem({ question, index }: ResultQuestionIt
   const mapped = mapResultQuestionToQuizQuestion(question, index)
   const submitted = question.submittedAnswer
   const noop = () => {}
+  const normalizedType = normalizeResultType(question.type ?? '')
 
-  switch (question.type) {
+  switch (normalizedType) {
     case 'SINGLE_CHOICE':
       return (
         <SingleChoice

--- a/src/components/quiz/ShortAnswer.tsx
+++ b/src/components/quiz/ShortAnswer.tsx
@@ -1,6 +1,11 @@
+import { useEffect, useState } from 'react'
 import type { ExamDeploymentDetailResult } from '@/mappers/examDeploymentDetail'
+import { Modal } from '@/components/common'
 import QuizResultExplanation from './QuizResultExplanation'
 import QuestionHeader from './QuestionHeader'
+
+const SHORT_ANSWER_MAX_LENGTH = 20
+const OVERFLOW_MODAL_AUTO_CLOSE_MS = 3000
 
 interface ShortAnswerProps {
   question: ExamDeploymentDetailResult['questions'][0]
@@ -19,6 +24,27 @@ export default function ShortAnswer({
   isCorrect = false,
   explanation = null,
 }: ShortAnswerProps) {
+  const [showOverflowModal, setShowOverflowModal] = useState(false)
+
+  useEffect(() => {
+    if (!showOverflowModal) return
+    const timer = window.setTimeout(() => setShowOverflowModal(false), OVERFLOW_MODAL_AUTO_CLOSE_MS)
+    return () => window.clearTimeout(timer)
+  }, [showOverflowModal])
+
+  const handleChange = (value: string) => {
+    if (isResult) {
+      onAnswerChange(question.questionId, value)
+      return
+    }
+    if (value.length > SHORT_ANSWER_MAX_LENGTH) {
+      setShowOverflowModal(true)
+      onAnswerChange(question.questionId, value.slice(0, SHORT_ANSWER_MAX_LENGTH))
+    } else {
+      onAnswerChange(question.questionId, value)
+    }
+  }
+
   const containerClass = isResult ? 'mb-[100px]' : 'mb-20'
   const answerColorClass = isResult
     ? isCorrect
@@ -40,11 +66,21 @@ export default function ShortAnswer({
         <input
           type="text"
           value={answer ?? ''}
-          onChange={(e) => onAnswerChange(question.questionId, e.target.value)}
+          onChange={(e) => handleChange(e.target.value)}
           placeholder="20글자 이내로 입력해 주세요."
           className={`h-[48px] w-[648px] rounded-lg bg-surface px-4 py-[10px] text-[16px] font-normal ${answerColorClass} placeholder:text-mono-400`}
         />
       </div>
+
+      {!isResult && (
+        <Modal isOpen={showOverflowModal} onClose={() => setShowOverflowModal(false)}>
+          <Modal.Body>
+            <p className="py-4 text-center text-[16px] text-foreground-secondary">
+              단답형 문항은 20글자 미만으로 작성하세요
+            </p>
+          </Modal.Body>
+        </Modal>
+      )}
       {isResult && explanation && (
         <div className="mt-5 ml-8">
           <QuizResultExplanation explanation={explanation} isCorrect={isCorrect} />

--- a/src/hooks/quiz/useQuizSubmissionFlow.ts
+++ b/src/hooks/quiz/useQuizSubmissionFlow.ts
@@ -13,6 +13,8 @@ interface UseQuizSubmissionFlowParams {
   data: ExamDeploymentDetailResult | undefined
   answers: Record<number, string | string[] | null>
   cheatingCount: number
+  /** 응시 페이지 진입 후 타이머가 처음 시작된 시각 (ISO 문자열). 제출 시 started_at으로 전송 */
+  quizStartedAt: string
   setOpenModal: (modal: QuizOpenModal | null) => void
   setIsEnded: (ended: boolean) => void
   setEndReason: (reason: EndReason) => void
@@ -27,6 +29,7 @@ export function useQuizSubmissionFlow({
   data,
   answers,
   cheatingCount,
+  quizStartedAt,
   setOpenModal,
   setIsEnded,
   setEndReason,
@@ -88,7 +91,7 @@ export function useQuizSubmissionFlow({
     })
     return {
       deployment_id: deploymentIdNumber,
-      started_at: new Date().toISOString(),
+      started_at: quizStartedAt || new Date().toISOString(),
       cheating_count: cheatingCount,
       answers: answerList,
     }

--- a/src/hooks/quiz/useQuizTimer.ts
+++ b/src/hooks/quiz/useQuizTimer.ts
@@ -15,11 +15,13 @@ export function useQuizTimer(
   submitAndEndByTimeRef: React.MutableRefObject<() => void>
 ) {
   const [remainingSeconds, setRemainingSeconds] = useState(INITIAL_REMAINING_SECONDS)
+  const [startedAt, setStartedAt] = useState<string>('')
   const hasInitializedTimerFromApi = useRef(false)
 
   useEffect(() => {
     if (!data || hasInitializedTimerFromApi.current || isEnded) return
     hasInitializedTimerFromApi.current = true
+    setStartedAt(new Date().toISOString())
     const durationMinutes = data.durationTime
     const totalSeconds = durationMinutes * SECONDS_PER_MINUTE
     const elapsedSeconds = (data.elapsedTime ?? 0) * SECONDS_PER_MINUTE
@@ -45,5 +47,5 @@ export function useQuizTimer(
   const seconds = (remainingSeconds % 60).toString().padStart(2, '0')
   const formattedRemaining = `${minutes} : ${seconds}`
 
-  return { remainingSeconds, setRemainingSeconds, formattedRemaining }
+  return { remainingSeconds, setRemainingSeconds, formattedRemaining, startedAt }
 }

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -69,7 +69,7 @@ function QuizPage() {
   const { cheatingCount, handleCheatingClose } = useCheatingDetection(isEnded, setOpenModal)
 
   const submitAndEndByTimeRef = useRef<() => void>(() => {})
-  const { setRemainingSeconds, formattedRemaining } = useQuizTimer(
+  const { setRemainingSeconds, formattedRemaining, startedAt } = useQuizTimer(
     data,
     isEnded,
     submitAndEndByTimeRef
@@ -90,6 +90,7 @@ function QuizPage() {
     data,
     answers,
     cheatingCount,
+    quizStartedAt: startedAt,
     setOpenModal,
     setIsEnded,
     setEndReason,

--- a/src/pages/QuizResultPage.tsx
+++ b/src/pages/QuizResultPage.tsx
@@ -9,22 +9,19 @@ import { ResultQuestionItem } from '@/components/quiz'
 
 // 분당 밀리초 수
 const MS_PER_MINUTE = 60_000
-// 분당 초 수
-const SECONDS_PER_MINUTE = 60
 
 /**
  * 응시시간(분) 계산
- * - API의 elapsed_time(초)이 0 이상이면 우선 사용
- * - 없으면 started_at ~ submitted_at 차이로 계산 (1분 미만이면 0)
- * - fallback은 0 미만이면 0으로 처리
+ * - GET /api/v1/exams/submissions/:id 응답의 elapsed_time(분)을 그대로 사용
+ * - elapsed_time이 없거나 음수일 때만 started_at ~ submitted_at 차이로 계산
  */
 function getElapsedMinutes(
   startedAt: string | undefined,
   submittedAt: string | undefined,
-  elapsedTimeSeconds: number
+  elapsedTimeMinutes: number
 ): number {
-  if (elapsedTimeSeconds >= 0) {
-    return Math.max(0, Math.floor(elapsedTimeSeconds / SECONDS_PER_MINUTE))
+  if (elapsedTimeMinutes >= 0) {
+    return Math.max(0, Math.floor(elapsedTimeMinutes))
   }
   if (!startedAt || !submittedAt) return 0
   const started = new Date(startedAt).getTime()
@@ -75,6 +72,7 @@ function QuizResultPage() {
 
   const questionCount = data?.questions.length ?? 0
   const cheatingCount = data?.cheatingCount ?? 0
+  // 헤더 응시시간: GET /api/v1/exams/submissions/:id 응답의 elapsed_time(분) 그대로 사용
   const elapsedMinutes = getElapsedMinutes(
     data?.startedAt,
     data?.submittedAt,

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -84,7 +84,13 @@ export const useAuthStore = create<AuthState>()(
         }
 
         try {
-          const newAccessToken = await callRefreshToken()
+          let newAccessToken: string
+          try {
+            newAccessToken = await callRefreshToken()
+          } catch {
+            if (!refreshToken) throw new Error('Refresh failed')
+            newAccessToken = await callRefreshToken(refreshToken)
+          }
           const userData = user ?? (await authApi.me(newAccessToken))
           get().setAuth({
             accessToken: newAccessToken,

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -3,17 +3,19 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { LoginPayload, User } from '@/types/auth'
 import * as authApi from '@/api/auth'
+import { refreshToken as callRefreshToken } from '@/api/refresh'
 
 type AuthState = {
   accessToken: string | null
   refreshToken: string | null
   user: User | null
 
-  setAuth: (payload: {
+  /** 넘긴 필드만 반영 (생략한 필드는 기존 값 유지). 리프레시 후 accessToken·user만 갱신할 때 사용 */
+  setAuth: (payload: Partial<{
     accessToken: string | null
     refreshToken: string | null
-    user: User
-  }) => void
+    user: User | null
+  }>) => void
   clearAuth: () => void
 
   login: (payload: LoginPayload) => Promise<void>
@@ -28,12 +30,8 @@ export const useAuthStore = create<AuthState>()(
       refreshToken: null,
       user: null,
 
-      setAuth: ({ accessToken, refreshToken, user }) => {
-        set({
-          accessToken,
-          refreshToken,
-          user,
-        })
+      setAuth: (payload) => {
+        set((state) => ({ ...state, ...payload }))
       },
 
       clearAuth: () => {
@@ -73,11 +71,26 @@ export const useAuthStore = create<AuthState>()(
       restore: async () => {
         const accessToken = get().accessToken
         const refreshToken = get().refreshToken
-        if (!accessToken) return
+        const user = get().user
+
+        if (accessToken) {
+          try {
+            const userData = await authApi.me(accessToken)
+            get().setAuth({ accessToken, refreshToken, user: userData })
+            return
+          } catch {
+            // accessToken 만료 등: 쿠키로 refresh 시도 (로그인 유지)
+          }
+        }
 
         try {
-          const user = await authApi.me(accessToken)
-          get().setAuth({ accessToken, refreshToken, user })
+          const newAccessToken = await callRefreshToken()
+          const userData = user ?? (await authApi.me(newAccessToken))
+          get().setAuth({
+            accessToken: newAccessToken,
+            refreshToken,
+            user: userData,
+          })
         } catch {
           get().clearAuth()
         }


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #178 

## 📑 구현 사항

- **Refresh 토큰 / 로그인 유지**
  - Refresh API는 쿠키만 사용하도록 변경
  - 401 시 쿠키로 refresh 시도, 실패 시 스토어의 refreshToken을 body로 fallback
  - accessToken 없을 때 `restore()`로 로그인 복구 시도 후 로딩 표시
  - RequireAuth에서 accessToken 없으면 50ms 대기 후 `restore()` 호출해 persist 복원 후 인증 시도
 
- **쪽지시험 제출**
  - 제출 시 `started_at`에 "제출 시점"이 아니라 "타이머가 시작된 시점"을 넣어 전송
  - useQuizTimer에서 타이머 시작 시각을 저장해 제출 플로우에 전달

- **쪽지시험 결과 페이지**
  - 결과 API가 `{ data: { ... } }` / `{ result: { ... } }` 형태로 오면 그 안의 payload만 꺼내서 매핑
  - 문항 `type`이 snake_case(`single_choice`) / 대문자(`SINGLE_CHOICE`) 둘 다 와도 정규화해서 모든 문항 렌더링
  - 응시시간은 API의 `elapsed_time`(분 단위)을 그대로 사용 (초로 변환하지 않음)

- **기타**
  - 단답형 20글자 초과 시 에러 알림 표시

---

## 🌀 어려웠던 점 / 고민했던 부분

- **로그인 유지**: persist가 복원되기 전에 RequireAuth가 실행되면 refreshToken이 비어 있어 실패할 수 있어, 50ms 지연 후 `restore()` 호출로 해결
- **결과 페이지 문항 미표시**: 백엔드가 문항 타입을 snake_case / 대문자 둘 다 쓸 수 있어, 한쪽만 처리하면 일부 문항이 `default`로 빠져 안 보이는 문제가 있어, 타입 정규화 맵으로 둘 다 처리하도록 수정
- **결과 API 응답 구조**: 실제 API가 `{ data: { id, questions, ... } }`로 감싸서 오는 경우를 고려해, 배포 상세 API처럼 `data`/`result`를 풀어서 매퍼에 넘기도록 처리

---

## 📸 구현 이미지

-

## ❇️ 코드 설명


| 변경 위치 | 설명 |
|-----------|------|
| `api/refresh.ts`, `setupRefreshInterceptor.ts`, `authStore.ts` | Refresh는 쿠키 우선, 실패 시 body fallback. `restore()`에서 쿠키 → body 순으로 refresh 시도 |
| `RequireAuth.tsx` | accessToken 없을 때 50ms 후 `restore()` 호출해 persist 복원 후 인증 시도 |
| `useQuizTimer.ts` | 타이머가 처음 초기화될 때 `startedAt`(ISO 문자열) state에 저장 후 반환 |
| `useQuizSubmissionFlow.ts` | `quizStartedAt` 인자 추가, `buildSubmitPayload()`의 `started_at`에 사용 |
| `QuizPage.tsx` | useQuizTimer의 `startedAt`을 useQuizSubmissionFlow의 `quizStartedAt`으로 전달 |
| `api/quiz.ts` (fetchExamSubmissionResult) | 응답에 `data`/`result`가 있으면 그 안의 객체를 payload로 사용 후 매퍼에 전달 |
| `ResultQuestionItem.tsx` | 문항 `type`을 snake_case/대문자 모두 switch에 맞게 정규화하는 맵과 `normalizeResultType()` 추가 |
| `QuizResultPage.tsx` | `getElapsedMinutes`에서 API `elapsed_time`(분)을 60으로 나누지 않고 그대로 사용 |


## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.