### PR TITLE
refactor: 인증 로그아웃 안정화 및 랜딩 로딩 UX 개선 (#187)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,6 @@ import MainLayout from '@/components/layout/MainLayout'
 import { RequireAuth } from '@/components/auth/RequireAuth'
 import { useAuthStore } from '@/store/authStore'
 import {
-  clearClientAuthCookies,
   clearPersistedAuthState,
   isManualLogoutMarked,
 } from '@/utils/authSessionMarker'
@@ -53,7 +52,6 @@ function AuthBootstrap() {
 
     if (isManualLogoutMarked()) {
       attemptedRef.current = true
-      clearClientAuthCookies()
       clearPersistedAuthState()
       clearAuth()
       return

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,11 @@
-import { useEffect, useRef } from 'react'
-import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { useEffect, useLayoutEffect, useRef } from 'react'
+import {
+  BrowserRouter,
+  Routes,
+  Route,
+  useLocation,
+  useNavigationType,
+} from 'react-router-dom'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 
 import '@/App.css'
@@ -28,10 +34,21 @@ import PasswordChange from './components/PasswordChange'
 
 function ScrollToTop() {
   const { pathname } = useLocation()
+  const navigationType = useNavigationType()
+  const isFirstRenderRef = useRef(true)
 
-  useEffect(() => {
-    window.scrollTo(0, 0)
-  }, [pathname])
+  useLayoutEffect(() => {
+    // 초기 렌더(새로고침 포함)에서는 브라우저의 기존 스크롤 복원을 유지
+    if (isFirstRenderRef.current) {
+      isFirstRenderRef.current = false
+      return
+    }
+
+    // 뒤로가기/앞으로가기(POP)에서는 사용자의 스크롤 컨텍스트를 보존
+    if (navigationType === 'POP') return
+
+    window.scrollTo({ top: 0, left: 0, behavior: 'auto' })
+  }, [navigationType, pathname])
 
   return null
 }

--- a/src/components/common/Skeleton.tsx
+++ b/src/components/common/Skeleton.tsx
@@ -9,8 +9,6 @@ export default function Skeleton({ className }: SkeletonProps) {
     <div
       className={cn('animate-pulse rounded bg-[#E8E8E8]', className)}
       aria-hidden
-      // animate-pulse: 회색 블록이 살짝 깜빡이면서 “데이터 로딩 중”이라는 느낌의 애니메이션
-      //aria-hidden: 스켈레톤 요소는 시각적으로 숨겨져 있지만, 스크린 리더가 읽지 않도록 함
     />
   )
 }

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -3,11 +3,21 @@ import { Link } from 'react-router-dom'
 import clsx from 'clsx'
 
 import { Button } from '@/components/common/Button'
+import Skeleton from '@/components/common/Skeleton'
+
+const TAB_SWITCH_DELAY_MS = 180
+const PREVIEW_IMAGE_SIZE = { width: 1208, height: 603 } as const
+const BANNER_IMAGE_SIZE = { width: 1200, height: 277 } as const
+const SKELETON_TONE_CLASS = 'bg-[#EEF1F4]'
 
 const TABS = [
   { id: 'exam', label: '쪽지시험', image: '/LandingPage_img/main_exam.png' },
   { id: 'qna', label: '질의응답', image: '/LandingPage_img/main_qna.png' },
-  { id: 'community',label: '커뮤니티',image: '/LandingPage_img/main_community.png'},
+  {
+    id: 'community',
+    label: '커뮤니티',
+    image: '/LandingPage_img/main_community.png',
+  },
 ] as const
 
 type TabType = (typeof TABS)[number]['id']
@@ -16,6 +26,8 @@ function LandingPage() {
   const [activeTab, setActiveTab] = useState<TabType>('exam')
   const [displayTab, setDisplayTab] = useState<TabType>('exam')
   const [isFadingOut, setIsFadingOut] = useState(false)
+  const [isPreviewLoaded, setIsPreviewLoaded] = useState(false)
+  const [isBannerLoaded, setIsBannerLoaded] = useState(false)
 
   const timeoutRef = useRef<number | null>(null)
   const currentTab = useMemo(
@@ -23,19 +35,24 @@ function LandingPage() {
     [displayTab]
   )
 
+  const handlePreviewLoaded = () => {
+    setIsPreviewLoaded(true)
+  }
+
   const handleTabClick = (nextTab: TabType) => {
     if (nextTab === activeTab) return
 
     setActiveTab(nextTab)
     setIsFadingOut(true)
 
-    // 180ms 내에 이미지 변경 연속 눌렀을 때 중복 타이머를 방지
+    // 탭 전환 애니메이션 지연 동안 중복 타이머를 방지
     if (timeoutRef.current) window.clearTimeout(timeoutRef.current)
 
     timeoutRef.current = window.setTimeout(() => {
       setDisplayTab(nextTab)
+      setIsPreviewLoaded(false)
       setIsFadingOut(false)
-    }, 180)
+    }, TAB_SWITCH_DELAY_MS)
   }
 
   useEffect(() => {
@@ -92,20 +109,34 @@ function LandingPage() {
               </div>
             </div>
 
-            <div className="relative flex items-center justify-center">
+            <div className="relative flex w-full items-center justify-center">
               <div
                 className={clsx(
-                  'w-full transition-all duration-300 ease-out',
+                  'relative w-full overflow-hidden rounded-2xl transition-all duration-300 ease-out',
                   isFadingOut
                     ? 'translate-y-2 opacity-0'
                     : 'translate-y-0 opacity-100'
                 )}
               >
+                <Skeleton
+                  className={clsx(
+                    `${SKELETON_TONE_CLASS} pointer-events-none absolute inset-0 z-0 h-full w-full rounded-2xl transition-opacity duration-300`,
+                    isPreviewLoaded ? 'opacity-0' : 'opacity-100'
+                  )}
+                />
                 <img
                   src={currentTab.image}
                   alt={`${currentTab.label} 화면 미리보기`}
-                  className="h-auto max-h-[45dvh] w-full object-contain sm:max-h-[52dvh] lg:max-h-[58dvh]"
+                  width={PREVIEW_IMAGE_SIZE.width}
+                  height={PREVIEW_IMAGE_SIZE.height}
+                  className={clsx(
+                    'relative z-10 h-auto max-h-[45dvh] w-full object-contain sm:max-h-[52dvh] lg:max-h-[58dvh]',
+                    'transition-opacity duration-300',
+                    isPreviewLoaded ? 'opacity-100' : 'opacity-0'
+                  )}
                   draggable={false}
+                  onLoad={handlePreviewLoaded}
+                  onError={handlePreviewLoaded}
                 />
               </div>
             </div>
@@ -116,12 +147,25 @@ function LandingPage() {
           <div className="mx-auto w-full max-w-[1200px] px-5">
             <Link
               to="/qna"
-              className="block overflow-hidden rounded-2xl shadow-sm transition-shadow hover:shadow-md"
+              className="relative block overflow-hidden rounded-2xl shadow-sm transition-shadow hover:shadow-md"
             >
+              <Skeleton
+                className={clsx(
+                  `${SKELETON_TONE_CLASS} pointer-events-none absolute inset-0 z-0 h-full w-full rounded-2xl transition-opacity duration-300`,
+                  isBannerLoaded ? 'opacity-0' : 'opacity-100'
+                )}
+              />
               <img
                 src="/LandingPage_img/main_banner.png"
                 alt="Q&A 페이지 바로가기"
-                className="h-auto w-full"
+                width={BANNER_IMAGE_SIZE.width}
+                height={BANNER_IMAGE_SIZE.height}
+                className={clsx(
+                  'relative z-10 h-auto w-full transition-opacity duration-300',
+                  isBannerLoaded ? 'opacity-100' : 'opacity-0'
+                )}
+                onLoad={() => setIsBannerLoaded(true)}
+                onError={() => setIsBannerLoaded(true)}
               />
             </Link>
           </div>

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -8,7 +8,7 @@ import Skeleton from '@/components/common/Skeleton'
 const TAB_SWITCH_DELAY_MS = 180
 const PREVIEW_IMAGE_SIZE = { width: 1208, height: 603 } as const
 const BANNER_IMAGE_SIZE = { width: 1200, height: 277 } as const
-const SKELETON_TONE_CLASS = 'bg-[#EEF1F4]'
+const SKELETON_TONE_CLASS = 'bg-[#EEF1F4] animate-none'
 
 const TABS = [
   { id: 'exam', label: '쪽지시험', image: '/LandingPage_img/main_exam.png' },
@@ -26,6 +26,7 @@ function LandingPage() {
   const [activeTab, setActiveTab] = useState<TabType>('exam')
   const [displayTab, setDisplayTab] = useState<TabType>('exam')
   const [isFadingOut, setIsFadingOut] = useState(false)
+
   const [isPreviewLoaded, setIsPreviewLoaded] = useState(false)
   const [isBannerLoaded, setIsBannerLoaded] = useState(false)
 

--- a/src/pages/SocialLoginCallbackPage.tsx
+++ b/src/pages/SocialLoginCallbackPage.tsx
@@ -21,6 +21,11 @@ const getCookie = (name: string): string | null => {
   return decodeURIComponent(raw)
 }
 
+const clearCookie = (name: string) => {
+  document.cookie = `${name}=; Max-Age=0; Path=/`
+  document.cookie = `${name}=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/`
+}
+
 const SOCIAL_ERROR_MESSAGE: Record<string, string> = {
   KAKAO_ERROR_001: '토큰 또는 사용자 정보를 불러오지 못했습니다.',
   KAKAO_ERROR_002: '카카오 로그인 중 알 수 없는 오류가 발생했습니다.',
@@ -64,8 +69,10 @@ export default function SocialLoginCallbackPage() {
         const user = await authApi.me(token)
         clearManualLogoutMark()
         setAuth({ accessToken: token, user })
+        clearCookie('access_token')
         navigate('/', { replace: true })
       } catch {
+        clearCookie('access_token')
         setErrorMessage(
           '로그인 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.'
         )

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -6,7 +6,6 @@ import * as authApi from '@/api/auth'
 import { refreshToken as callRefreshToken } from '@/api/refresh'
 import { normalizeProfileImageUrl } from '@/utils/profileImageUrl'
 import {
-  clearClientAuthCookies,
   clearPersistedAuthState,
   clearManualLogoutMark,
   isManualLogoutMarked,
@@ -32,10 +31,6 @@ type AuthState = {
 export const useAuthStore = create<AuthState>()(
   persist(
     (set, get) => {
-      if (isManualLogoutMarked()) {
-        clearPersistedAuthState()
-      }
-
       let restorePromise: Promise<void> | null = null
 
       return {
@@ -97,7 +92,6 @@ export const useAuthStore = create<AuthState>()(
           } catch {
             // 로그아웃 API 실패 시에도 클라이언트 인증은 초기화
           } finally {
-            clearClientAuthCookies()
             clearPersistedAuthState()
           }
         },
@@ -107,7 +101,6 @@ export const useAuthStore = create<AuthState>()(
 
           restorePromise = (async () => {
             if (isManualLogoutMarked()) {
-              clearClientAuthCookies()
               clearPersistedAuthState()
               get().clearAuth()
               return

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -4,6 +4,7 @@ import { persist } from 'zustand/middleware'
 import type { LoginPayload, User } from '@/types/auth'
 import * as authApi from '@/api/auth'
 import { refreshToken as callRefreshToken } from '@/api/refresh'
+import { normalizeProfileImageUrl } from '@/utils/profileImageUrl'
 import {
   clearClientAuthCookies,
   clearPersistedAuthState,
@@ -46,7 +47,21 @@ export const useAuthStore = create<AuthState>()(
           if (payload.accessToken && isManualLogoutMarked()) {
             return
           }
-          set((state) => ({ ...state, ...payload }))
+          const normalizedPayload: Partial<{
+            accessToken: string | null
+            user: User | null
+          }> = { ...payload }
+
+          if ('user' in payload && payload.user) {
+            normalizedPayload.user = {
+              ...payload.user,
+              profile_img_url: normalizeProfileImageUrl(
+                payload.user.profile_img_url
+              ),
+            }
+          }
+
+          set((state) => ({ ...state, ...normalizedPayload }))
         },
 
         clearAuth: () => {

--- a/src/utils/authSessionMarker.ts
+++ b/src/utils/authSessionMarker.ts
@@ -1,13 +1,8 @@
 const MANUAL_LOGOUT_MARKER_KEY = 'auth-manual-logout'
 const AUTH_PERSIST_STORAGE_KEY = 'auth-storage'
-const AUTH_COOKIE_NAMES = ['access_token', 'refresh_token', 'sessionid'] as const
 
 function canUseStorage() {
   return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
-}
-
-function canUseDocument() {
-  return typeof document !== 'undefined'
 }
 
 export function markManualLogout() {
@@ -23,36 +18,6 @@ export function clearManualLogoutMark() {
 export function isManualLogoutMarked() {
   if (!canUseStorage()) return false
   return window.localStorage.getItem(MANUAL_LOGOUT_MARKER_KEY) === '1'
-}
-
-export function clearClientAuthCookies() {
-  if (!canUseDocument()) return
-
-  const hostname =
-    typeof window !== 'undefined' && window.location?.hostname
-      ? window.location.hostname
-      : ''
-
-  const domainCandidates = new Set<string>([''])
-  if (hostname) {
-    domainCandidates.add(hostname)
-    domainCandidates.add(`.${hostname}`)
-
-    const parts = hostname.split('.').filter(Boolean)
-    if (parts.length >= 2) {
-      const parentDomain = parts.slice(-2).join('.')
-      domainCandidates.add(parentDomain)
-      domainCandidates.add(`.${parentDomain}`)
-    }
-  }
-
-  AUTH_COOKIE_NAMES.forEach((cookieName) => {
-    domainCandidates.forEach((domain) => {
-      const domainPart = domain ? `; Domain=${domain}` : ''
-      document.cookie = `${cookieName}=; Max-Age=0; Path=/${domainPart}`
-      document.cookie = `${cookieName}=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/${domainPart}`
-    })
-  })
 }
 
 export function clearPersistedAuthState() {

--- a/src/utils/profileImageUrl.ts
+++ b/src/utils/profileImageUrl.ts
@@ -1,0 +1,34 @@
+function toHttps(url: string) {
+  if (url.startsWith('http://')) {
+    return `https://${url.slice('http://'.length)}`
+  }
+  if (url.startsWith('//')) {
+    return `https:${url}`
+  }
+  return url
+}
+
+/**
+ * 외부 프로필 이미지 URL을 https로 정규화해 Mixed Content 경고를 방지한다.
+ * - URL 자체가 http면 https로 변환
+ * - 쿼리 파라미터 값에 포함된 http URL도 https로 변환 (예: kakao CDN fname 파라미터)
+ */
+export function normalizeProfileImageUrl(
+  url: string | null | undefined
+): string | null | undefined {
+  if (!url) return url
+
+  const normalized = toHttps(url.trim())
+
+  try {
+    const parsed = new URL(normalized)
+    parsed.searchParams.forEach((value, key) => {
+      if (value.startsWith('http://')) {
+        parsed.searchParams.set(key, `https://${value.slice('http://'.length)}`)
+      }
+    })
+    return parsed.toString()
+  } catch {
+    return normalized
+  }
+}


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #187 

## 요약
- 로그아웃 이후 인증 재복구를 방지하도록 인증 흐름을 정리
- 소셜 콜백 처리 후 임시 토큰 쿠키 정리 추가
- 랜딩페이지 이미지 스켈레톤 적용 및 스크롤 점프 체감 개선

## 주요 변경 사항

### 1) 로그아웃/복구 흐름 안정화
- `authStore`에서 수동 로그아웃 마커 기반으로 복구 차단
- 로그아웃 시 클라이언트 인증 상태와 persisted auth 정리
- 불필요한 클라이언트 쿠키 강제 삭제 로직 제거(서버 책임 우선)

관련 파일:
- `src/store/authStore.ts`
- `src/utils/authSessionMarker.ts`

### 2) 소셜 로그인 콜백 정리
- 콜백에서 `access_token` 쿠키를 읽어 세션 복구 후 즉시 쿠키 정리
- 실패 케이스에서도 임시 쿠키 정리

관련 파일:
- `src/pages/SocialLoginCallbackPage.tsx`

### 3) 스크롤 처리 실무형 개선
- 초기 렌더(새로고침)에서는 브라우저 스크롤 복원 유지
- POP(뒤로/앞으로)에서는 스크롤 컨텍스트 유지
- PUSH/REPLACE 라우팅 시에만 상단 이동

관련 파일:
- `src/App.tsx`

### 4) 랜딩페이지 로딩 UX 개선
- 메인 프리뷰/배너 이미지에 스켈레톤 적용
- 이미지 영역 크기 상수화로 레이아웃 시프트 최소화
- 스켈레톤 톤 조정 및 불필요한 배너 프리로드 제거

관련 파일:
- `src/pages/LandingPage.tsx`

## 룰/리뷰 포인트 반영
- 매직 넘버 상수화(R4/C2)
- 불필요 방어 코드 제거(결합도/복잡도 감소)
- 핵심 플로우 가독성 유지(로그아웃/복구/콜백)

## 검증
- `npm run build` 통과
- `npm run lint` 에러 없음(기존 warning만 존재)

## 확인 요청
1. 일반 로그인/소셜 로그인 로그아웃 후 새로고침 유지 여부
2. 랜딩페이지 새로고침 시 이미지 로딩 체감 개선 여부
3. 스크롤 하단 상태에서 새로고침/뒤로가기 시 점프 감소 여부
