### PR TITLE
feat: Mock 배포용 인증 안내 UX 개선 수정

### DIFF
--- a/src/components/auth/MockAuthHelpPanel.tsx
+++ b/src/components/auth/MockAuthHelpPanel.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react'
+import { useLocation } from 'react-router-dom'
+
+import {
+  MOCK_EMAIL_VERIFICATION_CODE,
+  MOCK_LOGIN_CREDENTIALS,
+  MOCK_SMS_VERIFICATION_CODE,
+} from '@/constants/mockAuth'
+
+const MOCK_HELP_ROUTES = new Set(['/login', '/signup', '/signup/email'])
+
+export default function MockAuthHelpPanel() {
+  const { pathname } = useLocation()
+  const isMockMode = import.meta.env.VITE_USE_MSW === 'true'
+  const [isOpen, setIsOpen] = useState(true)
+
+  if (!isMockMode || !MOCK_HELP_ROUTES.has(pathname)) {
+    return null
+  }
+
+  return (
+    <aside className="fixed right-4 bottom-4 left-4 z-40 sm:right-auto sm:left-6 sm:w-[336px]">
+      <div className="overflow-hidden border border-gray-200 bg-white/95 shadow-lg backdrop-blur">
+        <button
+          type="button"
+          className="flex w-full cursor-pointer items-center justify-between px-4 py-3 text-left"
+          onClick={() => setIsOpen((current) => !current)}
+        >
+          <span className="text-foreground text-sm font-semibold">
+            Mock 체험 안내
+          </span>
+          <span className="text-mono-600 text-xs">
+            {isOpen ? '접기' : '열기'}
+          </span>
+        </button>
+
+        {isOpen ? (
+          <div className="border-t border-gray-200 p-4">
+            <div className="flex flex-col gap-3">
+              <div>
+                <p className="text-mono-600 text-xs">
+                  아래 정보로 로그인하거나 회원가입 인증을 진행할 수 있습니다.
+                </p>
+              </div>
+
+              <div className="border-t border-gray-200 pt-3">
+                <p className="text-foreground text-sm font-semibold">로그인</p>
+                <dl className="mt-2 grid grid-cols-[72px_1fr] gap-x-2 gap-y-1 text-xs">
+                  <dt className="text-mono-600">이메일</dt>
+                  <dd className="font-mono text-[12px]">
+                    {MOCK_LOGIN_CREDENTIALS.email}
+                  </dd>
+                  <dt className="text-mono-600">비밀번호</dt>
+                  <dd className="font-mono text-[12px]">
+                    {MOCK_LOGIN_CREDENTIALS.password}
+                  </dd>
+                </dl>
+              </div>
+
+              <div className="border-t border-gray-200 pt-3">
+                <p className="text-foreground text-sm font-semibold">
+                  회원가입 인증코드
+                </p>
+                <dl className="mt-2 grid grid-cols-[72px_1fr] gap-x-2 gap-y-1 text-xs">
+                  <dt className="text-mono-600">이메일 코드</dt>
+                  <dd className="font-mono text-[12px]">
+                    {MOCK_EMAIL_VERIFICATION_CODE}
+                  </dd>
+                  <dt className="text-mono-600">문자 코드</dt>
+                  <dd className="font-mono text-[12px]">
+                    {MOCK_SMS_VERIFICATION_CODE}
+                  </dd>
+                </dl>
+              </div>
+
+              <p className="text-mono-600 text-[11px] leading-4">
+                회원가입 입력값은 자유롭게 작성하고, 인증 단계에서는 위 고정 코드를 사용하면 됩니다.
+              </p>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </aside>
+  )
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Resolves #213 

## 📑 구현 사항

- mock 환경에서 소셜 로그인 버튼 클릭 시 실제 리다이렉트 대신 토스트 안내가 나오도록 수정
- 로그인, 회원가입, 일반회원 가입 화면에 토글 가능한 mock 안내 패널 추가
- 안내 패널에서 로그인용 계정 정보와 회원가입용 고정 인증코드를 바로 확인할 수 있도록 구성
- mock 인증 관련 상수를 한곳에서 관리하도록 정리하고 mock handler와 동일한 값을 사용하도록 연결
- 앱 루트에 `react-hot-toast` `Toaster` 추가

## 🌀 어려웠던 점 / 고민했던 부분

- mock 환경에서도 소셜 로그인 버튼의 원래 스타일은 유지하되, 클릭 시점에만 명확히 막는 방식으로 UX를 정리했습니다.
- 안내 패널은 항상 펼쳐두면 화면을 가릴 수 있어 왼쪽 아래 고정 + 토글형 구조로 구성했습니다.
- 사용자에게 보이는 로그인 정보와 인증코드가 실제 mock 응답 값과 어긋나지 않도록 상수화를 적용했습니다.

## 📸 구현 이미지

- 로그인 화면에서 좌측 하단 mock 안내 패널
- mock 환경에서 소셜 로그인 클릭 시 토스트 안내 화면

## ❇️ 코드 설명

- `src/components/auth/SocialLoginSection.tsx`
  - mock 환경에서 소셜 로그인 클릭 시 토스트만 띄우고 실제 이동은 막도록 변경
- `src/components/auth/MockAuthHelpPanel.tsx`
  - 로그인/회원가입 관련 mock 정보를 보여주는 토글형 안내 패널 추가
- `src/constants/mockAuth.ts`
  - 로그인 계정, 인증코드, 토스트 문구 등 mock 안내용 상수 정리
- `src/mocks/handlers/auth.mock.ts`
  - 실제 mock 응답 값이 안내 패널과 동일하도록 공통 상수 사용
- `src/App.tsx`
  - 전역 토스트 표시를 위한 `Toaster` 추가

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1. mock 안내 패널의 위치와 크기가 실제 체험 흐름에서 과하지 않은지 확인 부탁드립니다.
2. 소셜 로그인 버튼을 숨기지 않고 토스트로 안내하는 방식이 적절한지 확인 부탁드립니다.
3. 회원가입 안내를 고정 인증코드만 노출하는 현재 구성이 적절한지 확인 부탁드립니다.
