### PR TITLE
fix: refreshToken 있으면 자동으로 accessToken 재발급 후 로그인 상태 유지 (#183)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 
@@ -18,6 +18,7 @@ import SocialLoginCallbackPage from '@/pages/SocialLoginCallbackPage'
 import MyPage from '@/pages/MyPage'
 import MainLayout from '@/components/layout/MainLayout'
 import { RequireAuth } from '@/components/auth/RequireAuth'
+import { useAuthStore } from '@/store/authStore'
 import MyInfo from './components/MyInfo'
 import PasswordChange from './components/PasswordChange'
 
@@ -31,9 +32,34 @@ function ScrollToTop() {
   return null
 }
 
+function AuthBootstrap() {
+  const accessToken = useAuthStore((s) => s.accessToken)
+  const restore = useAuthStore((s) => s.restore)
+  const attemptedRef = useRef(false)
+
+  useEffect(() => {
+    if (attemptedRef.current) return
+    if (accessToken) {
+      attemptedRef.current = true
+      return
+    }
+
+    // persist rehydration 직후 값을 사용하도록 아주 짧게 지연
+    const timer = window.setTimeout(() => {
+      attemptedRef.current = true
+      void restore()
+    }, 50)
+
+    return () => window.clearTimeout(timer)
+  }, [accessToken, restore])
+
+  return null
+}
+
 function App() {
   return (
     <BrowserRouter>
+      <AuthBootstrap />
       <ScrollToTop />
       <Routes>
         {/* 헤더가 포함된 페이지 */}

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -23,72 +23,84 @@ type AuthState = {
 
 export const useAuthStore = create<AuthState>()(
   persist(
-    (set, get) => ({
-      accessToken: null,
-      user: null,
+    (set, get) => {
+      let restorePromise: Promise<void> | null = null
 
-      setAuth: (payload) => {
-        set((state) => ({ ...state, ...payload }))
-      },
+      return {
+        accessToken: null,
+        user: null,
 
-      clearAuth: () => {
-        set({
-          accessToken: null,
-          user: null,
-        })
-      },
+        setAuth: (payload) => {
+          set((state) => ({ ...state, ...payload }))
+        },
 
-      login: async (payload) => {
-        try {
-          const response = await authApi.login(payload)
-          const accessToken = response?.access_token
-          if (!accessToken) {
-            throw new Error('LOGIN_FAILED')
-          }
-          const user = await authApi.me(accessToken)
-          get().setAuth({ accessToken, user })
-        } catch (error) {
-          get().clearAuth()
-          throw error
-        }
-      },
-
-      logout: async () => {
-        try {
-          await authApi.logout()
-        } catch {
-          // 로그아웃 API 실패 시에도 클라이언트 인증은 초기화
-        } finally {
-          get().clearAuth()
-        }
-      },
-
-      restore: async () => {
-        const accessToken = get().accessToken
-        const user = get().user
-
-        if (accessToken) {
-          try {
-            const userData = await authApi.me(accessToken)
-            get().setAuth({ accessToken, user: userData })
-            return
-          } catch {
-            // accessToken 만료 등: 쿠키로 refresh 시도 (로그인 유지)
-          }
-        }
-
-        try {
-          const newAccessToken = await callRefreshToken()
-          const userData = user ?? (await authApi.me(newAccessToken))
-          get().setAuth({
-            accessToken: newAccessToken,
-            user: userData,
+        clearAuth: () => {
+          set({
+            accessToken: null,
+            user: null,
           })
-        } catch {
-          get().clearAuth()
-        }
-      },
-    }),
+        },
+
+        login: async (payload) => {
+          try {
+            const response = await authApi.login(payload)
+            const accessToken = response?.access_token
+            if (!accessToken) {
+              throw new Error('LOGIN_FAILED')
+            }
+            const user = await authApi.me(accessToken)
+            get().setAuth({ accessToken, user })
+          } catch (error) {
+            get().clearAuth()
+            throw error
+          }
+        },
+
+        logout: async () => {
+          try {
+            await authApi.logout()
+          } catch {
+            // 로그아웃 API 실패 시에도 클라이언트 인증은 초기화
+          } finally {
+            get().clearAuth()
+          }
+        },
+
+        restore: async () => {
+          if (restorePromise) return restorePromise
+
+          restorePromise = (async () => {
+            const accessToken = get().accessToken
+            const user = get().user
+
+            if (accessToken) {
+              try {
+                const userData = await authApi.me(accessToken)
+                get().setAuth({ accessToken, user: userData })
+                return
+              } catch {
+                // accessToken 만료 등: 쿠키로 refresh 시도 (로그인 유지)
+              }
+            }
+
+            try {
+              const newAccessToken = await callRefreshToken()
+              const userData = user ?? (await authApi.me(newAccessToken))
+              get().setAuth({
+                accessToken: newAccessToken,
+                user: userData,
+              })
+            } catch {
+              get().clearAuth()
+            }
+          })().finally(() => {
+            restorePromise = null
+          })
+
+          return restorePromise
+        },
+      }
+    },
     {
       name: 'auth-storage',
       partialize: (s) => ({


### PR DESCRIPTION
<!-- PR 제목 예시:
fix(auth): restore session on public routes after idle (#이슈번호)
-->

## #️⃣ 연관된 이슈

- Resolves #183 

## 📑 구현 사항

- 앱 루트에 전역 인증 복구 컴포넌트(`AuthBootstrap`)를 추가해 퍼블릭 페이지에서도 초기 복구를 수행하도록 변경
- `authStore.restore()`에 single-flight 로직을 적용해 동시 호출 시 중복 refresh/me 요청을 방지
- 기존 `RequireAuth` 복구 흐름은 유지하여 보호 페이지 접근 시 안전망 역할 지속

## 🌀 어려웠던 점 / 고민했던 부분

- 퍼블릭 라우트에서도 복구가 필요하지만, `RequireAuth`와 중복 호출 시 경쟁 상태가 발생하지 않도록 store 레벨에서 요청 병합이 필요했다.

## 📸 구현 이미지

- UI 변경 없음

## ❇️ 코드 설명

- 핵심 변경 파일:
  - `src/App.tsx`
  - `src/store/authStore.ts`
- 기대 동작:
  - 장시간 유휴 후 `/` 복귀 시에도 유효한 refresh 쿠키가 있으면 로그인 상태 자동 복구
  - refresh 쿠키 만료 시에는 정상적으로 비로그인 상태 유지
- 검증:
  - `npm run build` 통과

## 💬 리뷰 요청사항

1. 전역 복구를 앱 시작 1회로 제한한 방식이 팀의 인증 UX 정책과 맞는지 확인 부탁드립니다.
2. `restore()` 실패 시 현재처럼 무음 처리 후 비로그인 상태 유지하는 정책이 적절한지 확인 부탁드립니다.
