### PR TITLE
feat: Mock 인증 안내 복사 UX 개선

### DIFF
--- a/src/components/auth/MockAuthHelpPanel.tsx
+++ b/src/components/auth/MockAuthHelpPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useLocation } from 'react-router-dom'
+import { toast } from 'react-hot-toast'
 
 import {
   MOCK_EMAIL_VERIFICATION_CODE,
@@ -13,6 +14,15 @@ export default function MockAuthHelpPanel() {
   const { pathname } = useLocation()
   const isMockMode = import.meta.env.VITE_USE_MSW === 'true'
   const [isOpen, setIsOpen] = useState(true)
+
+  const handleCopy = async (label: string, value: string) => {
+    try {
+      await navigator.clipboard.writeText(value)
+      toast.success(`${label} 복사됨`, { duration: 1800 })
+    } catch {
+      toast.error('복사에 실패했습니다.')
+    }
+  }
 
   if (!isMockMode || !MOCK_HELP_ROUTES.has(pathname)) {
     return null
@@ -45,32 +55,82 @@ export default function MockAuthHelpPanel() {
 
               <div className="border-t border-gray-200 pt-3">
                 <p className="text-foreground text-sm font-semibold">로그인</p>
-                <dl className="mt-2 grid grid-cols-[72px_1fr] gap-x-2 gap-y-1 text-xs">
-                  <dt className="text-mono-600">이메일</dt>
-                  <dd className="font-mono text-[12px]">
-                    {MOCK_LOGIN_CREDENTIALS.email}
-                  </dd>
-                  <dt className="text-mono-600">비밀번호</dt>
-                  <dd className="font-mono text-[12px]">
-                    {MOCK_LOGIN_CREDENTIALS.password}
-                  </dd>
+                <dl className="mt-2 grid grid-cols-[72px_1fr_auto] items-center gap-x-2 gap-y-2 text-xs">
+                  <div className="contents">
+                    <dt className="text-mono-600">이메일</dt>
+                    <dd className="font-mono text-[12px]">
+                      {MOCK_LOGIN_CREDENTIALS.email}
+                    </dd>
+                    <button
+                      type="button"
+                      className="cursor-pointer rounded border border-gray-200 px-2 py-1 text-[11px] font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                      onClick={() =>
+                        void handleCopy('이메일', MOCK_LOGIN_CREDENTIALS.email)
+                      }
+                    >
+                      복사
+                    </button>
+                  </div>
+                  <div className="contents">
+                    <dt className="text-mono-600">비밀번호</dt>
+                    <dd className="font-mono text-[12px]">
+                      {MOCK_LOGIN_CREDENTIALS.password}
+                    </dd>
+                    <button
+                      type="button"
+                      className="cursor-pointer rounded border border-gray-200 px-2 py-1 text-[11px] font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                      onClick={() =>
+                        void handleCopy('비밀번호', MOCK_LOGIN_CREDENTIALS.password)
+                      }
+                    >
+                      복사
+                    </button>
+                  </div>
                 </dl>
+                <p className="text-mono-600 mt-2 text-[11px] leading-4">
+                  복사 버튼을 사용하면 공백 없이 입력됩니다.
+                </p>
               </div>
 
               <div className="border-t border-gray-200 pt-3">
                 <p className="text-foreground text-sm font-semibold">
                   회원가입 인증코드
                 </p>
-                <dl className="mt-2 grid grid-cols-[72px_1fr] gap-x-2 gap-y-1 text-xs">
-                  <dt className="text-mono-600">이메일 코드</dt>
-                  <dd className="font-mono text-[12px]">
-                    {MOCK_EMAIL_VERIFICATION_CODE}
-                  </dd>
-                  <dt className="text-mono-600">문자 코드</dt>
-                  <dd className="font-mono text-[12px]">
-                    {MOCK_SMS_VERIFICATION_CODE}
-                  </dd>
+                <dl className="mt-2 grid grid-cols-[72px_1fr_auto] items-center gap-x-2 gap-y-2 text-xs">
+                  <div className="contents">
+                    <dt className="text-mono-600">이메일 코드</dt>
+                    <dd className="font-mono text-[12px]">
+                      {MOCK_EMAIL_VERIFICATION_CODE}
+                    </dd>
+                    <button
+                      type="button"
+                      className="cursor-pointer rounded border border-gray-200 px-2 py-1 text-[11px] font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                      onClick={() =>
+                        void handleCopy('이메일 코드', MOCK_EMAIL_VERIFICATION_CODE)
+                      }
+                    >
+                      복사
+                    </button>
+                  </div>
+                  <div className="contents">
+                    <dt className="text-mono-600">문자 코드</dt>
+                    <dd className="font-mono text-[12px]">
+                      {MOCK_SMS_VERIFICATION_CODE}
+                    </dd>
+                    <button
+                      type="button"
+                      className="cursor-pointer rounded border border-gray-200 px-2 py-1 text-[11px] font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                      onClick={() =>
+                        void handleCopy('문자 코드', MOCK_SMS_VERIFICATION_CODE)
+                      }
+                    >
+                      복사
+                    </button>
+                  </div>
                 </dl>
