### PR TITLE
fix: 소셜 로그인 로그아웃 후 새로고침 시 재로그인되는 문제

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,11 @@ import MyPage from '@/pages/MyPage'
 import MainLayout from '@/components/layout/MainLayout'
 import { RequireAuth } from '@/components/auth/RequireAuth'
 import { useAuthStore } from '@/store/authStore'
+import {
+  clearClientAuthCookies,
+  clearPersistedAuthState,
+  isManualLogoutMarked,
+} from '@/utils/authSessionMarker'
 import MyInfo from './components/MyInfo'
 import PasswordChange from './components/PasswordChange'
 
@@ -35,10 +40,20 @@ function ScrollToTop() {
 function AuthBootstrap() {
   const accessToken = useAuthStore((s) => s.accessToken)
   const restore = useAuthStore((s) => s.restore)
+  const clearAuth = useAuthStore((s) => s.clearAuth)
   const attemptedRef = useRef(false)
 
   useEffect(() => {
     if (attemptedRef.current) return
+
+    if (isManualLogoutMarked()) {
+      attemptedRef.current = true
+      clearClientAuthCookies()
+      clearPersistedAuthState()
+      clearAuth()
+      return
+    }
+
     if (accessToken) {
       attemptedRef.current = true
       return
@@ -51,7 +66,7 @@ function AuthBootstrap() {
     }, 50)
 
     return () => window.clearTimeout(timer)
-  }, [accessToken, restore])
+  }, [accessToken, clearAuth, restore])
 
   return null
 }

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -54,8 +54,13 @@ export async function login(payload: LoginPayload): Promise<LoginResult> {
   return data
 }
 
