### PR TITLE
refactor: 쪽지시험·수강생 등록 리팩터링 및 에러 처리 보강 (#197)

### DIFF
--- a/src/components/common/Modal/variants/RegisterStudentModal.tsx
+++ b/src/components/common/Modal/variants/RegisterStudentModal.tsx
@@ -151,9 +151,12 @@ export function RegisterStudentModal({
 
             {enrollMutation.isError && (
               <p className="text-sm text-red-500">
-                {axios.isAxiosError(enrollMutation.error) &&
-                enrollMutation.error.response?.status === 403
-                  ? '*등록 신청에 실패했습니다. 이미 해당 기수에 등록 신청하였습니다.'
+                {axios.isAxiosError(enrollMutation.error)
+                  ? enrollMutation.error.response?.status === 409
+                    ? '* 이미 해당 기수에 등록 신청하였습니다.'
+                    : enrollMutation.error.response?.status === 403
+                      ? '* 등록 신청에 실패했습니다. 이미 수강생 등록 완료된 회원입니다.'
+                      : '등록 신청에 실패했습니다. 다시 시도해 주세요.'
                   : '등록 신청에 실패했습니다. 다시 시도해 주세요.'}
               </p>
             )}

--- a/src/mocks/handlers/info/enrollStudent.ts
+++ b/src/mocks/handlers/info/enrollStudent.ts
@@ -3,6 +3,10 @@ import { unauthorizedResponse } from './constants'
 
 const COHORT_ID_REQUIRED = { error_detail: { cohort_id: ['이 필드는 필수 항목입니다.'] } }
 
+/** 웹 개발 초격차 프론트엔드 부트캠프 10기 → 409, 11기 → 403 (MSW 개발용) */
+const COHORT_10TH_ID = 101 // course_id 1, number 10
+const COHORT_11TH_ID = 102 // course_id 1, number 11
+
 export const enrollStudentHandler = http.post(
   '/api/v1/accounts/enroll-student/',
   async ({ request }) => {
@@ -12,6 +16,18 @@ export const enrollStudentHandler = http.post(
     const body = (await request.json()) as { cohort_id?: number }
     if (body.cohort_id == null || typeof body.cohort_id !== 'number') {
       return HttpResponse.json(COHORT_ID_REQUIRED, { status: 400 })
+    }
+    if (body.cohort_id === COHORT_10TH_ID) {
+      return HttpResponse.json(
+        { error_detail: '이미 해당 기수에 등록 신청하였습니다.' },
+        { status: 409 }
+      )
+    }
+    if (body.cohort_id === COHORT_11TH_ID) {
+      return HttpResponse.json(
+        { error_detail: '이미 수강생 등록 완료된 회원입니다.' },
+        { status: 403 }
+      )
     }
     return HttpResponse.json({ detail: '수강 신청이 완료되었습니다.' })
   }

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -195,10 +195,11 @@ function QuizPage() {
     handleCheatingClose()
   }
 
-  const handleStatusEndTest = () => {
-    setIsEnded(true)
-    setEndReason('status')
-  }
+  // 개발용: 상태 종료 테스트 버튼과 함께 주석 해제
+  // const handleStatusEndTest = () => {
+  //   setIsEnded(true)
+  //   setEndReason('status')
+  // }
 
   if (showInvalidAccessModal) {
     return (

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -225,7 +225,7 @@ function QuizPage() {
 
       <main className="flex flex-col items-center px-10 py-6">
         <QuizWarningBox />
-        <div className="mb-6 flex items-center gap-3">
+        {/* <div className="mb-6 flex items-center gap-3">
           <Button
             variant="secondary"
             size="sm"
@@ -243,7 +243,7 @@ function QuizPage() {
           >
             상태 종료 테스트
           </Button>
-        </div>
+        </div> */}
 
         <div className="min-h-[500px] min-w-[1200px]">
           {data?.questions && data.questions.length > 0 ? (

--- a/src/pages/QuizResultPage.tsx
+++ b/src/pages/QuizResultPage.tsx
@@ -12,16 +12,16 @@ const MS_PER_MINUTE = 60_000
 
 /**
  * 응시시간(분) 계산
- * - GET /api/v1/exams/submissions/:id 응답의 elapsed_time(분)을 그대로 사용
+ * - GET /api/v1/exams/submissions/:id 응답의 elapsed_time(초)을 60으로 나눠 분으로 표시
  * - elapsed_time이 없거나 음수일 때만 started_at ~ submitted_at 차이로 계산
  */
 function getElapsedMinutes(
   startedAt: string | undefined,
   submittedAt: string | undefined,
-  elapsedTimeMinutes: number
+  elapsedTimeSeconds: number
 ): number {
-  if (elapsedTimeMinutes >= 0) {
-    return Math.max(0, Math.floor(elapsedTimeMinutes))
+  if (elapsedTimeSeconds >= 0) {
+    return Math.max(0, Math.floor(elapsedTimeSeconds / 60))
   }
   if (!startedAt || !submittedAt) return 0
   const started = new Date(startedAt).getTime()
@@ -72,7 +72,7 @@ function QuizResultPage() {
 
   const questionCount = data?.questions.length ?? 0
   const cheatingCount = data?.cheatingCount ?? 0
-  // 헤더 응시시간: GET /api/v1/exams/submissions/:id 응답의 elapsed_time(분) 그대로 사용
+  // 헤더 응시시간: API elapsed_time(초) → 60으로 나눠 분으로 표시
   const elapsedMinutes = getElapsedMinutes(
     data?.startedAt,
     data?.submittedAt,


### PR DESCRIPTION
<!-- PR 제목 규칙:
[type]: 작업 요약 (#이슈번호)
예시: feat: 로그인 페이지 UI 구현 (#12)
-->

## #️⃣ 연관된 이슈

- Resolves #197 

## 📑 구현 사항

- **응시 페이지**: 타이머 종료 테스트 등 개발용 버튼을 주석 처리해 화면에서 숨김
- **쪽지시험 결과 페이지**: 백엔드가 `elapsed_time`을 초 단위로 변경함에 따라, 60으로 나눠 **분 단위**로 표시하도록 수정
- **수강생 등록 (MSW)**: 웹 개발 초격차 프론트엔드 부트캠프 10기 등록 시 **409**, 11기 등록 시 **403** 응답 목업 추가 (개발 환경에서 에러 플로우 확인용)
- **수강생 등록 모달**: 409·403 응답 시 각각 다른 안내 문구 표시 (이미 해당 기수 등록 신청 / 이미 수강생 등록 완료된 회원)

## 🌀 어려웠던 점 / 고민했던 부분

-

## 📸 구현 이미지

-

## ❇️ 코드 설명

-

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1.