### PR TITLE
fix: refreshToken을 Store에 제거하고 쿠키 refresh 사용 (#181)

### DIFF
--- a/src/api/refresh.ts
+++ b/src/api/refresh.ts
@@ -5,14 +5,12 @@ export const REFRESH_REQUEST_CONFIG = { __isRefreshRequest: true } as const
 
 /**
  * accessToken 재발급.
- * - token 없음: 쿠키만 전송 (백엔드가 쿠키에서 읽는 경우).
- * - token 있음: body에 refresh_token 전송 (쿠키 없을 때 fallback).
+ * - 쿠키 기반 refresh_token으로 재발급 요청.
  */
-export async function refreshToken(token?: string): Promise<string> {
-  const body = token != null ? { refresh_token: token } : {}
+export async function refreshToken(): Promise<string> {
   const { data } = await apiClient.post<{ access_token?: string }>(
     '/api/v1/accounts/me/refresh/',
-    body,
+    {},
     REFRESH_REQUEST_CONFIG as object
   )
   const accessToken = data?.access_token

--- a/src/api/setupInterceptors.ts
+++ b/src/api/setupInterceptors.ts
@@ -6,6 +6,16 @@ export function setupAuthInterceptor(
 ) {
   const id = client.interceptors.request.use(
     (config: InternalAxiosRequestConfig) => {
+      // refresh 요청은 쿠키 기반으로 처리하므로 Authorization 주입 스킵
+      const isRefreshRequest = Boolean(
+        (
+          config as InternalAxiosRequestConfig & {
+            __isRefreshRequest?: boolean
+          }
+        ).__isRefreshRequest
+      )
+      if (isRefreshRequest) return config
+
       const token = getAccessToken()
       if (token) {
         config.headers = config.headers ?? {}

--- a/src/api/setupRefreshInterceptor.ts
+++ b/src/api/setupRefreshInterceptor.ts
@@ -5,11 +5,10 @@ import type { User } from '@/types/auth'
 const LOGIN_PATH = '/login'
 
 type AuthState = {
-  refreshToken: string | null
+  accessToken: string | null
   user: User | null
   setAuth: (payload: Partial<{
     accessToken: string | null
-    refreshToken: string | null
     user: User | null
   }>) => void
   clearAuth: () => void
@@ -24,7 +23,7 @@ function clearAuthAndRedirectToLogin(getAuthState: () => AuthState) {
 /** 재시도 요청 플래그: 재시도된 요청이 또 401이면 refresh 재시도 무한 루프 방지 */
 const RETRY_REQUEST_FLAG = '__isRetryRequest' as const
 
-/** 401 시 리프레시 토큰으로 accessToken 갱신 후 실패한 요청 재시도 */
+/** 401 시 refresh로 accessToken 갱신 후 실패한 요청 재시도 */
 export function setupRefreshInterceptor(
   client: AxiosInstance,
   getAuthState: () => AuthState
@@ -53,24 +52,17 @@ export function setupRefreshInterceptor(
         return Promise.reject(error)
       }
 
-      const { refreshToken, user, setAuth } = state
-      if (!user) {
-        clearAuthAndRedirectToLogin(getAuthState)
+      // 인증 컨텍스트가 없으면(예: 로그인 실패 401) refresh 시도하지 않음
+      if (!state.accessToken) {
         return Promise.reject(error)
       }
+      const { setAuth } = state
 
       try {
         if (!refreshPromise) {
-          refreshPromise = (async () => {
-            try {
-              return await callRefreshToken()
-            } catch {
-              if (refreshToken) return await callRefreshToken(refreshToken)
-              throw new Error('Refresh failed')
-            }
-          })()
+          refreshPromise = callRefreshToken()
             .then((newToken) => {
-              setAuth({ accessToken: newToken, user })
+              setAuth({ accessToken: newToken })
               return newToken
             })
             .finally(() => {

--- a/src/components/MyInfo.tsx
+++ b/src/components/MyInfo.tsx
@@ -13,13 +13,13 @@ export default function MyInfo() {
   const [isEdit, setIsEdit] = useState(false)
   const [loading, setLoading] = useState(true)
   const [selectedImage, setSelectedImage] = useState<File | null>(null)
-  const { user, setAuth, accessToken, refreshToken } = useAuthStore()
+  const { user, setAuth, accessToken } = useAuthStore()
 
   useEffect(() => {
     const fetchData = async () => {
       try {
         const [userData] = await Promise.all([me(), getMyCourses()])
-        setAuth({ accessToken, refreshToken, user: userData })
+        setAuth({ accessToken, user: userData })
       } catch (e) {
         console.error('내 정보 조회 실패', e)
       } finally {
@@ -67,7 +67,6 @@ export default function MyInfo() {
       }
       setAuth({
         accessToken,
-        refreshToken,
         user: { ...updated, profile_img_url: newProfileImgUrl },
       })
       setIsEdit(false)

--- a/src/components/myinfo/ViewMyInfo.tsx
+++ b/src/components/myinfo/ViewMyInfo.tsx
@@ -10,7 +10,6 @@ import type { WithdrawalReasonFormData } from '@/schemas/modalSchemas'
 export function ViewMyInfo() {
   const {
     accessToken,
-    refreshToken,
     user: currentUser,
     setAuth,
   } = useAuthStore()
@@ -33,7 +32,7 @@ export function ViewMyInfo() {
         const res = await import('@/api/auth')
         if (!accessToken) throw new Error('토큰 없음')
         const info = await res.me(accessToken)
-        setAuth({ accessToken, refreshToken, user: info })
+        setAuth({ accessToken, user: info })
       } catch {
         setProfileError('내 정보 조회에 실패했습니다.')
       } finally {
@@ -43,7 +42,7 @@ export function ViewMyInfo() {
     if (!currentUser) {
       fetchAndUpdateUser()
     }
-  }, [accessToken, currentUser, refreshToken, setAuth])
+  }, [accessToken, currentUser, setAuth])
 
   // 수강 과정 별도 로딩/에러 관리 (zustand)
   useEffect(() => {

--- a/src/pages/SocialLoginCallbackPage.tsx
+++ b/src/pages/SocialLoginCallbackPage.tsx
@@ -61,7 +61,7 @@ export default function SocialLoginCallbackPage() {
     const restoreSession = async () => {
       try {
         const user = await authApi.me(token)
-        setAuth({ accessToken: token, refreshToken: null, user })
+        setAuth({ accessToken: token, user })
         navigate('/', { replace: true })
       } catch {
         setErrorMessage(

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -7,13 +7,11 @@ import { refreshToken as callRefreshToken } from '@/api/refresh'
 
 type AuthState = {
   accessToken: string | null
-  refreshToken: string | null
   user: User | null
 
   /** 넘긴 필드만 반영 (생략한 필드는 기존 값 유지). 리프레시 후 accessToken·user만 갱신할 때 사용 */
   setAuth: (payload: Partial<{
     accessToken: string | null
-    refreshToken: string | null
     user: User | null
   }>) => void
   clearAuth: () => void
@@ -27,7 +25,6 @@ export const useAuthStore = create<AuthState>()(
   persist(
     (set, get) => ({
       accessToken: null,
-      refreshToken: null,
       user: null,
 
       setAuth: (payload) => {
@@ -37,7 +34,6 @@ export const useAuthStore = create<AuthState>()(
       clearAuth: () => {
         set({
           accessToken: null,
-          refreshToken: null,
           user: null,
         })
       },
@@ -46,12 +42,11 @@ export const useAuthStore = create<AuthState>()(
         try {
           const response = await authApi.login(payload)
           const accessToken = response?.access_token
-          const refreshToken = response?.refresh_token ?? null
           if (!accessToken) {
             throw new Error('LOGIN_FAILED')
           }
           const user = await authApi.me(accessToken)
-          get().setAuth({ accessToken, refreshToken, user })
+          get().setAuth({ accessToken, user })
         } catch (error) {
           get().clearAuth()
           throw error
@@ -70,13 +65,12 @@ export const useAuthStore = create<AuthState>()(
 
       restore: async () => {
         const accessToken = get().accessToken
-        const refreshToken = get().refreshToken
         const user = get().user
 
         if (accessToken) {
           try {
             const userData = await authApi.me(accessToken)
-            get().setAuth({ accessToken, refreshToken, user: userData })
+            get().setAuth({ accessToken, user: userData })
             return
           } catch {
             // accessToken 만료 등: 쿠키로 refresh 시도 (로그인 유지)
@@ -84,17 +78,10 @@ export const useAuthStore = create<AuthState>()(
         }
 
         try {
-          let newAccessToken: string
-          try {
-            newAccessToken = await callRefreshToken()
-          } catch {
-            if (!refreshToken) throw new Error('Refresh failed')
-            newAccessToken = await callRefreshToken(refreshToken)
-          }
+          const newAccessToken = await callRefreshToken()
           const userData = user ?? (await authApi.me(newAccessToken))
           get().setAuth({
             accessToken: newAccessToken,
-            refreshToken,
             user: userData,
           })
         } catch {
@@ -106,7 +93,6 @@ export const useAuthStore = create<AuthState>()(
       name: 'auth-storage',
       partialize: (s) => ({
         accessToken: s.accessToken,
-        refreshToken: s.refreshToken,
         user: s.user,
       }),
     }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -6,7 +6,6 @@ export type LoginPayload = {
 
 export type LoginResult = {
   access_token: string
-  refresh_token: string
 }
 
 export type User = {


### PR DESCRIPTION
<!-- PR 제목 예시:
refactor(auth): migrate refresh flow to cookie-based handling (#이슈번호)
-->

## #️⃣ 연관된 이슈

- Resolves #181 

## 📑 구현 사항

- `authStore`에서 `refreshToken` 상태와 관련 타입/저장 로직 제거
- 로그인/복구 로직을 쿠키 기반 refresh 단일 경로로 정리
- `refreshToken()` API를 body 토큰 인자 없이 쿠키 기반 호출로 단순화
- request interceptor에서 refresh 요청(`__isRefreshRequest`)일 때 `Authorization` 헤더 주입 스킵
- response interceptor의 401 처리에서 `user` 의존 제거, 인증 컨텍스트(`accessToken`) 기준으로 refresh 시도
- `setAuth` 호출부(`MyInfo`, `ViewMyInfo`, `SocialLoginCallbackPage`) payload에서 `refreshToken` 제거
- `LoginResult` 타입에서 `refresh_token` 제거

## 🌀 어려웠던 점 / 고민했던 부분

- 로그인 실패로 발생한 401과 만료 토큰으로 발생한 401을 같은 인터셉터에서 구분해야 했다.
- refresh 요청에 기존 `Authorization` 헤더가 붙을 때 서버 정책에 따라 재발급이 실패할 수 있어, refresh 요청 헤더 주입 스킵 조건을 명시했다.

## 📸 구현 이미지

- UI 변경 없음

## ❇️ 코드 설명

- 핵심 변경 파일:
  - `src/store/authStore.ts`
  - `src/api/refresh.ts`
  - `src/api/setupInterceptors.ts`
  - `src/api/setupRefreshInterceptor.ts`
  - `src/components/MyInfo.tsx`
  - `src/components/myinfo/ViewMyInfo.tsx`
  - `src/pages/SocialLoginCallbackPage.tsx`
  - `src/types/auth.ts`
- 검증:
  - `npm run build` 통과

## 💬 리뷰 요청사항

