### PR TITLE
feat: Mock 인증 안내 패널을 흐름별로 분리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,6 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { Toaster } from 'react-hot-toast'
 
 import '@/App.css'
-import MockAuthHelpPanel from '@/components/auth/MockAuthHelpPanel'
 import LandingPage from '@/pages/LandingPage'
 import TestPage from '@/pages/TestPage'
 import {
@@ -98,7 +97,6 @@ function App() {
     <BrowserRouter>
       <AuthBootstrap />
       <ScrollToTop />
-      <MockAuthHelpPanel />
       <Routes>
         {/* 헤더가 포함된 페이지 */}
         <Route element={<MainLayout />}>

--- a/src/components/auth/MockAuthHelpPanel.tsx
+++ b/src/components/auth/MockAuthHelpPanel.tsx
@@ -1,19 +1,142 @@
 import { useState } from 'react'
-import { useLocation } from 'react-router-dom'
 import { toast } from 'react-hot-toast'
 
 import {
   MOCK_EMAIL_VERIFICATION_CODE,
+  MOCK_FIND_ID_EXAMPLE,
+  MOCK_FIND_PASSWORD_EXAMPLE,
   MOCK_LOGIN_CREDENTIALS,
+  MOCK_RESTORE_ACCOUNT_CREDENTIALS,
   MOCK_SMS_VERIFICATION_CODE,
 } from '@/constants/mockAuth'
 
-const MOCK_HELP_ROUTES = new Set(['/login', '/signup', '/signup/email'])
+export type MockAuthHelpPanelVariant =
+  | 'login'
+  | 'signup'
+  | 'find-id'
+  | 'find-password'
+  | 'restore-account'
 
-export default function MockAuthHelpPanel() {
-  const { pathname } = useLocation()
+type MockAuthHelpPanelProps = {
+  variant: MockAuthHelpPanelVariant
+}
+
+type MockHelpField = {
+  label: string
+  value: string
+  copyLabel?: string
+}
+
+type MockHelpSection = {
+  title: string
+  helper?: string
+  fields: MockHelpField[]
+}
+
+type MockHelpPanelContent = {
+  description: string
+  sections: MockHelpSection[]
+}
+
+const MOCK_HELP_CONTENT: Record<MockAuthHelpPanelVariant, MockHelpPanelContent> =
+  {
+    login: {
+      description: '아래 계정으로 일반 로그인을 진행할 수 있습니다.',
+      sections: [
+        {
+          title: '로그인 정보',
+          helper: '복사 버튼을 사용하면 공백 없이 입력됩니다.',
+          fields: [
+            { label: '이메일', value: MOCK_LOGIN_CREDENTIALS.email },
+            { label: '비밀번호', value: MOCK_LOGIN_CREDENTIALS.password },
+          ],
+        },
+      ],
+    },
+    signup: {
+      description:
+        '회원가입 인증은 먼저 전송 버튼을 누른 뒤 같은 이메일과 휴대전화로 확인해주세요.',
+      sections: [
+        {
+          title: '회원가입 인증코드',
+          helper: '이메일 코드와 문자 코드는 언제나 아래 고정값을 사용하면 됩니다.',
+          fields: [
+            {
+              label: '이메일 코드',
+              value: MOCK_EMAIL_VERIFICATION_CODE,
+            },
+            { label: '문자 코드', value: MOCK_SMS_VERIFICATION_CODE },
+          ],
+        },
+      ],
+    },
+    'find-id': {
+      description:
+        '아이디 찾기는 아래 이름과 휴대전화로 인증번호를 요청한 뒤 같은 정보로 확인해주세요.',
+      sections: [
+        {
+          title: '아이디 찾기 정보',
+          helper: '문자 인증은 전송 후 같은 휴대전화 번호로 확인해야 합니다.',
+          fields: [
+            { label: '이름', value: MOCK_FIND_ID_EXAMPLE.name },
+            {
+              label: '휴대전화',
+              value: MOCK_FIND_ID_EXAMPLE.phoneNumber,
+            },
+            { label: '문자 코드', value: MOCK_SMS_VERIFICATION_CODE },
+          ],
+        },
+      ],
+    },
+    'find-password': {
+      description:
+        '비밀번호 찾기는 아래 이메일로 인증코드를 전송한 뒤 같은 이메일로 확인해주세요.',
+      sections: [
+        {
+          title: '비밀번호 찾기 정보',
+          helper: '이메일 인증은 전송 후 같은 이메일로 확인해야 합니다.',
+          fields: [
+            { label: '이메일', value: MOCK_FIND_PASSWORD_EXAMPLE.email },
+            {
+              label: '이메일 코드',
+              value: MOCK_EMAIL_VERIFICATION_CODE,
+            },
+          ],
+        },
+      ],
+    },
+    'restore-account': {
+      description:
+        '탈퇴회원 복구 테스트는 아래 계정으로 로그인한 뒤 같은 이메일로 인증을 진행해주세요.',
+      sections: [
+        {
+          title: '계정 복구 정보',
+          helper: '복구 모달에서는 로그인 후 이메일 인증코드를 전송하고 같은 이메일로 확인합니다.',
+          fields: [
+            {
+              label: '이메일',
+              value: MOCK_RESTORE_ACCOUNT_CREDENTIALS.email,
+            },
+            {
+              label: '비밀번호',
+              value: MOCK_RESTORE_ACCOUNT_CREDENTIALS.password,
+            },
+            {
+              label: '이메일 코드',
+              value: MOCK_EMAIL_VERIFICATION_CODE,
+            },
+          ],
+        },
+      ],
+    },
+  }
+
+export default function MockAuthHelpPanel({
+  variant,
+}: MockAuthHelpPanelProps) {
   const isMockMode = import.meta.env.VITE_USE_MSW === 'true'
   const [isOpen, setIsOpen] = useState(true)
+  const content = MOCK_HELP_CONTENT[variant]
 
   const handleCopy = async (label: string, value: string) => {
     try {
@@ -24,12 +147,12 @@ export default function MockAuthHelpPanel() {
     }
   }
 
-  if (!isMockMode || !MOCK_HELP_ROUTES.has(pathname)) {
+  if (!isMockMode) {
     return null
   }
 
   return (
-    <aside className="fixed right-4 bottom-4 left-4 z-40 sm:right-auto sm:left-6 sm:w-[336px]">
+    <aside className="fixed right-4 bottom-4 left-4 z-[80] sm:right-auto sm:left-6 sm:w-[348px]">
       <div className="overflow-hidden border border-gray-200 bg-white/95 shadow-lg backdrop-blur">
         <button
           type="button"
@@ -48,94 +171,38 @@ export default function MockAuthHelpPanel() {
           <div className="border-t border-gray-200 p-4">
             <div className="flex flex-col gap-3">
               <div>
-                <p className="text-mono-600 text-xs">
-                  아래 정보로 로그인하거나 회원가입 인증을 진행할 수 있습니다.
-                </p>
+                <p className="text-mono-600 text-xs">{content.description}</p>
               </div>
 
-              <div className="border-t border-gray-200 pt-3">
-                <p className="text-foreground text-sm font-semibold">로그인</p>
-                <dl className="mt-2 grid grid-cols-[72px_1fr_auto] items-center gap-x-2 gap-y-2 text-xs">
-                  <div className="contents">
-                    <dt className="text-mono-600">이메일</dt>
-                    <dd className="font-mono text-[12px]">
-                      {MOCK_LOGIN_CREDENTIALS.email}
-                    </dd>
-                    <button
-                      type="button"
-                      className="cursor-pointer rounded border border-gray-200 px-2 py-1 text-[11px] font-medium text-gray-600 transition-colors hover:bg-gray-50"
-                      onClick={() =>
-                        void handleCopy('이메일', MOCK_LOGIN_CREDENTIALS.email)
-                      }
-                    >
-                      복사
-                    </button>
-                  </div>
-                  <div className="contents">
-                    <dt className="text-mono-600">비밀번호</dt>
-                    <dd className="font-mono text-[12px]">
-                      {MOCK_LOGIN_CREDENTIALS.password}
-                    </dd>
-                    <button
-                      type="button"
-                      className="cursor-pointer rounded border border-gray-200 px-2 py-1 text-[11px] font-medium text-gray-600 transition-colors hover:bg-gray-50"
-                      onClick={() =>
-                        void handleCopy('비밀번호', MOCK_LOGIN_CREDENTIALS.password)
-                      }
-                    >
-                      복사
-                    </button>
-                  </div>
-                </dl>
-                <p className="text-mono-600 mt-2 text-[11px] leading-4">
-                  복사 버튼을 사용하면 공백 없이 입력됩니다.
-                </p>
-              </div>
-
-              <div className="border-t border-gray-200 pt-3">
-                <p className="text-foreground text-sm font-semibold">
-                  회원가입 인증코드
-                </p>
-                <dl className="mt-2 grid grid-cols-[72px_1fr_auto] items-center gap-x-2 gap-y-2 text-xs">
-                  <div className="contents">
-                    <dt className="text-mono-600">이메일 코드</dt>
-                    <dd className="font-mono text-[12px]">
-                      {MOCK_EMAIL_VERIFICATION_CODE}
-                    </dd>
-                    <button
-                      type="button"
-                      className="cursor-pointer rounded border border-gray-200 px-2 py-1 text-[11px] font-medium text-gray-600 transition-colors hover:bg-gray-50"
-                      onClick={() =>
-                        void handleCopy('이메일 코드', MOCK_EMAIL_VERIFICATION_CODE)
-                      }
-                    >
-                      복사
-                    </button>
-                  </div>
-                  <div className="contents">
-                    <dt className="text-mono-600">문자 코드</dt>
-                    <dd className="font-mono text-[12px]">
-                      {MOCK_SMS_VERIFICATION_CODE}
-                    </dd>
-                    <button
-                      type="button"
-                      className="cursor-pointer rounded border border-gray-200 px-2 py-1 text-[11px] font-medium text-gray-600 transition-colors hover:bg-gray-50"
-                      onClick={() =>
-                        void handleCopy('문자 코드', MOCK_SMS_VERIFICATION_CODE)
-                      }
-                    >
-                      복사
-                    </button>
-                  </div>
-                </dl>
-                <p className="text-mono-600 mt-2 text-[11px] leading-4">
-                  인증 단계에서는 복사 버튼으로 정확한 코드를 붙여넣으면 됩니다.
-                </p>
-              </div>
-
-              <p className="text-mono-600 text-[11px] leading-4">
-                회원가입 입력값은 자유롭게 작성하고, 인증 단계에서는 위 고정 코드를 사용하면 됩니다.
-              </p>
+              {content.sections.map((section) => (
+                <div key={section.title} className="border-t border-gray-200 pt-3">
+                  <p className="text-foreground text-sm font-semibold">
+                    {section.title}
+                  </p>
+                  <dl className="mt-2 grid grid-cols-[72px_1fr_auto] items-center gap-x-2 gap-y-2 text-xs">
+                    {section.fields.map((field) => (
+                      <div key={`${section.title}-${field.label}`} className="contents">
+                        <dt className="text-mono-600">{field.label}</dt>
+                        <dd className="font-mono text-[12px]">{field.value}</dd>
+                        <button
+                          type="button"
+                          className="cursor-pointer rounded border border-gray-200 px-2 py-1 text-[11px] font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                          onClick={() =>
+                            void handleCopy(field.copyLabel ?? field.label, field.value)
+                          }
+                        >
+                          복사
+                        </button>
+                      </div>
+                    ))}
+                  </dl>
+                  {section.helper ? (
+                    <p className="text-mono-600 mt-2 text-[11px] leading-4">
+                      {section.helper}
+                    </p>
+                  ) : null}
+                </div>
+              ))}
             </div>
           </div>
         ) : null}

--- a/src/constants/mockAuth.ts
+++ b/src/constants/mockAuth.ts
@@ -19,6 +19,20 @@ export const MOCK_LOGIN_USER: User = {
 export const MOCK_EMAIL_VERIFICATION_CODE = 'ABCDE12345'
 export const MOCK_SMS_VERIFICATION_CODE = '123456'
 
+export const MOCK_FIND_ID_EXAMPLE = {
+  name: MOCK_LOGIN_USER.name,
+  phoneNumber: '010-1234-5678',
+}
+
+export const MOCK_FIND_PASSWORD_EXAMPLE = {
+  email: MOCK_LOGIN_CREDENTIALS.email,
+}
+
+export const MOCK_RESTORE_ACCOUNT_CREDENTIALS: LoginPayload = {
+  email: 'restore@example.com',
+  password: 'Restore123!',
+}
+
 export const MOCK_SIGNUP_EXAMPLE = {
   name: '홍길동',
   birthdate: '20000101',

--- a/src/mocks/handlers/auth.mock.ts
+++ b/src/mocks/handlers/auth.mock.ts
@@ -5,6 +5,7 @@ import {
   MOCK_LOGIN_USER,
   MOCK_SMS_VERIFICATION_CODE,
 } from '@/constants/mockAuth'
+import { maskEmailForDisplay } from '@/utils/emailMask'
 
 const CODE_TTL_MS = 5 * 60 * 1000
 
@@ -15,6 +16,8 @@ const FIXED_SMS_CODE = MOCK_SMS_VERIFICATION_CODE // SMS 코드: 123456
 // 테스트용 아이디/비밀번호
 const SEED_EMAIL = MOCK_LOGIN_CREDENTIALS.email // 아이디: test@example.com
 const SEED_PASSWORD = MOCK_LOGIN_CREDENTIALS.password // 비밀번호: Test123!
+const WITHDRAWN_EMAIL = 'restore@example.com'
+const WITHDRAWN_PASSWORD = 'Restore123!'
 
 const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 const api = (path: string) => new RegExp(`(${escapeRegExp(path)})(\\?.*)?$`)
@@ -33,6 +36,7 @@ type UserDto = {
 
 type StoredUser = {
   password: string
+  withdrawn: boolean
   user: UserDto
 }
 
@@ -74,6 +78,13 @@ type JsonValue =
 const error = (status: number, payload: JsonValue) =>
   HttpResponse.json(payload, { status })
 
+const findUserByPhone = (phone: string) => {
+  for (const stored of usersByEmail.values()) {
+    if (stored.user.phone_number === phone) return stored
+  }
+  return null
+}
+
 // 시드 유저 추가
 if (!usersByEmail.has(SEED_EMAIL)) {
   const user: UserDto = {
@@ -87,7 +98,32 @@ if (!usersByEmail.has(SEED_EMAIL)) {
     profile_img_url: MOCK_LOGIN_USER.profile_img_url,
     created_at: new Date().toISOString(),
   }
-  usersByEmail.set(SEED_EMAIL, { password: SEED_PASSWORD, user })
+  usersByEmail.set(SEED_EMAIL, {
+    password: SEED_PASSWORD,
+    withdrawn: false,
+    user,
+  })
+  usedNicknames.add(user.nickname.toLowerCase())
+  usedPhones.add(user.phone_number)
+}
+
+if (!usersByEmail.has(WITHDRAWN_EMAIL)) {
+  const user: UserDto = {
+    id: seq++,
+    email: WITHDRAWN_EMAIL,
+    nickname: '복구유저',
+    name: '복구 유저',
+    phone_number: '01055556666',
+    birthday: '1999-01-01',
+    gender: 'F',
+    profile_img_url: null,
+    created_at: new Date().toISOString(),
+  }
+  usersByEmail.set(WITHDRAWN_EMAIL, {
+    password: WITHDRAWN_PASSWORD,
+    withdrawn: true,
+    user,
+  })
   usedNicknames.add(user.nickname.toLowerCase())
   usedPhones.add(user.phone_number)
 }
@@ -98,9 +134,15 @@ export const loginHandler = http.post(
     await delay(120)
     const body = (await request.json()) as { email?: string; password?: string }
     const email = normEmail(String(body.email ?? ''))
-    const password = String(body.password ?? '')
+    const password = String(body.password ?? '').trim()
 
     const found = usersByEmail.get(email)
+    if (found?.withdrawn) {
+      return error(403, {
+        error_detail: '탈퇴한 회원입니다. 계정 복구를 진행해주세요.',
+      })
+    }
+
     if (!found || found.password !== password) {
       return error(400, {
         error_detail: {
@@ -237,10 +279,6 @@ export const sendEmailHandler = http.post(
       return error(400, { error_detail: { email: ['이메일을 입력해주세요.'] } })
     }
 
-    if (usersByEmail.has(email)) {
-      return error(409, { error_detail: '이미 가입된 이메일입니다.' })
-    }
-
     emailCodes.set(email, { code: FIXED_EMAIL_CODE, at: now() })
 
     return HttpResponse.json(
@@ -267,14 +305,12 @@ export const verifyEmailHandler = http.post(
       })
     }
 
-    if (usersByEmail.has(email)) {
-      return error(409, { error_detail: '이미 가입된 이메일입니다.' })
-    }
-
     const saved = emailCodes.get(email)
     if (!saved) {
       return error(400, {
-        error_detail: { code: ['인증코드가 일치하지 않습니다.'] },
+        error_detail: {
+          code: ['먼저 인증코드를 전송한 뒤 같은 이메일로 확인해주세요.'],
+        },
       })
     }
 
@@ -314,12 +350,6 @@ export const sendSmsHandler = http.post(
       })
     }
 
-    if (usedPhones.has(phone)) {
-      return error(409, {
-        error_detail: '이미 가입에 사용된 휴대전화 번호입니다.',
-      })
-    }
-
     smsCodes.set(phone, { code: FIXED_SMS_CODE, at: now() })
 
     return HttpResponse.json(
@@ -352,16 +382,12 @@ export const verifySmsHandler = http.post(
       })
     }
 
-    if (usedPhones.has(phone)) {
-      return error(409, {
-        error_detail: '이미 가입에 사용된 휴대전화 번호입니다.',
-      })
-    }
-
     const saved = smsCodes.get(phone)
     if (!saved) {
       return error(400, {
-        error_detail: { code: ['인증코드가 일치하지 않습니다.'] },
+        error_detail: {
+          code: ['먼저 인증번호를 전송한 뒤 같은 휴대전화 번호로 확인해주세요.'],
+        },
       })
     }
 
@@ -383,6 +409,130 @@ export const verifySmsHandler = http.post(
 
     return HttpResponse.json(
       { detail: '회원가입을 위한 휴대폰 인증에 성공하였습니다.', sms_token },
+      { status: 200 }
+    )
+  }
+)
+
+export const findEmailHandler = http.post(
+  api('/api/v1/accounts/find-email/'),
+  async ({ request }) => {
+    await delay(100)
+    const body = (await request.json()) as { name?: string; sms_token?: string }
+    const name = String(body.name ?? '').trim()
+    const smsToken = String(body.sms_token ?? '')
+
+    if (!name || !smsToken) {
+      return error(400, {
+        error_detail: '이름과 휴대폰 인증 정보를 확인해주세요.',
+      })
+    }
+
+    const phone = smsTokens.get(smsToken)
+    if (!phone) {
+      return error(400, {
+        error_detail: { sms_token: ['휴대폰 인증을 다시 진행해주세요.'] },
+      })
+    }
+
+    const found = findUserByPhone(phone)
+    if (!found || found.user.name !== name) {
+      return error(404, {
+        error_detail: '입력한 이름과 휴대폰 번호로 등록된 이메일이 존재하지 않습니다.',
+      })
+    }
+
+    return HttpResponse.json(
+      { email: maskEmailForDisplay(found.user.email) },
+      { status: 200 }
+    )
+  }
+)
+
+export const resetPasswordHandler = http.post(
+  api('/api/v1/accounts/find-password/'),
+  async ({ request }) => {
+    await delay(120)
+    const body = (await request.json()) as {
+      email_token?: string
+      new_password?: string
+    }
+    const emailToken = String(body.email_token ?? '')
+    const newPassword = String(body.new_password ?? '').trim()
+
+    if (!emailToken || !newPassword) {
+      return error(400, {
+        error_detail: '인증 정보와 새 비밀번호를 확인해주세요.',
+      })
+    }
+
+    const email = emailTokens.get(emailToken)
+    if (!email) {
+      return error(400, {
+        error_detail: { email_token: ['이메일 인증을 다시 진행해주세요.'] },
+      })
+    }
+
+    const found = usersByEmail.get(email)
+    if (!found) {
+      return error(404, {
+        detail: '등록된 계정을 찾을 수 없습니다.',
+      })
+    }
+
+    usersByEmail.set(email, {
+      ...found,
+      password: newPassword,
+    })
+
+    return HttpResponse.json(
+      { detail: '비밀번호가 재설정되었습니다.' },
+      { status: 200 }
+    )
+  }
+)
+
+export const restoreAccountHandler = http.post(
+  api('/api/v1/accounts/restore/'),
+  async ({ request }) => {
+    await delay(120)
+    const body = (await request.json()) as { email_token?: string }
+    const emailToken = String(body.email_token ?? '')
+
+    if (!emailToken) {
+      return error(400, {
+        error_detail: { email_token: ['이메일 인증을 다시 진행해주세요.'] },
+      })
+    }
+
+    const email = emailTokens.get(emailToken)
+    if (!email) {
+      return error(400, {
+        error_detail: { email_token: ['이메일 인증을 다시 진행해주세요.'] },
+      })
+    }
+
+    const found = usersByEmail.get(email)
+    if (!found) {
+      return error(404, {
+        detail: '등록된 계정을 찾을 수 없습니다.',
+      })
+    }
+
+    if (!found.withdrawn) {
+      return HttpResponse.json(
+        { detail: '이미 사용 가능한 계정입니다.' },
+        { status: 200 }
+      )
+    }
+
+    usersByEmail.set(email, {
+      ...found,
+      withdrawn: false,
+    })
+
+    return HttpResponse.json(
+      { detail: '계정 복구가 완료되었습니다.' },
       { status: 200 }
     )
   }
@@ -473,7 +623,7 @@ export const signupHandler = http.post(
       created_at: new Date().toISOString(),
     }
 
-    usersByEmail.set(email, { password, user })
+    usersByEmail.set(email, { password, withdrawn: false, user })
     usedPhones.add(phone)
     usedNicknames.add(nickname.toLowerCase())
 
@@ -495,5 +645,8 @@ export const authHandlers = [
   verifyEmailHandler,
   sendSmsHandler,
   verifySmsHandler,
+  findEmailHandler,
+  resetPasswordHandler,
+  restoreAccountHandler,
   signupHandler,
 ]

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -6,6 +6,9 @@ import { CommonInputField } from '@/components/common/CommonInputField'
 import { PasswordField } from '@/components/common/PasswordField'
 import { Button } from '@/components/common/Button'
 import { FormErrorDisplay } from '@/components/common/FormErrorDisplay'
+import MockAuthHelpPanel, {
+  type MockAuthHelpPanelVariant,
+} from '@/components/auth/MockAuthHelpPanel'
 import SocialLoginSection from '@/components/auth/SocialLoginSection'
 import {
   FindIdModal,
@@ -41,6 +44,18 @@ export default function LoginPage() {
 
   const { handleSubmit, setError, clearErrors } = methods
   const redirectPath = getRedirectPathFromLocation(location.state)
+  const helpPanelVariant = getMockAuthHelpPanelVariant({
+    isFindIdOpen:
+      accountRecovery.modals.findId.isOpen ||
+      accountRecovery.modals.findIdResult.isOpen,
+    isFindPasswordOpen:
+      accountRecovery.modals.findPassword.isOpen ||
+      accountRecovery.modals.resetPassword.isOpen,
+    isRestoreOpen:
+      withdrawnMemberFlow.modals.withdrawn.isOpen ||
+      withdrawnMemberFlow.modals.restore.isOpen ||
+      withdrawnMemberFlow.modals.result.isOpen,
+  })
 
   // 로그인 제출 플로우
   const handleLoginSubmit = handleSubmit(async (formData) => {
@@ -179,6 +194,8 @@ export default function LoginPage() {
         </div>
       </div>
 
+      <MockAuthHelpPanel variant={helpPanelVariant} />
+
       {/* 아이디/비밀번호 찾기 모달 */}
       <FindIdModal
         isOpen={accountRecovery.modals.findId.isOpen}
@@ -226,4 +243,15 @@ export default function LoginPage() {
 function getRedirectPathFromLocation(locationState: unknown): string {
   const state = locationState as { from?: string } | null
   return typeof state?.from === 'string' ? state.from : '/'
+}
+
+function getMockAuthHelpPanelVariant(params: {
+  isFindIdOpen: boolean
+  isFindPasswordOpen: boolean
+  isRestoreOpen: boolean
+}): MockAuthHelpPanelVariant {
+  if (params.isRestoreOpen) return 'restore-account'
+  if (params.isFindPasswordOpen) return 'find-password'
+  if (params.isFindIdOpen) return 'find-id'
+  return 'login'
 }

--- a/src/pages/SignupEmailPage.tsx
+++ b/src/pages/SignupEmailPage.tsx
@@ -13,6 +13,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { Button } from '@/components/common/Button'
 import { CommonInputField } from '@/components/common/CommonInputField'
 import { FormErrorDisplay } from '@/components/common/FormErrorDisplay'
+import MockAuthHelpPanel from '@/components/auth/MockAuthHelpPanel'
 
 import { NicknameSection } from '@/components/signup/NicknameSection'
 import { EmailSection } from '@/components/signup/EmailSection'
@@ -253,122 +254,125 @@ export default function SignupEmailPage() {
 
   return (
     <FormProvider {...methods}>
-      <div className="flex min-h-[calc(100vh-96px)] items-center justify-center bg-gray-100 pt-[min(8vh)] pb-[min(10vh)]">
-        <div className="bg-white px-6 py-10">
-          <div className="flex w-[480px] flex-col gap-9">
-            <div className="flex flex-col items-center gap-4">
-              <p className="text-foreground text-center text-[18px] font-bold">
-                마법같이 빠르게 성장시켜줄
-              </p>
-              <img
-                className="h-6 w-[180px] object-contain"
-                alt="OZ. 오즈코딩스쿨"
-                src="/LoginPage_img/ozcoding_logo.png"
-              />
-            </div>
-
-            <h1 className="text-foreground text-left text-[18px] font-semibold">
-              회원가입
-            </h1>
-
-            <form
-              onSubmit={handleSignupSubmit}
-              className="flex flex-col gap-11"
-            >
-              <SectionBlock label="이름">
-                <CommonInputField<SignupFormData>
-                  name="name"
-                  type="text"
-                  placeholder="이름을 입력해주세요"
-                  width="100%"
-                  placeholderVariant="a"
-                  helperVisibility="always"
+      <>
+        <div className="flex min-h-[calc(100vh-96px)] items-center justify-center bg-gray-100 pt-[min(8vh)] pb-[min(10vh)]">
+          <div className="bg-white px-6 py-10">
+            <div className="flex w-[480px] flex-col gap-9">
+              <div className="flex flex-col items-center gap-4">
+                <p className="text-foreground text-center text-[18px] font-bold">
+                  마법같이 빠르게 성장시켜줄
+                </p>
+                <img
+                  className="h-6 w-[180px] object-contain"
+                  alt="OZ. 오즈코딩스쿨"
+                  src="/LoginPage_img/ozcoding_logo.png"
                 />
-              </SectionBlock>
-
-              <NicknameSection
-                nicknameFieldState={nicknameFieldState}
-                flowMessage={nicknameCheck.nicknameFlowMessage}
-                nicknameChecked={nicknameCheck.nicknameChecked}
-                nickname={values.nickname}
-                canCheckNickname={nicknameCheck.canCheckNickname}
-                busy={isBusy}
-                onCheckNickname={nicknameCheck.onCheckNickname}
-              />
-
-              <SectionBlock label="생년월일">
-                <CommonInputField<SignupFormData>
-                  name="birthdate"
-                  type="text"
-                  placeholder="8자리 입력해주세요 (ex.20000101)"
-                  width="100%"
-                  placeholderVariant="a"
-                  helperVisibility="always"
-                />
-              </SectionBlock>
-
-              <SectionBlock label="성별">
-                <GenderField />
-              </SectionBlock>
-
-              <EmailSection
-                emailFieldState={emailFlow.ui.fieldState}
-                emailVerificationCodeFieldState={emailFlow.ui.codeFieldState}
-                flowMessage={emailFlow.flowMessage}
-                emailVerified={emailFlow.verified}
-                emailCodeSent={emailFlow.codeSent}
-                emailTimer={emailFlow.timer}
-                emailSendLabel={emailSendLabel}
-                canSendEmail={emailFlow.ui.canSend}
-                canVerifyEmail={emailFlow.ui.canVerify}
-                onSendEmailCode={emailFlow.actions.onSendCode}
-                onVerifyEmailCode={emailFlow.actions.onVerifyCode}
-              />
-              <PhoneSection
-                phone1={values.phone1}
-                phoneDigitsState={smsFlow.ui.fieldState}
-                phoneVerificationCodeFieldState={smsFlow.ui.codeFieldState}
-                flowMessage={smsFlow.flowMessage}
-                smsVerified={smsFlow.verified}
-                smsCodeSent={smsFlow.codeSent}
-                smsTimer={smsFlow.timer}
-                smsSendLabel={smsSendLabel}
-                canSendSms={smsFlow.ui.canSend}
-                canVerifySms={smsFlow.ui.canVerify}
-                onSendSmsCode={smsFlow.actions.onSendCode}
-                onVerifySmsCode={smsFlow.actions.onVerifyCode}
-              />
-              <PasswordSection
-                passwordFieldState={passwordState.passwordFieldState}
-                passwordConfirmState={passwordState.passwordConfirmState}
-                passwordConfirmMsg={passwordState.passwordConfirmMessage}
-              />
-
-              <div className="flex flex-col gap-2">
-                <FormErrorDisplay message={rootError} />
-                <Button
-                  type="submit"
-                  size="xxl"
-                  variant={submitVariant}
-                  disabled={!canSubmit}
-                  className="whitespace-nowrap"
-                >
-                  {submitLabel}
-                </Button>
               </div>
-            </form>
 
-            <p className="mt-6 text-center">
-              <Link
-                to="/signup"
-                className="text-mono-600 text-[16px] leading-[22.4px] tracking-[-0.48px] underline hover:no-underline"
+              <h1 className="text-foreground text-left text-[18px] font-semibold">
+                회원가입
+              </h1>
+
+              <form
+                onSubmit={handleSignupSubmit}
+                className="flex flex-col gap-11"
               >
-                소셜/일반 선택으로 돌아가기
-              </Link>
-            </p>
+                <SectionBlock label="이름">
+                  <CommonInputField<SignupFormData>
+                    name="name"
+                    type="text"
+                    placeholder="이름을 입력해주세요"
+                    width="100%"
+                    placeholderVariant="a"
+                    helperVisibility="always"
+                  />
+                </SectionBlock>
+
+                <NicknameSection
+                  nicknameFieldState={nicknameFieldState}
+                  flowMessage={nicknameCheck.nicknameFlowMessage}
+                  nicknameChecked={nicknameCheck.nicknameChecked}
+                  nickname={values.nickname}
+                  canCheckNickname={nicknameCheck.canCheckNickname}
+                  busy={isBusy}
+                  onCheckNickname={nicknameCheck.onCheckNickname}
+                />
+
+                <SectionBlock label="생년월일">
+                  <CommonInputField<SignupFormData>
+                    name="birthdate"
+                    type="text"
+                    placeholder="8자리 입력해주세요 (ex.20000101)"
+                    width="100%"
+                    placeholderVariant="a"
+                    helperVisibility="always"
+                  />
+                </SectionBlock>
+
+                <SectionBlock label="성별">
+                  <GenderField />
+                </SectionBlock>
+
+                <EmailSection
+                  emailFieldState={emailFlow.ui.fieldState}
+                  emailVerificationCodeFieldState={emailFlow.ui.codeFieldState}
+                  flowMessage={emailFlow.flowMessage}
+                  emailVerified={emailFlow.verified}
+                  emailCodeSent={emailFlow.codeSent}
+                  emailTimer={emailFlow.timer}
+                  emailSendLabel={emailSendLabel}
+                  canSendEmail={emailFlow.ui.canSend}
+                  canVerifyEmail={emailFlow.ui.canVerify}
+                  onSendEmailCode={emailFlow.actions.onSendCode}
+                  onVerifyEmailCode={emailFlow.actions.onVerifyCode}
+                />
+                <PhoneSection
+                  phone1={values.phone1}
+                  phoneDigitsState={smsFlow.ui.fieldState}
+                  phoneVerificationCodeFieldState={smsFlow.ui.codeFieldState}
+                  flowMessage={smsFlow.flowMessage}
+                  smsVerified={smsFlow.verified}
+                  smsCodeSent={smsFlow.codeSent}
+                  smsTimer={smsFlow.timer}
+                  smsSendLabel={smsSendLabel}
+                  canSendSms={smsFlow.ui.canSend}
+                  canVerifySms={smsFlow.ui.canVerify}
+                  onSendSmsCode={smsFlow.actions.onSendCode}
+                  onVerifySmsCode={smsFlow.actions.onVerifyCode}
+                />
+                <PasswordSection
+                  passwordFieldState={passwordState.passwordFieldState}
+                  passwordConfirmState={passwordState.passwordConfirmState}
+                  passwordConfirmMsg={passwordState.passwordConfirmMessage}
+                />
+
+                <div className="flex flex-col gap-2">
+                  <FormErrorDisplay message={rootError} />
+                  <Button
+                    type="submit"
+                    size="xxl"
+                    variant={submitVariant}
+                    disabled={!canSubmit}
+                    className="whitespace-nowrap"
+                  >
+                    {submitLabel}
+                  </Button>
+                </div>
+              </form>
+
+              <p className="mt-6 text-center">
+                <Link
+                  to="/signup"
+                  className="text-mono-600 text-[16px] leading-[22.4px] tracking-[-0.48px] underline hover:no-underline"
+                >
+                  소셜/일반 선택으로 돌아가기
+                </Link>
+              </p>
+            </div>
           </div>
         </div>
-      </div>
+        <MockAuthHelpPanel variant="signup" />
+      </>
     </FormProvider>
   )
 }

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,5 +1,6 @@
 // 회원가입 진입 페이지 - 소셜 가입 or 일반회원 가입 선택
 import { Link } from 'react-router-dom'
+import MockAuthHelpPanel from '@/components/auth/MockAuthHelpPanel'
 import SocialLoginSection from '@/components/auth/SocialLoginSection'
 import type { SocialProviderId } from '@/types/social'
 import { createSocialRedirect } from '@/api/socialAuth'
@@ -11,45 +12,48 @@ export default function SignupPage() {
   }
 
   return (
-    <div className="flex min-h-[calc(100vh-96px)] items-center justify-center px-4 py-12">
-      <div className="relative mb-[min(40vh)] flex w-[348px] flex-col items-center gap-16">
-        <div className="flex w-full flex-col items-center gap-[27px]">
-          <div className="flex w-[191px] flex-col items-center gap-4">
-            <img
-              className="h-6 w-[180px] object-cover"
-              alt="OZ. 오즈코딩스쿨"
-              src="/LoginPage_img/ozcoding_logo.png"
-            />
-          </div>
-          <div className="flex w-full items-start justify-center gap-3">
-            <div className="inline-flex items-center justify-center gap-2.5">
-              <span className="text-mono-600 truncate whitespace-nowrap">
-                현재 회원이신가요?{' '}
-              </span>
-              <Link
-                to="/login"
-                className="text-primary text-[16px] whitespace-nowrap hover:underline"
-              >
-                로그인하기
-              </Link>
+    <>
+      <div className="flex min-h-[calc(100vh-96px)] items-center justify-center px-4 py-12">
+        <div className="relative mb-[min(40vh)] flex w-[348px] flex-col items-center gap-16">
+          <div className="flex w-full flex-col items-center gap-[27px]">
+            <div className="flex w-[191px] flex-col items-center gap-4">
+              <img
+                className="h-6 w-[180px] object-cover"
+                alt="OZ. 오즈코딩스쿨"
+                src="/LoginPage_img/ozcoding_logo.png"
+              />
+            </div>
+            <div className="flex w-full items-start justify-center gap-3">
+              <div className="inline-flex items-center justify-center gap-2.5">
+                <span className="text-mono-600 truncate whitespace-nowrap">
+                  현재 회원이신가요?{' '}
+                </span>
+                <Link
+                  to="/login"
+                  className="text-primary text-[16px] whitespace-nowrap hover:underline"
+                >
+                  로그인하기
+                </Link>
+              </div>
             </div>
           </div>
-        </div>
 
-        <div className="flex w-full flex-col items-center gap-9">
-          <div className="flex w-full flex-col items-start gap-10">
-            <SocialLoginSection onLogin={handleSocialSignup} mode="signup" />
-            <div className="flex w-full justify-center">
-              <Link
-                to="/signup/email"
-                className="text-mono-600 text-[16px] whitespace-nowrap underline"
-              >
-                일반회원 가입
-              </Link>
+          <div className="flex w-full flex-col items-center gap-9">
+            <div className="flex w-full flex-col items-start gap-10">
+              <SocialLoginSection onLogin={handleSocialSignup} mode="signup" />
+              <div className="flex w-full justify-center">
+                <Link
+                  to="/signup/email"
+                  className="text-mono-600 text-[16px] whitespace-nowrap underline"
+                >
+                  일반회원 가입
+                </Link>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+      <MockAuthHelpPanel variant="signup" />
+    </>
   )
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Resolves #218 

## 📑 구현 사항

- mock 인증 안내 패널을 로그인, 회원가입, 아이디 찾기, 비밀번호 찾기, 계정 복구 흐름별 variant 구조로 분리
- 로그인 페이지에서 열린 모달 상태에 따라 안내 패널 내용이 자동으로 전환되도록 연결
- 회원가입 진입 페이지와 일반회원 가입 페이지에서는 회원가입에 필요한 인증코드만 노출하도록 조정
- 아이디 찾기, 비밀번호 찾기, 계정 복구 테스트에 필요한 mock 예시 값을 상수로 정리
- 안내 패널의 z-index를 높여 모달이 열린 상태에서도 복사 버튼을 사용할 수 있도록 수정
- 전역 `App`에서 렌더하던 패널을 각 인증 페이지에서 직접 렌더하도록 이동

## 🌀 어려웠던 점 / 고민했던 부분

- 같은 로그인 페이지 안에서도 기본 로그인, 아이디 찾기, 비밀번호 찾기, 계정 복구가 모두 다른 정보를 필요로 해서 단순 라우트 기준 분기만으로는 부족했습니다.
- 모달이 포털로 렌더링되고 있어 패널 자체를 없애기보다 레이어를 올려 항상 복사 가능한 상태를 유지하는 쪽으로 정리했습니다.
- 사용자에게 보이는 예시 값과 실제 mock handler 값이 어긋나지 않도록 상수 분리를 함께 진행했습니다.

## 📸 구현 이미지

<img width="2032" height="1162" alt="스크린샷 2026-03-27 오후 5 20 03" src="https://github.com/user-attachments/assets/fff2267c-0b3b-46dc-a078-ba9c52e937e5" />
<img width="2032" height="1162" alt="스크린샷 2026-03-27 오후 5 20 10" src="https://github.com/user-attachments/assets/dca4af27-e33b-4f30-a870-5c3ed0711201" />
<img width="2032" height="1162" alt="스크린샷 2026-03-27 오후 5 20 18" src="https://github.com/user-attachments/assets/91b58f85-381e-4ad2-bca0-cdcab793a8c5" />
<img width="2032" height="1162" alt="스크린샷 2026-03-27 오후 5 20 26" src="https://github.com/user-attachments/assets/2103af71-31c6-434d-bade-6133dccd09c9" />


## ❇️ 코드 설명

- `src/components/auth/MockAuthHelpPanel.tsx`
  - 흐름별 variant를 받아 필요한 정보만 렌더하도록 구조 변경
  - 모달 위에서도 클릭 가능하도록 레이어 조정
- `src/pages/LoginPage.tsx`
  - 계정 찾기/복구 모달 상태에 따라 패널 variant를 선택하도록 추가
- `src/pages/SignupPage.tsx`
  - 회원가입 진입 페이지에서 회원가입 전용 패널 렌더
- `src/pages/SignupEmailPage.tsx`
  - 일반회원 가입 페이지에서 회원가입 전용 패널 렌더
- `src/constants/mockAuth.ts`
  - 아이디 찾기, 비밀번호 찾기, 계정 복구용 mock 예시 상수 추가
- `src/App.tsx`
  - 전역 mock 안내 패널 렌더 제거

## 💬 리뷰 요청사항

> 리뷰어에게 피드백을 받고 싶은 지점이 있다면 작성해주세요.

1. 로그인 페이지에서 모달 상태에 따라 패널 내용이 바뀌는 방식이 사용자 경험상 자연스러운지 확인 부탁드립니다.
2. 모달 위에 패널을 띄우는 현재 레이어 구성이 다른 UI 클릭을 과하게 방해하지 않는지 확인 부탁드립니다.
3. 아이디 찾기/비밀번호 찾기/계정 복구용 mock 예시 정보 범위가 적절한지 확인 부탁드립니다.