-export async function logout(): Promise<void> {
-  await apiClient.post('/api/v1/accounts/logout/')
+export async function logout(accessToken: string | null = null): Promise<void> {
+  const config =
+    accessToken && accessToken !== ''
+      ? { headers: { Authorization: `Bearer ${accessToken}` } }
+      : undefined
+
+  await apiClient.post('/api/v1/accounts/logout/', {}, config)
 }
 
 export async function me(accessToken: string | null = null): Promise<User> {

--- a/src/api/setupInterceptors.ts
+++ b/src/api/setupInterceptors.ts
@@ -1,4 +1,5 @@
 import type { AxiosInstance, InternalAxiosRequestConfig } from 'axios'
+import { isManualLogoutMarked } from '@/utils/authSessionMarker'
 
 export function setupAuthInterceptor(
   client: AxiosInstance,
@@ -15,6 +16,8 @@ export function setupAuthInterceptor(
         ).__isRefreshRequest
       )
       if (isRefreshRequest) return config
+
+      if (isManualLogoutMarked()) return config
 
       const token = getAccessToken()
       if (token) {

--- a/src/api/setupRefreshInterceptor.ts
+++ b/src/api/setupRefreshInterceptor.ts
@@ -1,6 +1,7 @@
 import type { AxiosInstance, InternalAxiosRequestConfig } from 'axios'
 import { refreshToken as callRefreshToken } from '@/api/refresh'
 import type { User } from '@/types/auth'
+import { isManualLogoutMarked } from '@/utils/authSessionMarker'
 
 const LOGIN_PATH = '/login'
 
@@ -53,7 +54,7 @@ export function setupRefreshInterceptor(
       }
 
       // 인증 컨텍스트가 없으면(예: 로그인 실패 401) refresh 시도하지 않음
-      if (!state.accessToken) {
+      if (!state.accessToken || isManualLogoutMarked()) {
         return Promise.reject(error)
       }
       const { setAuth } = state

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -7,11 +7,7 @@ import { Button } from '@/components/common/Button'
 const TABS = [
   { id: 'exam', label: '쪽지시험', image: '/LandingPage_img/main_exam.png' },
   { id: 'qna', label: '질의응답', image: '/LandingPage_img/main_qna.png' },
-  {
-    id: 'community',
-    label: '커뮤니티',
-    image: '/LandingPage_img/main_community.png',
-  },
+  { id: 'community',label: '커뮤니티',image: '/LandingPage_img/main_community.png'},
 ] as const
 
 type TabType = (typeof TABS)[number]['id']
@@ -24,7 +20,7 @@ function LandingPage() {
 
   const timeoutRef = useRef<number | null>(null)
   const currentTab = useMemo(
-    () => TABS.find((t) => t.id === displayTab) ?? TABS[0],
+    () => TABS.find((tab) => tab.id === displayTab) ?? TABS[0],
     [displayTab]
   )
 

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -11,7 +11,6 @@ const TABS = [
 ] as const
 
 type TabType = (typeof TABS)[number]['id']
-const TAB_FADE_DELAY_MS = 180
 
 function LandingPage() {
   const [activeTab, setActiveTab] = useState<TabType>('exam')
@@ -30,13 +29,13 @@ function LandingPage() {
     setActiveTab(nextTab)
     setIsFadingOut(true)
 
-    // 새 탭을 또 눌렀을 때 이전에 걸어둔 타이머가 아직 살아있으면 바로 취소
+    // 180ms 내에 이미지 변경 연속 눌렀을 때 중복 타이머를 방지
     if (timeoutRef.current) window.clearTimeout(timeoutRef.current)
 
     timeoutRef.current = window.setTimeout(() => {
       setDisplayTab(nextTab)
       setIsFadingOut(false)
-    }, TAB_FADE_DELAY_MS)
+    }, 180)
   }
 
   useEffect(() => {

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -24,17 +24,17 @@ function LandingPage() {
     [displayTab]
   )
 
-  const handleTabClick = (next: TabType) => {
-    if (next === activeTab) return
+  const handleTabClick = (nextTab: TabType) => {
+    if (nextTab === activeTab) return
 
-    setActiveTab(next)
+    setActiveTab(nextTab)
     setIsFadingOut(true)
 
     // 새 탭을 또 눌렀을 때 이전에 걸어둔 타이머가 아직 살아있으면 바로 취소
     if (timeoutRef.current) window.clearTimeout(timeoutRef.current)
 
     timeoutRef.current = window.setTimeout(() => {
-      setDisplayTab(next)
+      setDisplayTab(nextTab)
       setIsFadingOut(false)
     }, TAB_FADE_DELAY_MS)
   }

--- a/src/pages/SocialLoginCallbackPage.tsx
+++ b/src/pages/SocialLoginCallbackPage.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/common/Button'
 import Loading from '@/components/common/Loading'
 import * as authApi from '@/api/auth'
 import { useAuthStore } from '@/store/authStore'
+import { clearManualLogoutMark } from '@/utils/authSessionMarker'
 
 // access_token 쿠키 조회
 const getCookie = (name: string): string | null => {
@@ -61,6 +62,7 @@ export default function SocialLoginCallbackPage() {
     const restoreSession = async () => {
       try {
         const user = await authApi.me(token)
+        clearManualLogoutMark()
         setAuth({ accessToken: token, user })
         navigate('/', { replace: true })
       } catch {

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -4,6 +4,13 @@ import { persist } from 'zustand/middleware'
 import type { LoginPayload, User } from '@/types/auth'
 import * as authApi from '@/api/auth'
 import { refreshToken as callRefreshToken } from '@/api/refresh'
+import {
+  clearClientAuthCookies,
+  clearPersistedAuthState,
+  clearManualLogoutMark,
+  isManualLogoutMarked,
+  markManualLogout,
+} from '@/utils/authSessionMarker'
 
 type AuthState = {
   accessToken: string | null
@@ -24,6 +31,10 @@ type AuthState = {
 export const useAuthStore = create<AuthState>()(
   persist(
     (set, get) => {
+      if (isManualLogoutMarked()) {
+        clearPersistedAuthState()
+      }
+
       let restorePromise: Promise<void> | null = null
 
       return {
@@ -31,6 +42,10 @@ export const useAuthStore = create<AuthState>()(
         user: null,
 
         setAuth: (payload) => {
+          // 명시적 로그아웃 이후에는 의도치 않은 비동기 setAuth(지연 응답)로 재로그인되는 것을 차단
+          if (payload.accessToken && isManualLogoutMarked()) {
+            return
+          }
           set((state) => ({ ...state, ...payload }))
         },
 
@@ -49,6 +64,7 @@ export const useAuthStore = create<AuthState>()(
               throw new Error('LOGIN_FAILED')
             }
             const user = await authApi.me(accessToken)
+            clearManualLogoutMark()
             get().setAuth({ accessToken, user })
           } catch (error) {
             get().clearAuth()
@@ -57,12 +73,17 @@ export const useAuthStore = create<AuthState>()(
         },
 
         logout: async () => {
+          const currentAccessToken = get().accessToken
+          markManualLogout()
+          get().clearAuth()
+
           try {
-            await authApi.logout()
+            await authApi.logout(currentAccessToken)
           } catch {
             // 로그아웃 API 실패 시에도 클라이언트 인증은 초기화
           } finally {
-            get().clearAuth()
+            clearClientAuthCookies()
+            clearPersistedAuthState()
           }
         },
 
@@ -70,6 +91,13 @@ export const useAuthStore = create<AuthState>()(
           if (restorePromise) return restorePromise
 
           restorePromise = (async () => {
+            if (isManualLogoutMarked()) {
+              clearClientAuthCookies()
+              clearPersistedAuthState()
+              get().clearAuth()
+              return
+            }
+
             const accessToken = get().accessToken
             const user = get().user
 

--- a/src/utils/authSessionMarker.ts
+++ b/src/utils/authSessionMarker.ts
@@ -1,0 +1,61 @@
+const MANUAL_LOGOUT_MARKER_KEY = 'auth-manual-logout'
+const AUTH_PERSIST_STORAGE_KEY = 'auth-storage'
+const AUTH_COOKIE_NAMES = ['access_token', 'refresh_token', 'sessionid'] as const
+
+function canUseStorage() {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+}
+
+function canUseDocument() {
+  return typeof document !== 'undefined'
+}
+
+export function markManualLogout() {
+  if (!canUseStorage()) return
+  window.localStorage.setItem(MANUAL_LOGOUT_MARKER_KEY, '1')
+}
+
+export function clearManualLogoutMark() {
+  if (!canUseStorage()) return
+  window.localStorage.removeItem(MANUAL_LOGOUT_MARKER_KEY)
+}
+
+export function isManualLogoutMarked() {
+  if (!canUseStorage()) return false
+  return window.localStorage.getItem(MANUAL_LOGOUT_MARKER_KEY) === '1'
+}
+
+export function clearClientAuthCookies() {
+  if (!canUseDocument()) return
+
+  const hostname =
+    typeof window !== 'undefined' && window.location?.hostname
+      ? window.location.hostname
+      : ''
+
+  const domainCandidates = new Set<string>([''])
+  if (hostname) {
+    domainCandidates.add(hostname)
+    domainCandidates.add(`.${hostname}`)
+
+    const parts = hostname.split('.').filter(Boolean)
+    if (parts.length >= 2) {
+      const parentDomain = parts.slice(-2).join('.')
+      domainCandidates.add(parentDomain)
+      domainCandidates.add(`.${parentDomain}`)
+    }
+  }
+
+  AUTH_COOKIE_NAMES.forEach((cookieName) => {
+    domainCandidates.forEach((domain) => {
+      const domainPart = domain ? `; Domain=${domain}` : ''
+      document.cookie = `${cookieName}=; Max-Age=0; Path=/${domainPart}`
+      document.cookie = `${cookieName}=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/${domainPart}`
+    })
+  })
+}
+
+export function clearPersistedAuthState() {
+  if (!canUseStorage()) return
+  window.localStorage.removeItem(AUTH_PERSIST_STORAGE_KEY)
+}


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #189

## 📑 구현 사항

- 수동 로그아웃 마커(`auth-manual-logout`)를 도입해 사용자 로그아웃 의도를 명시적으로 저장/조회하도록 구성했습니다.
  - 파일: `src/utils/authSessionMarker.ts`
  - 로그아웃 시 마커 저장, 로그인 성공 시 마커 제거
- 인증 상태 관리(store)에서 로그아웃 이후 되살림 경로를 차단했습니다.
  - 파일: `src/store/authStore.ts`
  - `logout`에서 현재 accessToken으로 서버 로그아웃 호출 후 클라이언트 상태 정리
  - 마커가 존재하면 `restore` 중단
  - 마커 상태에서 `setAuth`의 accessToken 주입 차단
- 앱 부트스트랩에서 로그아웃 마커를 최우선 처리하도록 보강했습니다.
  - 파일: `src/App.tsx`
  - 앱 초기화 시 마커가 있으면 persisted 상태/스토어 정리 후 복구 로직 중단
- 인터셉터 레이어에서 마커 기반 가드를 추가했습니다.
  - 파일: `src/api/setupInterceptors.ts`
  - 마커 존재 시 `Authorization` 헤더 주입 스킵
  - 파일: `src/api/setupRefreshInterceptor.ts`
  - 마커 존재 시 refresh 재발급 경로 진입 차단
- 로그아웃 API 호출 신뢰도를 높이기 위해 명시적으로 토큰을 전달하도록 변경했습니다.
  - 파일: `src/api/auth.ts`
  - `logout(accessToken)` 형태로 변경

## 🌀 어려웠던 점 / 고민했던 부분

- 이슈가 단일 버그가 아니라 `restore`/request interceptor/refresh interceptor가 동시에 개입하는 레이스 컨디션 형태라, 한 지점 수정만으로는 재발 가능성이 높았습니다.
- `AbortController` 기반 취소 방식도 검토했지만 레이어별 누락 위험이 있어, 전 경로에서 동일하게 적용 가능한 단일 가드(`manual logout marker`) 전략을 선택했습니다.
- 소셜 로그인 경로는 서버 세션(`sessionid`) 영향 가능성이 있어, 프론트 개선 범위와 백엔드 처리 범위를 분리해 정리했습니다.

## 📸 구현 이미지

![로그아웃 정상](https://github.com/user-attachments/assets/02222995-583f-4661-821c-3e82840fc81e)

## ❇️ 코드 설명

- 핵심 불변식: 수동 로그아웃 이후에는 어떤 지연 응답도 accessToken을 다시 store에 주입할 수 없어야 함
- 이를 위해 store(`setAuth`, `restore`), request interceptor, refresh interceptor, bootstrap에 동일 가드(`isManualLogoutMarked`)를 적용
- `logout` API 실패 여부와 무관하게 클라이언트 인증 초기화는 유지해 사용자 관점의 로그아웃 일관성 보장
- persisted 상태는 `clearPersistedAuthState()`로 명시 정리해 복구 경쟁 상태를 줄임

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

- `manual logout marker`를 localStorage 플래그로 둔 현재 설계가 레이스 차단 관점에서 적절한지 확인 부탁드립니다.
- refresh interceptor에서 마커/인증 컨텍스트 가드(`!state.accessToken || isManualLogoutMarked()`)의 순서와 처리 방식이 적합한지 검토 부탁드립니다.
- 소셜 로그인(sessionid) 관련해서 프론트에서 추가로 방어할 수 있는 지점이 있는지도 의견 부탁드립니다.
