### PR TITLE
build: Vercel mock 배포 환경 구성

### DIFF
--- a/src/components/auth/SocialLoginSection.tsx
+++ b/src/components/auth/SocialLoginSection.tsx
@@ -40,15 +40,18 @@ type Props = {
 }
 
 export default function SocialLoginSection({ onLogin, mode = 'login' }: Props) {
+  const isMockMode = import.meta.env.VITE_USE_MSW === 'true'
   const providers =
     mode === 'signup' ? SOCIAL_PROVIDERS_SIGNUP : SOCIAL_PROVIDERS_LOGIN
+
   return (
     <div className="flex w-full flex-col items-start gap-3">
       {providers.map((provider) => (
         <Button
           key={provider.id}
           type="button"
-          variant={provider.variant}
+          variant={isMockMode ? 'disabled' : provider.variant}
+          disabled={isMockMode}
           onClick={() => onLogin(provider.id)}
           className="h-[52px] w-full gap-2.5 rounded px-2 py-2"
         >
@@ -68,6 +71,11 @@ export default function SocialLoginSection({ onLogin, mode = 'login' }: Props) {
           </div>
         </Button>
       ))}
+      {isMockMode ? (
+        <p className="text-mono-600 text-sm">
+          Mock 배포에서는 소셜 로그인 대신 일반 로그인을 사용하세요.
+        </p>
+      ) : null}
     </div>
   )
 }

--- a/src/constants/mockAuth.ts
+++ b/src/constants/mockAuth.ts
@@ -1,0 +1,17 @@
+import type { LoginPayload, User } from '@/types/auth'
+
+export const MOCK_LOGIN_CREDENTIALS: LoginPayload = {
+  email: 'test@example.com',
+  password: 'Test123!',
+}
+
+export const MOCK_LOGIN_USER: User = {
+  id: 1,
+  email: MOCK_LOGIN_CREDENTIALS.email,
+  nickname: '테스트유저',
+  name: '테스트 유저',
+  phone_number: '01012345678',
+  birthday: '2000-01-01',
+  gender: 'M',
+  profile_img_url: null,
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,7 +14,8 @@ const queryClient = new QueryClient()
 
 async function enableMocking() {
   // VITE_USE_MSW=true → 목 데이터(MSW), false → 실백엔드
-  if (!import.meta.env.DEV || import.meta.env.VITE_USE_MSW !== 'true') return
+  // 프로덕션 배포(Vercel)에서도 mock 배포가 가능하도록 DEV 여부와 분리한다.
+  if (import.meta.env.VITE_USE_MSW !== 'true') return
 
   const { worker } = await import('./mocks/browser')
   await worker.start({

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Resolves #205 

## 📑 구현 사항

- `VITE_USE_MSW`만으로 mock 활성화를 제어하도록 수정해 Vercel 프로덕션 배포에서도 MSW가 동작하도록 변경
- `vercel.json`을 추가해 SPA 라우트 새로고침 시 `index.html`로 rewrite 되도록 설정
- mock 모드에서는 소셜 로그인 버튼을 비활성화하고 일반 로그인을 사용하도록 안내 문구 추가
- `npm run build`로 프로덕션 빌드 통과 확인

## 🌀 어려웠던 점 / 고민했던 부분

- 기존 로직은 `DEV` 환경에서만 mock을 켜도록 되어 있어 로컬 개발과 배포 환경의 동작이 달랐다
- mock 배포에서는 소셜 로그인이 실제 백엔드 리다이렉트로 이어지기 때문에, UX상 아예 막는 편이 더 안전하다고 판단했다

## 📸 구현 이미지

- 배포 설정 및 런타임 분기 수정 작업이라 별도 이미지 없음

## ❇️ 코드 설명

- `src/main.tsx`
  - `import.meta.env.DEV` 조건을 제거하고 `VITE_USE_MSW` 값만으로 mock 활성화 여부를 판단하도록 변경
- `vercel.json`
  - 모든 경로를 `index.html`로 rewrite 하도록 설정해 `BrowserRouter` 새로고침 404를 방지
- `src/components/auth/SocialLoginSection.tsx`
  - mock 모드일 때 소셜 로그인 버튼을 비활성화하고 안내 문구를 노출하도록 수정

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1. mock 배포 환경에서 소셜 로그인 비활성화 방향이 적절한지 확인 부탁드립니다.
2. `VITE_USE_MSW=true`를 preview/prod 모두 사용할지, preview 전용으로 제한할지 의견 부탁드립니다.