+                <p className="text-mono-600 mt-2 text-[11px] leading-4">
+                  인증 단계에서는 복사 버튼으로 정확한 코드를 붙여넣으면 됩니다.
+                </p>
               </div>
 
               <p className="text-mono-600 text-[11px] leading-4">

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -33,6 +33,7 @@ export default function LoginPage() {
   const navigate = useNavigate()
   const location = useLocation()
   const login = useAuthStore((state) => state.login)
+  const isMockMode = import.meta.env.VITE_USE_MSW === 'true'
 
   const { methods, rootError, submitButton } = useLoginForm()
   const accountRecovery = useAccountRecoveryModals()
@@ -47,7 +48,14 @@ export default function LoginPage() {
     clearErrors('root')
 
     try {
-      await login(formData)
+      const loginPayload = isMockMode
+        ? {
+            email: formData.email.trim(),
+            password: formData.password.trim(),
+          }
+        : formData
+
+      await login(loginPayload)
       // 로그인 성공 시 원래 가려던 페이지로 이동
       navigate(redirectPath, { replace: true })
     } catch (error) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Resolves #215 

## 📑 구현 사항

- mock 체험 안내 패널의 로그인 섹션에 이메일/비밀번호 전용 복사 버튼 추가
- 회원가입 인증코드 섹션에 이메일 코드/문자 코드 복사 버튼 추가
- 복사 성공 시 짧은 토스트가 뜨도록 구현하고 실패 시 에러 토스트 처리 추가
- mock 모드 로그인에서는 이메일과 비밀번호의 앞뒤 공백을 제거한 뒤 요청하도록 보정
- 안내 문구를 추가해 드래그 복사 대신 복사 버튼 사용을 유도

## 🌀 어려웠던 점 / 고민했던 부분

- 로그인 실패 원인은 안내 패널 값 자체가 아니라 드래그 복사 시 섞이는 공백/줄바꿈일 가능성이 높아, UI 복사 버튼과 로그인 trim 보정을 함께 적용했습니다.
- 실제 서비스 동작을 건드리지 않기 위해 로그인 trim 보정은 mock 모드에만 한정했습니다.
- 복사 버튼은 정보 노출을 늘리는 대신 mock 체험 진입 장벽을 낮추는 방향으로 판단했습니다.

## 📸 구현 이미지

- 로그인 정보 복사 버튼이 포함된 mock 안내 패널
- 회원가입 인증코드 복사 버튼이 포함된 mock 안내 패널
- 복사 성공 토스트 화면

## ❇️ 코드 설명

- `src/components/auth/MockAuthHelpPanel.tsx`
  - 로그인 정보 및 인증코드 복사 버튼 추가
  - 복사 성공/실패 토스트 처리
- `src/pages/LoginPage.tsx`
  - mock 모드에서 로그인 payload의 이메일/비밀번호 앞뒤 공백 trim 적용

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1. mock 안내 패널에서 복사 버튼 배치가 과하지 않은지 확인 부탁드립니다.
2. mock 모드에 한정한 로그인 trim 보정 범위가 적절한지 확인 부탁드립니다.
3. 복사 성공 토스트 메시지 길이와 위치가 기존 소셜 로그인 안내 토스트와 충돌하지 않는지 확인 부탁드립니다.
