### PR TITLE
fix: 소셜로그인 accessToken 삭제하기

### DIFF
--- a/src/pages/SocialLoginCallbackPage.tsx
+++ b/src/pages/SocialLoginCallbackPage.tsx
@@ -22,8 +22,9 @@ const getCookie = (name: string): string | null => {
 }
 
 const clearCookie = (name: string) => {
-  document.cookie = `${name}=; Max-Age=0; Path=/`
-  document.cookie = `${name}=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/`
+  const expires = 'Expires=Thu, 01 Jan 1970 00:00:00 GMT'
+  document.cookie = `${name}=; ${expires}; Max-Age=0; Path=/; Domain=.ozcodingschool.site; SameSite=None; Secure`
+  document.cookie = `${name}=; ${expires}; Max-Age=0; Path=/; SameSite=None; Secure`
 }
 
 const SOCIAL_ERROR_MESSAGE: Record<string, string> = {


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #198

## 📑 구현 사항

- 소셜 로그인 콜백에서 `accessToken` 쿠키 삭제 시 `Domain=.ozcodingschool.site` 옵션을 명시해 상위 도메인 스코프 쿠키도 제거되도록 수정했습니다.
- 도메인 미지정 쿠키도 함께 삭제하도록 추가해 저장 위치가 다른 동일 이름 쿠키를 모두 정리하도록 했습니다.
- 쿠키 삭제 시 `Expires`와 `Max-Age=0`를 함께 적용해 브라우저 호환성을 높였습니다.

## 🌀 어려웠던 점 / 고민했던 부분

- 동일한 `accessToken` 쿠키라도 생성 시점의 속성(`Domain`, `SameSite`, `Secure`, `Path`)이 다르면 삭제 시 같은 속성으로 지정하지 않으면 제거되지 않았습니다.
- 소셜 로그인 환경(크로스 사이트 리다이렉트)에서는 `SameSite=None; Secure` 조합을 유지해야 해서, 삭제 로직에서도 동일 조건을 반영했습니다.

## 📸 구현 이미지

![소셜로그인 엑세스토큰 없음](https://github.com/user-attachments/assets/9c8c1ddc-80e0-4cea-8707-713fcabf74b4)

## ❇️ 코드 설명

- `src/pages/SocialLoginCallbackPage.tsx`의 `clearCookie` 함수에서 공통 만료 문자열(`Expires=Thu, 01 Jan 1970 00:00:00 GMT`)을 만들고,
- `Domain=.ozcodingschool.site`를 포함한 삭제 1회와 도메인 미지정 삭제 1회를 순차 실행해 `accessToken` 쿠키 제거 범위를 확장했습니다.

## 💬 리뷰 요청사항

> 소셜 로그인 후 콜백 진입 시 `accessToken`이 브라우저에 남지 않는지(특히 서브도메인/브라우저별) 확인 부탁드립니다.
