### PR TITLE
feat: Mock 배포용 인증 안내 UX 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,10 @@ import {
   useNavigationType,
 } from 'react-router-dom'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { Toaster } from 'react-hot-toast'
 
 import '@/App.css'
+import MockAuthHelpPanel from '@/components/auth/MockAuthHelpPanel'
 import LandingPage from '@/pages/LandingPage'
 import TestPage from '@/pages/TestPage'
 import {
@@ -96,6 +98,7 @@ function App() {
     <BrowserRouter>
       <AuthBootstrap />
       <ScrollToTop />
+      <MockAuthHelpPanel />
       <Routes>
         {/* 헤더가 포함된 페이지 */}
         <Route element={<MainLayout />}>
@@ -132,6 +135,17 @@ function App() {
           />
         </Route>
       </Routes>
+      <Toaster
+        position="top-center"
+        toastOptions={{
+          duration: 3000,
+          style: {
+            border: '1px solid #e5e7eb',
+            padding: '12px 16px',
+            color: '#111827',
+          },
+        }}
+      />
       <ReactQueryDevtools initialIsOpen={false} />
     </BrowserRouter>
   )

--- a/src/components/auth/SocialLoginSection.tsx
+++ b/src/components/auth/SocialLoginSection.tsx
@@ -1,6 +1,10 @@
 // 소셜 로그인 버튼 (카카오, 네이버) - createSocialRedirect 호출
 import { Button } from '@/components/common/Button'
+import {
+  MOCK_SOCIAL_LOGIN_TOAST_MESSAGE,
+} from '@/constants/mockAuth'
 import type { SocialProviderId } from '@/types/social'
+import { toast } from 'react-hot-toast'
 
 const SOCIAL_PROVIDERS_LOGIN = [
   {
@@ -40,9 +44,18 @@ type Props = {
 }
 
 export default function SocialLoginSection({ onLogin, mode = 'login' }: Props) {
-  const isMockMode = import.meta.env.VITE_USE_MSW === 'true'
   const providers =
     mode === 'signup' ? SOCIAL_PROVIDERS_SIGNUP : SOCIAL_PROVIDERS_LOGIN
+  const isMockMode = import.meta.env.VITE_USE_MSW === 'true'
+
+  const handleProviderClick = (provider: SocialProviderId) => {
+    if (isMockMode) {
+      toast.error(MOCK_SOCIAL_LOGIN_TOAST_MESSAGE)
+      return
+    }
+
+    onLogin(provider)
+  }
 
   return (
     <div className="flex w-full flex-col items-start gap-3">
@@ -50,9 +63,8 @@ export default function SocialLoginSection({ onLogin, mode = 'login' }: Props) {
         <Button
           key={provider.id}
           type="button"
-          variant={isMockMode ? 'disabled' : provider.variant}
-          disabled={isMockMode}
-          onClick={() => onLogin(provider.id)}
+          variant={provider.variant}
+          onClick={() => handleProviderClick(provider.id)}
           className="h-[52px] w-full gap-2.5 rounded px-2 py-2"
         >
           <div className="inline-flex items-center gap-1">
@@ -71,11 +83,6 @@ export default function SocialLoginSection({ onLogin, mode = 'login' }: Props) {
           </div>
         </Button>
       ))}
-      {isMockMode ? (
-        <p className="text-mono-600 text-sm">
-          Mock 배포에서는 소셜 로그인 대신 일반 로그인을 사용하세요.
-        </p>
-      ) : null}
     </div>
   )
 }

--- a/src/constants/mockAuth.ts
+++ b/src/constants/mockAuth.ts
@@ -15,3 +15,17 @@ export const MOCK_LOGIN_USER: User = {
   gender: 'M',
   profile_img_url: null,
 }
+
+export const MOCK_EMAIL_VERIFICATION_CODE = 'ABCDE12345'
+export const MOCK_SMS_VERIFICATION_CODE = '123456'
+
+export const MOCK_SIGNUP_EXAMPLE = {
+  name: '홍길동',
+  birthdate: '20000101',
+  nickname: '체험유저01',
+  email: 'demo01@example.com',
+  phoneNumber: '010-9876-5432',
+}
+
+export const MOCK_SOCIAL_LOGIN_TOAST_MESSAGE =
+  '목 모드에서는 소셜 로그인을 지원하지 않습니다. 일반 로그인을 사용해주세요.'

--- a/src/mocks/handlers/auth.mock.ts
+++ b/src/mocks/handlers/auth.mock.ts
@@ -1,14 +1,20 @@
 import { http, HttpResponse, delay } from 'msw'
+import {
+  MOCK_EMAIL_VERIFICATION_CODE,
+  MOCK_LOGIN_CREDENTIALS,
+  MOCK_LOGIN_USER,
+  MOCK_SMS_VERIFICATION_CODE,
+} from '@/constants/mockAuth'
 
 const CODE_TTL_MS = 5 * 60 * 1000
 
 // 테스트용 인증코드
-const FIXED_EMAIL_CODE = 'ABCDE12345' // 이메일 코드: ABCDE12345
-const FIXED_SMS_CODE = '123456' // SMS 코드: 123456
+const FIXED_EMAIL_CODE = MOCK_EMAIL_VERIFICATION_CODE // 이메일 코드: ABCDE12345
+const FIXED_SMS_CODE = MOCK_SMS_VERIFICATION_CODE // SMS 코드: 123456
 
 // 테스트용 아이디/비밀번호
-const SEED_EMAIL = 'test@example.com' // 아이디: test@example.com
-const SEED_PASSWORD = 'Test123!' // 비밀번호: Test123!
+const SEED_EMAIL = MOCK_LOGIN_CREDENTIALS.email // 아이디: test@example.com
+const SEED_PASSWORD = MOCK_LOGIN_CREDENTIALS.password // 비밀번호: Test123!
 
 const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 const api = (path: string) => new RegExp(`(${escapeRegExp(path)})(\\?.*)?$`)
@@ -71,14 +77,14 @@ const error = (status: number, payload: JsonValue) =>
 // 시드 유저 추가
 if (!usersByEmail.has(SEED_EMAIL)) {
   const user: UserDto = {
-    id: seq++,
-    email: SEED_EMAIL,
-    nickname: '테스트유저',
-    name: '테스트 유저',
-    phone_number: '01012345678',
-    birthday: '2000-01-01',
-    gender: 'M',
-    profile_img_url: null,
+    id: MOCK_LOGIN_USER.id ?? seq++,
+    email: MOCK_LOGIN_USER.email,
+    nickname: MOCK_LOGIN_USER.nickname,
+    name: MOCK_LOGIN_USER.name,
+    phone_number: MOCK_LOGIN_USER.phone_number,
+    birthday: MOCK_LOGIN_USER.birthday,
+    gender: MOCK_LOGIN_USER.gender,
+    profile_img_url: MOCK_LOGIN_USER.profile_img_url,
     created_at: new Date().toISOString(),
   }
   usersByEmail.set(SEED_EMAIL, { password: SEED_PASSWORD, user })


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Resolves #211 

## 📑 구현 사항

- mock 환경에서 소셜 로그인 버튼 클릭 시 인라인 문구 대신 토스트로 안내하도록 수정
- 로그인, 회원가입, 일반회원 가입 화면에 토글 가능한 mock 안내 패널 추가
- 안내 패널에서 로그인용 계정 정보와 회원가입용 고정 인증코드를 바로 확인할 수 있도록 구성
- mock 인증 관련 상수를 한곳에서 관리하도록 정리하고 mock handler와 동일한 값을 사용하도록 연결
- 앱 루트에 `react-hot-toast` `Toaster` 추가

## 🌀 어려웠던 점 / 고민했던 부분

- mock 배포에서는 소셜 로그인 버튼을 완전히 숨기기보다, 기존 UI를 유지하면서 클릭 시 명확히 안내하는 방식이 더 자연스럽다고 판단했습니다.
- 안내 패널은 항상 펼쳐두면 화면을 가릴 수 있어 왼쪽 아래 고정 + 토글형 구조로 정리했습니다.
- 사용자 안내 텍스트와 실제 mock handler 값이 어긋나지 않도록 상수화를 적용했습니다.

## 📸 구현 이미지

- mock 로그인/회원가입 화면의 좌측 하단 안내 패널
- mock 환경에서 소셜 로그인 클릭 시 토스트 안내 화면

## ❇️ 코드 설명

- `src/components/auth/SocialLoginSection.tsx`
  - mock 환경에서 소셜 로그인 클릭 시 토스트만 띄우고 실제 리다이렉트는 막도록 변경
- `src/components/auth/MockAuthHelpPanel.tsx`
  - 로그인/회원가입 관련 mock 정보를 보여주는 토글형 고정 패널 추가
- `src/constants/mockAuth.ts`
  - 로그인 계정, 인증코드, 토스트 문구 등 mock 안내용 상수 정리
- `src/mocks/handlers/auth.mock.ts`
  - 실제 mock 응답 값이 안내 패널과 동일하도록 공통 상수 사용
- `src/App.tsx`
  - 전역 토스트 표시를 위한 `Toaster` 추가

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1. mock 안내 패널의 위치와 크기가 실제 체험 흐름에서 과하게 시선을 빼앗지 않는지 확인 부탁드립니다.
2. 소셜 로그인 버튼을 숨기지 않고 토스트로 안내하는 방식이 적절한지 확인 부탁드립니다.
3. 회원가입 안내를 고정 인증코드만 노출하는 현재 구성으로 유지해도 되는지 의견 부탁드립니다.
